### PR TITLE
Document more of the entities loading code

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -7617,15 +7617,15 @@ SkipDisabledEntityDuringRoomTransition::
     cp   $88
     jr   nc, .skip
 
-    ; If wEntitiesTransitionIntersectingXTable[c] != 0, skip
-    ld   hl, wEntitiesTransitionIntersectingXTable
+    ; If wEntitiesPosXSignTable[c] != 0, skip
+    ld   hl, wEntitiesPosXSignTable
     add  hl, bc
     ld   a, [hl]
     and  a
     jr   nz, .skip
 
-    ; If wEntitiesTransitionIntersectingYTable[c] != 0, skip
-    ld   hl, wEntitiesTransitionIntersectingYTable
+    ; If wEntitiesPosYSignTable[c] != 0, skip
+    ld   hl, wEntitiesPosYSignTable
     add  hl, bc
     ld   a, [hl]
     and  a

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -2319,7 +2319,7 @@ label_1629::
 
 label_1637::
     ld   a, c
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
     call label_2178
     ld   a, [wIsRunningWithPegasusBoots]
     and  a
@@ -2350,7 +2350,7 @@ label_1653::
     ld   [hl], a
     ld   hl, $C3B0
     add  hl, de
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     ld   [hl], a
     ld   c, e
     ld   b, d
@@ -7043,7 +7043,7 @@ LoadEntity::
     ld   hl, $C3B0
     add  hl, bc
     ld   a, [hl]
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
 
     ld   a, $19
     ld   [wCurrentBank], a
@@ -7285,7 +7285,7 @@ label_3BB5::
 
 ; Render active NPC
 label_3BC0::
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     inc  a
     ret  z
 
@@ -7312,7 +7312,7 @@ label_3BC0::
     sub  a, c
     ld   [de], a
     inc  de
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     ld   c, a
     ld   b, $00
     sla  c
@@ -7413,7 +7413,7 @@ label_3C71::
     jp   ReloadSavedBank
 
 label_3C77::
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     inc  a
     ret  z
     call AdjustEntityPositionDuringRoomTransition
@@ -7445,7 +7445,7 @@ label_3C9C::
     sub  a, h
     ld   [de], a
     inc  de
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     ld   c, a
     ld   b, $00
     sla  c
@@ -7491,7 +7491,7 @@ label_3CE0::
     jr   label_3CF6
 
 label_3CE6::
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     inc  a
     jr   z, label_3D52
     push hl

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -2586,7 +2586,7 @@ EntityPosXOffsetTable::
 .bottom  db $00
 .default db $00
 
-data_001_5E9C::
+EntityPosXSignTable::
 .right   db $00
 .left    db $FF
 .top     db $00
@@ -2600,7 +2600,7 @@ EntityPosYOffsetTable::
 .bottom  db $80
 .default db $00
 
-data_001_5EA6::
+EntityPosYSignTable::
 .right   db $00
 .left    db $00
 .top     db $FF
@@ -2608,9 +2608,6 @@ data_001_5EA6::
 .default db $00
 
 ; Configure the position a newly created entity position before a room transition.
-; - Sets the initial position offset.
-; - In case of TOP or LEFT transitions, mark the entity as initially hidden.
-;   (UpdateEntityPositionForRoomTransition will make it visible when it reaches the viewport)
 ;
 ; Input:
 ;   de:  entity index
@@ -2637,8 +2634,8 @@ PrepareEntityPositionForRoomTransition::
     ld   a, [hl]
     ldh  [hScratchA], a
 
-    ; hScratchB = data_001_5E9C[wRoomTransitionDirection]
-    ld   hl, data_001_5E9C
+    ; hScratchB = EntityPosXSignTable[wRoomTransitionDirection]
+    ld   hl, EntityPosXSignTable
     add  hl, bc
     ld   a, [hl]
     ldh  [hScratchB], a
@@ -2649,8 +2646,8 @@ PrepareEntityPositionForRoomTransition::
     ld   a, [hl]
     ldh  [hScratchC], a
 
-    ; hScratchD = data_001_5EA6[wRoomTransitionDirection]
-    ld   hl, data_001_5EA6
+    ; hScratchD = EntityPosYSignTable[wRoomTransitionDirection]
+    ld   hl, EntityPosYSignTable
     add  hl, bc
     ld   a, [hl]
     ldh  [hScratchD], a
@@ -2662,9 +2659,9 @@ PrepareEntityPositionForRoomTransition::
     add  a, [hl]
     ld   [hl], a
 
-    ; [wEntitiesTransitionIntersectingXTable + de] += [hScratchB]
+    ; [wEntitiesPosXSignTable + de] += [hScratchB] + carry
     rr   c
-    ld   hl, wEntitiesTransitionIntersectingXTable
+    ld   hl, wEntitiesPosXSignTable
     add  hl, de
     ldh  a, [hScratchB]
     rl   c
@@ -2678,9 +2675,9 @@ PrepareEntityPositionForRoomTransition::
     add  a, [hl]
     ld   [hl], a
 
-    ; [wEntitiesTransitionIntersectingYTable + de] += [hScratchD] + carry
+    ; [wEntitiesPosYSignTable + de] += [hScratchD] + carry
     rr   c
-    ld   hl, wEntitiesTransitionIntersectingYTable
+    ld   hl, wEntitiesPosYSignTable
     add  hl, de
     ldh  a, [hScratchD]
     rl   c

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -2606,6 +2606,8 @@ label_5EA6::
     rst  $38
     nop
     nop
+
+func_001_5EAB::
     ld   hl, $C460
     add  hl, de
     ldh  a, [$FFE4]
@@ -2638,7 +2640,7 @@ label_5EA6::
     add  a, [hl]
     ld   [hl], a
     rr   c
-    ld   hl, $C220
+    ld   hl, wEntitiesTransitionIntersectingXTable
     add  hl, de
     ldh  a, [hScratchB]
     rl   c
@@ -2650,7 +2652,7 @@ label_5EA6::
     add  a, [hl]
     ld   [hl], a
     rr   c
-    ld   hl, $C230
+    ld   hl, wEntitiesTransitionIntersectingYTable
     add  hl, de
     ldh  a, [hScratchD]
     rl   c

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -2176,7 +2176,7 @@ label_5C72::
 
 label_5C7B::
     ld   [$C1B0], a
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
     ld   a, $00
     ld   [$C3C0], a
     ld   a, $08
@@ -2234,7 +2234,7 @@ label_5CBD::
     dec  a
     cp   $80
     jr   nc, label_5D13
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
     ld   de, $C030
     ldh  a, [wActiveEntityPosY]
     ld   [de], a
@@ -2242,7 +2242,7 @@ label_5CBD::
     ldh  a, [wActiveEntityPosX]
     ld   [de], a
     inc  de
-    ldh  a, [$FFF1]
+    ldh  a, [hActiveEntityUnknownG]
     ld   c, a
     ld   b, $00
     sla  c
@@ -3476,7 +3476,7 @@ label_6A7C::
     cp   MAP_EAGLES_TOWER
     ret  nz
     xor  a
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
     ldh  [$FFED], a
     ldh  [$FFF5], a
     ld   a, $38

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -64,10 +64,10 @@ SECTION "ROM Bank $015", ROMX[$4000], BANK[$15]
     ld   hl, $C410                                ; $4061: $21 $10 $C4
     add  hl, bc                                   ; $4064: $09
     ld   [hl], b                                  ; $4065: $70
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $4066: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $4066: $21 $20 $C2
     add  hl, bc                                   ; $4069: $09
     ld   [hl], b                                  ; $406A: $70
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $406B: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $406B: $21 $30 $C2
     add  hl, bc                                   ; $406E: $09
     ld   [hl], b                                  ; $406F: $70
     ld   hl, $C470                                ; $4070: $21 $70 $C4

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -64,10 +64,10 @@ SECTION "ROM Bank $015", ROMX[$4000], BANK[$15]
     ld   hl, $C410                                ; $4061: $21 $10 $C4
     add  hl, bc                                   ; $4064: $09
     ld   [hl], b                                  ; $4065: $70
-    ld   hl, $C220                                ; $4066: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $4066: $21 $20 $C2
     add  hl, bc                                   ; $4069: $09
     ld   [hl], b                                  ; $406A: $70
-    ld   hl, $C230                                ; $406B: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $406B: $21 $30 $C2
     add  hl, bc                                   ; $406E: $09
     ld   [hl], b                                  ; $406F: $70
     ld   hl, $C470                                ; $4070: $21 $70 $C4
@@ -162,7 +162,7 @@ jr_015_40F7:
     ld   a, [$1117]                               ; $40FE: $FA $17 $11
     db   $FC                                      ; $4101: $FC
     ld   b, b                                     ; $4102: $40
-    call label_3BC0                               ; $4103: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4103: $CD $C0 $3B
     call func_015_7B0D                            ; $4106: $CD $0D $7B
     xor  a                                        ; $4109: $AF
     ldh  [hFFE8], a                               ; $410A: $E0 $E8
@@ -310,7 +310,7 @@ jr_015_41C9:
     ret                                           ; $41C9: $C9
 
     ld   de, $40FC                                ; $41CA: $11 $FC $40
-    call label_3BC0                               ; $41CD: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $41CD: $CD $C0 $3B
     call func_015_7B0D                            ; $41D0: $CD $0D $7B
     xor  a                                        ; $41D3: $AF
     ldh  [hFFE8], a                               ; $41D4: $E0 $E8
@@ -392,7 +392,7 @@ jr_015_4239:
     jp   label_015_416F                           ; $4239: $C3 $6F $41
 
     ld   de, $40FC                                ; $423C: $11 $FC $40
-    call label_3BC0                               ; $423F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $423F: $CD $C0 $3B
     call func_015_7B0D                            ; $4242: $CD $0D $7B
     xor  a                                        ; $4245: $AF
     ldh  [hFFE8], a                               ; $4246: $E0 $E8
@@ -474,7 +474,7 @@ jr_015_42AB:
     jp   label_015_416F                           ; $42AB: $C3 $6F $41
 
     ld   de, $40FC                                ; $42AE: $11 $FC $40
-    call label_3BC0                               ; $42B1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $42B1: $CD $C0 $3B
     call func_015_7B0D                            ; $42B4: $CD $0D $7B
     xor  a                                        ; $42B7: $AF
     ldh  [hFFE8], a                               ; $42B8: $E0 $E8
@@ -567,7 +567,7 @@ jr_015_431D:
     and  $10                                      ; $432E: $E6 $10
     ldh  [$FFED], a                               ; $4330: $E0 $ED
     ld   de, $4320                                ; $4332: $11 $20 $43
-    call label_3BC0                               ; $4335: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4335: $CD $C0 $3B
     call func_015_7B0D                            ; $4338: $CD $0D $7B
     call label_C56                                ; $433B: $CD $56 $0C
     call label_3B70                               ; $433E: $CD $70 $3B
@@ -669,7 +669,7 @@ jr_015_43AD:
 
     xor  [hl]                                     ; $43CB: $AE
     ld   b, e                                     ; $43CC: $43
-    call label_3BC0                               ; $43CD: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $43CD: $CD $C0 $3B
     call func_015_7B0D                            ; $43D0: $CD $0D $7B
     call label_C56                                ; $43D3: $CD $56 $0C
     call label_3B39                               ; $43D6: $CD $39 $3B
@@ -853,7 +853,7 @@ jr_015_448C:
 
 jr_015_44D1:
     ld   de, $449F                                ; $44D1: $11 $9F $44
-    call label_3BC0                               ; $44D4: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $44D4: $CD $C0 $3B
 
 jr_015_44D7:
     call func_015_7B0D                            ; $44D7: $CD $0D $7B
@@ -2281,7 +2281,7 @@ jr_015_4CC4:
 
     push de                                       ; $4CDA: $D5
     ld   c, h                                     ; $4CDB: $4C
-    call label_3BC0                               ; $4CDC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4CDC: $CD $C0 $3B
     call func_015_7B0D                            ; $4CDF: $CD $0D $7B
     call func_015_7B3E                            ; $4CE2: $CD $3E $7B
     call GetEntityTransitionCountdown             ; $4CE5: $CD $05 $0C
@@ -2358,7 +2358,7 @@ jr_015_4D39:
     jp   nz, label_015_4DB5                       ; $4D49: $C2 $B5 $4D
 
     ld   de, $4D3B                                ; $4D4C: $11 $3B $4D
-    call label_3BC0                               ; $4D4F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4D4F: $CD $C0 $3B
     call IsEntityUnknownFZero                     ; $4D52: $CD $00 $0C
     ld   e, $00                                   ; $4D55: $1E $00
     and  a                                        ; $4D57: $A7
@@ -2442,7 +2442,7 @@ label_015_4DB5:
     and  $10                                      ; $4DBE: $E6 $10
     ldh  [$FFED], a                               ; $4DC0: $E0 $ED
     ld   de, $4D9D                                ; $4DC2: $11 $9D $4D
-    call label_3BC0                               ; $4DC5: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4DC5: $CD $C0 $3B
     call func_015_7B0D                            ; $4DC8: $CD $0D $7B
     call label_C56                                ; $4DCB: $CD $56 $0C
     call label_3B70                               ; $4DCE: $CD $70 $3B
@@ -2550,7 +2550,7 @@ label_015_4E62:
     and  $10                                      ; $4E66: $E6 $10
     ldh  [$FFED], a                               ; $4E68: $E0 $ED
     ld   de, $4DA9                                ; $4E6A: $11 $A9 $4D
-    call label_3BC0                               ; $4E6D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4E6D: $CD $C0 $3B
     call func_015_7B0D                            ; $4E70: $CD $0D $7B
     call func_015_7B88                            ; $4E73: $CD $88 $7B
     call GetEntityTransitionCountdown             ; $4E76: $CD $05 $0C
@@ -2578,7 +2578,7 @@ label_015_4E62:
     jr   z, jr_015_4EEE                           ; $4E9C: $28 $50
 
     ld   de, $4E8E                                ; $4E9E: $11 $8E $4E
-    call label_3BC0                               ; $4EA1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4EA1: $CD $C0 $3B
     call func_015_7B0D                            ; $4EA4: $CD $0D $7B
     ldh  a, [hFrameCounter]                       ; $4EA7: $F0 $E7
     rra                                           ; $4EA9: $1F
@@ -2625,7 +2625,7 @@ jr_015_4EDF:
 
 jr_015_4EEE:
     ld   de, $4E7D                                ; $4EEE: $11 $7D $4E
-    call label_3BC0                               ; $4EF1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4EF1: $CD $C0 $3B
     call func_015_7B0D                            ; $4EF4: $CD $0D $7B
     call func_015_7B3E                            ; $4EF7: $CD $3E $7B
     call GetEntityTransitionCountdown             ; $4EFA: $CD $05 $0C
@@ -3630,7 +3630,7 @@ jr_015_54CD:
 
 label_015_54D6:
     ld   de, $54BE                                ; $54D6: $11 $BE $54
-    call label_3BC0                               ; $54D9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $54D9: $CD $C0 $3B
     call func_015_7B0D                            ; $54DC: $CD $0D $7B
     call GetEntityTransitionCountdown             ; $54DF: $CD $05 $0C
     jp   z, label_015_7C31                        ; $54E2: $CA $31 $7C
@@ -3936,7 +3936,7 @@ jr_015_566B:
     ldh  [hActiveEntityUnknownG], a               ; $566C: $E0 $F1
 
 jr_015_566E:
-    call label_3BC0                               ; $566E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $566E: $CD $C0 $3B
     ld   a, $02                                   ; $5671: $3E $02
     call label_3DA0                               ; $5673: $CD $A0 $3D
 
@@ -4806,7 +4806,7 @@ jr_015_5B4B:
 
     ldh  [hActiveEntityUnknownG], a               ; $5B50: $E0 $F1
     ld   de, $5A73                                ; $5B52: $11 $73 $5A
-    call label_3BC0                               ; $5B55: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B55: $CD $C0 $3B
     jr   jr_015_5B6C                              ; $5B58: $18 $12
 
 jr_015_5B5A:
@@ -5317,7 +5317,7 @@ jr_015_5D9A:
     add  [hl]                                     ; $5DBC: $86
     ldh  [wActiveEntityPosY], a                   ; $5DBD: $E0 $EC
     ld   de, $5D79                                ; $5DBF: $11 $79 $5D
-    call label_3BC0                               ; $5DC2: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5DC2: $CD $C0 $3B
     ld   a, $02                                   ; $5DC5: $3E $02
     call label_3DA0                               ; $5DC7: $CD $A0 $3D
     jp   label_3D8A                               ; $5DCA: $C3 $8A $3D
@@ -5363,7 +5363,7 @@ jr_015_5DDE:
     and  $50                                      ; $5DF2: $E6 $50
     ldh  [$FFED], a                               ; $5DF4: $E0 $ED
     ld   de, $5DD9                                ; $5DF6: $11 $D9 $5D
-    call label_3BC0                               ; $5DF9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5DF9: $CD $C0 $3B
     call func_015_7B0D                            ; $5DFC: $CD $0D $7B
     call label_C56                                ; $5DFF: $CD $56 $0C
     ldh  a, [hActiveEntityWalking]                ; $5E02: $F0 $F0
@@ -6171,7 +6171,7 @@ jr_015_623A:
     ld   a, $00                                   ; $6285: $3E $00
     ldh  [hActiveEntityUnknownG], a               ; $6287: $E0 $F1
     ld   de, $6235                                ; $6289: $11 $35 $62
-    call label_3BC0                               ; $628C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $628C: $CD $C0 $3B
     ldh  a, [hScratchA]                           ; $628F: $F0 $D7
     sub  $18                                      ; $6291: $D6 $18
     and  $7F                                      ; $6293: $E6 $7F
@@ -6190,7 +6190,7 @@ jr_015_623A:
     ld   de, $6235                                ; $62A9: $11 $35 $62
 
 jr_015_62AC:
-    call label_3BC0                               ; $62AC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $62AC: $CD $C0 $3B
     ldh  a, [hScratchA]                           ; $62AF: $F0 $D7
     sub  $24                                      ; $62B1: $D6 $24
     and  $7F                                      ; $62B3: $E6 $7F
@@ -6207,7 +6207,7 @@ jr_015_62AC:
     ld   a, $01                                   ; $62C5: $3E $01
     ldh  [hActiveEntityUnknownG], a               ; $62C7: $E0 $F1
     ld   de, $6235                                ; $62C9: $11 $35 $62
-    call label_3BC0                               ; $62CC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $62CC: $CD $C0 $3B
     ldh  a, [hScratchA]                           ; $62CF: $F0 $D7
     sub  $2E                                      ; $62D1: $D6 $2E
     and  $7F                                      ; $62D3: $E6 $7F
@@ -6236,7 +6236,7 @@ jr_015_62AC:
     xor  [hl]                                     ; $62F9: $AE
     ld   [hl], a                                  ; $62FA: $77
     ld   de, $6235                                ; $62FB: $11 $35 $62
-    call label_3BC0                               ; $62FE: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $62FE: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $6301: $F0 $F0
     cp   $02                                      ; $6303: $FE $02
     jr   nc, jr_015_6330                          ; $6305: $30 $29
@@ -8199,7 +8199,7 @@ jr_015_6D3D:
     ld   bc, $1101                                ; $6D3E: $01 $01 $11
     jr   nc, @+$6F                                ; $6D41: $30 $6D
 
-    call label_3BC0                               ; $6D43: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6D43: $CD $C0 $3B
     call func_015_7B0D                            ; $6D46: $CD $0D $7B
     call GetEntityTransitionCountdown             ; $6D49: $CD $05 $0C
     jp   z, label_015_7C31                        ; $6D4C: $CA $31 $7C
@@ -8236,7 +8236,7 @@ jr_015_6D3D:
     and  $10                                      ; $6D72: $E6 $10
     ldh  [$FFED], a                               ; $6D74: $E0 $ED
     ld   de, $6D5E                                ; $6D76: $11 $5E $6D
-    call label_3BC0                               ; $6D79: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6D79: $CD $C0 $3B
     call func_015_7B0D                            ; $6D7C: $CD $0D $7B
     ldh  a, [hActiveEntityWalking]                ; $6D7F: $F0 $F0
 
@@ -9228,7 +9228,7 @@ func_015_72CF:
 label_015_72CF:
     ldh  [hActiveEntityUnknownG], a               ; $72CF: $E0 $F1
     ld   de, $716F                                ; $72D1: $11 $6F $71
-    call label_3BC0                               ; $72D4: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $72D4: $CD $C0 $3B
     ld   a, $02                                   ; $72D7: $3E $02
     call label_3DA0                               ; $72D9: $CD $A0 $3D
     ld   hl, hLinkPositionX                       ; $72DC: $21 $98 $FF
@@ -9284,7 +9284,7 @@ jr_015_731D:
     ei                                            ; $732E: $FB
     dec  b                                        ; $732F: $05
     ld   de, $7320                                ; $7330: $11 $20 $73
-    call label_3BC0                               ; $7333: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7333: $CD $C0 $3B
     call func_015_7B0D                            ; $7336: $CD $0D $7B
     call func_015_7B3E                            ; $7339: $CD $3E $7B
     call func_015_7B88                            ; $733C: $CD $88 $7B
@@ -9375,7 +9375,7 @@ jr_015_7382:
     ld   de, $7393                                ; $73B5: $11 $93 $73
 
 jr_015_73B8:
-    call label_3BC0                               ; $73B8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $73B8: $CD $C0 $3B
     call func_015_7B0D                            ; $73BB: $CD $0D $7B
     call func_015_7B3E                            ; $73BE: $CD $3E $7B
     ldh  a, [hFrameCounter]                       ; $73C1: $F0 $E7
@@ -9679,7 +9679,7 @@ jr_015_756E:
 
     ld   [hl], a                                  ; $7580: $77
     ld   [hl], l                                  ; $7581: $75
-    call label_3BC0                               ; $7582: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7582: $CD $C0 $3B
     call func_015_7B0D                            ; $7585: $CD $0D $7B
     call func_015_7B3E                            ; $7588: $CD $3E $7B
     ldh  a, [hFrameCounter]                       ; $758B: $F0 $E7
@@ -10116,7 +10116,7 @@ jr_015_77FE:
 
 label_015_7825:
     ld   de, $7813                                ; $7825: $11 $13 $78
-    call label_3BC0                               ; $7828: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7828: $CD $C0 $3B
     call func_015_7B0D                            ; $782B: $CD $0D $7B
     call func_015_7B3E                            ; $782E: $CD $3E $7B
     ldh  a, [hFrameCounter]                       ; $7831: $F0 $E7
@@ -10204,7 +10204,7 @@ jr_015_788C:
 
 jr_015_78AB:
     ld   de, $788D                                ; $78AB: $11 $8D $78
-    call label_3BC0                               ; $78AE: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $78AE: $CD $C0 $3B
     call func_015_7B0D                            ; $78B1: $CD $0D $7B
     call func_015_7BC1                            ; $78B4: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $78B7: $21 $20 $C3
@@ -10315,8 +10315,9 @@ jr_015_7950:
     ld   [$1810], sp                              ; $7956: $08 $10 $18
     jr   nz, jr_015_7983                          ; $7959: $20 $28
 
-    jr   nc, jr_015_7995                          ; $795B: $30 $38
+    jr   nc, func_015_7995                        ; $795B: $30 $38
 
+func_015_795D::
     ld   hl, $C340                                ; $795D: $21 $40 $C3
     add  hl, bc                                   ; $7960: $09
     ld   a, [hl]                                  ; $7961: $7E
@@ -10357,7 +10358,7 @@ jr_015_7983:
 jr_015_7994:
     ret                                           ; $7994: $C9
 
-jr_015_7995:
+func_015_7995::
     ldh  a, [hActiveEntityState]                  ; $7995: $F0 $EA
     cp   $07                                      ; $7997: $FE $07
     ret  z                                        ; $7999: $C8
@@ -11200,7 +11201,7 @@ label_015_7E09:
     ld   de, $7D60                                ; $7E1B: $11 $60 $7D
 
 jr_015_7E1E:
-    call label_3BC0                               ; $7E1E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7E1E: $CD $C0 $3B
     ldh  a, [hIsGBC]                              ; $7E21: $F0 $FE
     and  a                                        ; $7E23: $A7
     jr   z, jr_015_7E2E                           ; $7E24: $28 $08
@@ -11270,7 +11271,7 @@ jr_015_7E66:
     jr   z, jr_015_7E82                           ; $7E78: $28 $08
 
     ld   de, $7E6D                                ; $7E7A: $11 $6D $7E
-    call label_3BC0                               ; $7E7D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7E7D: $CD $C0 $3B
     jr   jr_015_7EA6                              ; $7E80: $18 $24
 
 jr_015_7E82:
@@ -11476,7 +11477,7 @@ jr_015_7F82:
     jp   z, label_015_7C31                        ; $7F9A: $CA $31 $7C
 
     ld   de, $7F86                                ; $7F9D: $11 $86 $7F
-    call label_3BC0                               ; $7FA0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7FA0: $CD $C0 $3B
     ld   a, [$C50F]                               ; $7FA3: $FA $0F $C5
     ld   e, a                                     ; $7FA6: $5F
     ld   d, b                                     ; $7FA7: $50

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -4716,10 +4716,10 @@ label_018_5C6A:
     ld   hl, $C3E0                                ; $5C72: $21 $E0 $C3
     add  hl, bc                                   ; $5C75: $09
     ld   [hl], a                                  ; $5C76: $77
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $5C77: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $5C77: $21 $20 $C2
     add  hl, bc                                   ; $5C7A: $09
     ld   [hl], b                                  ; $5C7B: $70
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $5C7C: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $5C7C: $21 $30 $C2
     add  hl, bc                                   ; $5C7F: $09
     ld   [hl], b                                  ; $5C80: $70
     ld   hl, $C380                                ; $5C81: $21 $80 $C3

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -6903,7 +6903,7 @@ jr_018_691B:
     ldh  [hScratchA], a                           ; $6930: $E0 $D7
     ld   a, [wLinkWalkingFrameCount]              ; $6932: $FA $23 $C1
     ld   c, a                                     ; $6935: $4F
-    call AdjustEntityPositionDuringRoomTransition ; $6936: $CD $57 $3D
+    call SkipDisabledEntityDuringRoomTransition ; $6936: $CD $57 $3D
     ldh  a, [hScratchA]                           ; $6939: $F0 $D7
     ld   c, a                                     ; $693B: $4F
 

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -520,7 +520,7 @@ func_018_43E3:
     jr   nc, jr_018_43EF                          ; $43E7: $30 $06
 
     ld   de, $43B3                                ; $43E9: $11 $B3 $43
-    jp   label_3BC0                               ; $43EC: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $43EC: $C3 $C0 $3B
 
 jr_018_43EF:
     sub  $04                                      ; $43EF: $D6 $04
@@ -1310,7 +1310,7 @@ jr_018_4834:
     add  $03                                      ; $483C: $C6 $03
     ldh  [wActiveEntityPosY], a                   ; $483E: $E0 $EC
     ld   de, $481F                                ; $4840: $11 $1F $48
-    call label_3BC0                               ; $4843: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4843: $CD $C0 $3B
     ld   a, $02                                   ; $4846: $3E $02
     call label_3DA0                               ; $4848: $CD $A0 $3D
     call label_3D8A                               ; $484B: $CD $8A $3D
@@ -1466,7 +1466,7 @@ jr_018_4913:
 
 jr_018_491D:
     ld   de, $48A4                                ; $491D: $11 $A4 $48
-    call label_3BC0                               ; $4920: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4920: $CD $C0 $3B
 
 jr_018_4923:
     ld   a, $02                                   ; $4923: $3E $02
@@ -1591,7 +1591,7 @@ jr_018_49B6:
     ld   d, d                                     ; $49D2: $52
     ld   [hl+], a                                 ; $49D3: $22
     ld   de, $49C0                                ; $49D4: $11 $C0 $49
-    call label_3BC0                               ; $49D7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $49D7: $CD $C0 $3B
     ld   a, [wIsIndoor]                           ; $49DA: $FA $A5 $DB
     and  a                                        ; $49DD: $A7
     jr   z, jr_018_4A2A                           ; $49DE: $28 $4A
@@ -1948,7 +1948,7 @@ jr_018_4BFB:
     ldh  a, [wActiveEntityPosY]                   ; $4C04: $F0 $EC
     add  $08                                      ; $4C06: $C6 $08
     ldh  [wActiveEntityPosY], a                   ; $4C08: $E0 $EC
-    call label_3BC0                               ; $4C0A: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4C0A: $CD $C0 $3B
     call label_3D8A                               ; $4C0D: $CD $8A $3D
     call func_018_7DE8                            ; $4C10: $CD $E8 $7D
     ldh  a, [hActiveEntityWalking]                ; $4C13: $F0 $F0
@@ -2170,7 +2170,7 @@ jr_018_4D51:
     ld   de, $4D07                                ; $4D55: $11 $07 $4D
 
 jr_018_4D58:
-    call label_3BC0                               ; $4D58: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4D58: $CD $C0 $3B
     call func_018_7DE8                            ; $4D5B: $CD $E8 $7D
     ldh  a, [hFrameCounter]                       ; $4D5E: $F0 $E7
     rra                                           ; $4D60: $1F
@@ -2278,7 +2278,7 @@ jr_018_4DF3:
     sub  $04                                      ; $4E05: $D6 $04
     ldh  [wActiveEntityPosX], a                   ; $4E07: $E0 $EE
     ld   de, $4D13                                ; $4E09: $11 $13 $4D
-    call label_3BC0                               ; $4E0C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4E0C: $CD $C0 $3B
     call label_3D8A                               ; $4E0F: $CD $8A $3D
     ld   a, $02                                   ; $4E12: $3E $02
     jp   label_3B0C                               ; $4E14: $C3 $0C $3B
@@ -2746,7 +2746,7 @@ func_018_50C3:
     and  $01                                      ; $50C8: $E6 $01
     ldh  [hActiveEntityUnknownG], a               ; $50CA: $E0 $F1
     ld   de, $50BB                                ; $50CC: $11 $BB $50
-    call label_3BC0                               ; $50CF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $50CF: $CD $C0 $3B
 
 func_018_50D2:
 jr_018_50D2:
@@ -2957,7 +2957,7 @@ func_018_51B0:
     jp   nz, label_018_7F08                       ; $51DC: $C2 $08 $7F
 
     ld   de, $51B8                                ; $51DF: $11 $B8 $51
-    call label_3BC0                               ; $51E2: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $51E2: $CD $C0 $3B
     ldh  a, [hFrameCounter]                       ; $51E5: $F0 $E7
     and  $3F                                      ; $51E7: $E6 $3F
     jr   nz, jr_018_51F3                          ; $51E9: $20 $08
@@ -3051,7 +3051,7 @@ jr_018_5255:
     ld   hl, $217C                                ; $5268: $21 $7C $21
     call func_018_51B0                            ; $526B: $CD $B0 $51
     ld   de, $525B                                ; $526E: $11 $5B $52
-    call label_3BC0                               ; $5271: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5271: $CD $C0 $3B
     ld   a, [$C50F]                               ; $5274: $FA $0F $C5
     ld   e, a                                     ; $5277: $5F
     ld   d, b                                     ; $5278: $50
@@ -3085,7 +3085,7 @@ jr_018_5286:
     ld   e, h                                     ; $52A2: $5C
     ld   bc, $015E                                ; $52A3: $01 $5E $01
     ld   de, $5296                                ; $52A6: $11 $96 $52
-    call label_3BC0                               ; $52A9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $52A9: $CD $C0 $3B
     ldh  a, [hFrameCounter]                       ; $52AC: $F0 $E7
     rra                                           ; $52AE: $1F
     rra                                           ; $52AF: $1F
@@ -3407,7 +3407,7 @@ func_018_548A:
 
 jr_018_5492:
     ld   de, $547A                                ; $5492: $11 $7A $54
-    call label_3BC0                               ; $5495: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5495: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableC               ; $5498: $21 $C0 $C2
     add  hl, bc                                   ; $549B: $09
     ld   a, [hl]                                  ; $549C: $7E
@@ -3419,7 +3419,7 @@ jr_018_5492:
 
 jr_018_54A4:
     ld   de, $5482                                ; $54A4: $11 $82 $54
-    call label_3BC0                               ; $54A7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $54A7: $CD $C0 $3B
     ldh  a, [wActiveEntityPosY]                   ; $54AA: $F0 $EC
     add  $10                                      ; $54AC: $C6 $10
     ldh  [wActiveEntityPosY], a                   ; $54AE: $E0 $EC
@@ -4325,7 +4325,7 @@ jr_018_5A18:
     xor  a                                        ; $5A18: $AF
     ld   [wEntitiesUnknownTableG], a              ; $5A19: $EA $B0 $C3
     ld   de, $59B8                                ; $5A1C: $11 $B8 $59
-    call label_3BC0                               ; $5A1F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5A1F: $CD $C0 $3B
     ld   a, $6C                                   ; $5A22: $3E $6C
     ldh  [hLinkAnimationState], a                 ; $5A24: $E0 $9D
     ld   a, $02                                   ; $5A26: $3E $02
@@ -4452,7 +4452,7 @@ jr_018_5A7F:
 
 jr_018_5AE7:
     ld   de, $59B8                                ; $5AE7: $11 $B8 $59
-    call label_3BC0                               ; $5AEA: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5AEA: $CD $C0 $3B
     ld   a, [wInventoryAppearing]                 ; $5AED: $FA $4F $C1
     and  a                                        ; $5AF0: $A7
     ret  nz                                       ; $5AF1: $C0
@@ -4716,10 +4716,10 @@ label_018_5C6A:
     ld   hl, $C3E0                                ; $5C72: $21 $E0 $C3
     add  hl, bc                                   ; $5C75: $09
     ld   [hl], a                                  ; $5C76: $77
-    ld   hl, $C220                                ; $5C77: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $5C77: $21 $20 $C2
     add  hl, bc                                   ; $5C7A: $09
     ld   [hl], b                                  ; $5C7B: $70
-    ld   hl, $C230                                ; $5C7C: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $5C7C: $21 $30 $C2
     add  hl, bc                                   ; $5C7F: $09
     ld   [hl], b                                  ; $5C80: $70
     ld   hl, $C380                                ; $5C81: $21 $80 $C3
@@ -5066,7 +5066,7 @@ jr_018_5E79:
     add  $01                                      ; $5E83: $C6 $01
     ldh  [wActiveEntityPosY], a                   ; $5E85: $E0 $EC
     ld   de, $5DF7                                ; $5E87: $11 $F7 $5D
-    call label_3BC0                               ; $5E8A: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5E8A: $CD $C0 $3B
     call func_018_7D36                            ; $5E8D: $CD $36 $7D
     call func_018_7DE8                            ; $5E90: $CD $E8 $7D
     call func_018_7D95                            ; $5E93: $CD $95 $7D
@@ -5130,7 +5130,7 @@ jr_018_5EAD:
     ld   a, c                                     ; $5EF6: $79
     ld   [$C50F], a                               ; $5EF7: $EA $0F $C5
     ld   de, $5EB7                                ; $5EFA: $11 $B7 $5E
-    call label_3BC0                               ; $5EFD: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5EFD: $CD $C0 $3B
     call func_018_7D60                            ; $5F00: $CD $60 $7D
     call func_018_7E98                            ; $5F03: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $5F06: $21 $20 $C3
@@ -5449,7 +5449,7 @@ jr_018_60C7:
 
 label_018_60F5:
     ld   de, $60D5                                ; $60F5: $11 $D5 $60
-    call label_3BC0                               ; $60F8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $60F8: $CD $C0 $3B
     call func_018_7D60                            ; $60FB: $CD $60 $7D
     ldh  a, [hActiveEntityWalking]                ; $60FE: $F0 $F0
     rst  $00                                      ; $6100: $C7
@@ -5550,7 +5550,7 @@ jr_018_6163:
     jp   c, label_018_7F08                        ; $61A3: $DA $08 $7F
 
     ld   de, $5EB7                                ; $61A6: $11 $B7 $5E
-    call label_3BC0                               ; $61A9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $61A9: $CD $C0 $3B
     ld   a, [wRoomTransitionState]                ; $61AC: $FA $24 $C1
     and  a                                        ; $61AF: $A7
     ret  nz                                       ; $61B0: $C0
@@ -5958,7 +5958,7 @@ jr_018_63F7:
 
 label_018_640C:
     ld   de, $63F8                                ; $640C: $11 $F8 $63
-    call label_3BC0                               ; $640F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $640F: $CD $C0 $3B
     call func_018_7DE8                            ; $6412: $CD $E8 $7D
     call func_018_7E15                            ; $6415: $CD $15 $7E
     ldh  a, [hActiveEntityWalking]                ; $6418: $F0 $F0
@@ -7956,7 +7956,7 @@ func_018_6EFB:
 
 label_018_6F1F:
     ld   de, $6F17                                ; $6F1F: $11 $17 $6F
-    call label_3BC0                               ; $6F22: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6F22: $CD $C0 $3B
     call func_018_7DE8                            ; $6F25: $CD $E8 $7D
     call label_C56                                ; $6F28: $CD $56 $0C
     ldh  a, [hFrameCounter]                       ; $6F2B: $F0 $E7
@@ -8009,7 +8009,7 @@ jr_018_6F54:
 
     ld   l, b                                     ; $6F71: $68
     ld   l, a                                     ; $6F72: $6F
-    call label_3BC0                               ; $6F73: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6F73: $CD $C0 $3B
     call func_018_7DE8                            ; $6F76: $CD $E8 $7D
     call func_018_7E15                            ; $6F79: $CD $15 $7E
     call func_018_7E5F                            ; $6F7C: $CD $5F $7E
@@ -8396,7 +8396,7 @@ func_018_7181:
 
 label_018_71A3:
     ld   de, $719B                                ; $71A3: $11 $9B $71
-    call label_3BC0                               ; $71A6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $71A6: $CD $C0 $3B
     call func_018_7DE8                            ; $71A9: $CD $E8 $7D
     call label_C56                                ; $71AC: $CD $56 $0C
     ldh  a, [hActiveEntityWalking]                ; $71AF: $F0 $F0
@@ -9329,7 +9329,7 @@ jr_018_76C9:
     inc  hl                                       ; $76CE: $23
     push hl                                       ; $76CF: $E5
     ld   de, $7666                                ; $76D0: $11 $66 $76
-    call label_3BC0                               ; $76D3: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $76D3: $CD $C0 $3B
     ld   a, [$DBC7]                               ; $76D6: $FA $C7 $DB
     and  a                                        ; $76D9: $A7
     jr   nz, jr_018_7717                          ; $76DA: $20 $3B
@@ -9439,7 +9439,7 @@ jr_018_774E:
 
 jr_018_7764:
     ld   de, $7729                                ; $7764: $11 $29 $77
-    call label_3BC0                               ; $7767: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7767: $CD $C0 $3B
     call func_018_7DE8                            ; $776A: $CD $E8 $7D
     call func_018_7E15                            ; $776D: $CD $15 $7E
     call label_3B39                               ; $7770: $CD $39 $3B
@@ -10386,7 +10386,7 @@ jr_018_7CAF:
 
 func_018_7CC8:
     ld   de, $7CC4                                ; $7CC8: $11 $C4 $7C
-    call label_3BC0                               ; $7CCB: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7CCB: $CD $C0 $3B
     ldh  a, [wActiveEntityPosX]                   ; $7CCE: $F0 $EE
     ld   hl, hLinkPositionX                       ; $7CD0: $21 $98 $FF
     sub  [hl]                                     ; $7CD3: $96

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -585,7 +585,7 @@ func_019_43A9:
     and  $01                                      ; $43B4: $E6 $01
     ldh  [hActiveEntityUnknownG], a               ; $43B6: $E0 $F1
     ld   de, $4393                                ; $43B8: $11 $93 $43
-    call label_3BC0                               ; $43BB: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $43BB: $CD $C0 $3B
     ld   hl, $C340                                ; $43BE: $21 $40 $C3
     add  hl, bc                                   ; $43C1: $09
     ld   [hl], $C1                                ; $43C2: $36 $C1
@@ -707,7 +707,7 @@ BoomerangEntityHandler::
     ld   [wProjectileCount], a                    ; $4463: $EA $4D $C1
 
     ld   de, $4451                                ; $4466: $11 $51 $44
-    call label_3BC0                               ; $4469: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4469: $CD $C0 $3B
     call func_019_7D3D                            ; $446C: $CD $3D $7D
     call label_29F8                               ; $446F: $CD $F8 $29
     ldh  a, [hFrameCounter]                       ; $4472: $F0 $E7
@@ -967,7 +967,7 @@ label_019_45E4:
     add  hl, bc                                   ; $45FE: $09
     ld   [hl], $50                                ; $45FF: $36 $50
     ld   de, $45C4                                ; $4601: $11 $C4 $45
-    call label_3BC0                               ; $4604: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4604: $CD $C0 $3B
     call func_019_7CD4                            ; $4607: $CD $D4 $7C
     ldh  a, [hFrameCounter]                       ; $460A: $F0 $E7
     and  $3F                                      ; $460C: $E6 $3F
@@ -1276,7 +1276,7 @@ jr_019_476A:
     jp   z, label_019_45E4                        ; $47C0: $CA $E4 $45
 
     ld   de, $4796                                ; $47C3: $11 $96 $47
-    call label_3BC0                               ; $47C6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $47C6: $CD $C0 $3B
     call func_019_7D3D                            ; $47C9: $CD $3D $7D
     call func_019_7D6E                            ; $47CC: $CD $6E $7D
     ld   hl, $C430                                ; $47CF: $21 $30 $C4
@@ -1465,7 +1465,7 @@ jr_019_48AC:
 
 jr_019_48EE:
     ld   de, $48CA                                ; $48EE: $11 $CA $48
-    call label_3BC0                               ; $48F1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $48F1: $CD $C0 $3B
     call func_019_7D3D                            ; $48F4: $CD $3D $7D
     call label_C56                                ; $48F7: $CD $56 $0C
     call func_019_7DF1                            ; $48FA: $CD $F1 $7D
@@ -1999,7 +1999,7 @@ jr_019_4BAB:
     ret  z                                        ; $4BF0: $C8
 
     ld   de, $4BAC                                ; $4BF1: $11 $AC $4B
-    jp   label_3BC0                               ; $4BF4: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $4BF4: $C3 $C0 $3B
 
 jr_019_4BF7:
     ldh  a, [hActiveEntityUnknownG]               ; $4BF7: $F0 $F1
@@ -2324,7 +2324,7 @@ label_019_4D9B:
 
 func_019_4E00:
     ld   de, $4DB8                                ; $4E00: $11 $B8 $4D
-    call label_3BC0                               ; $4E03: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4E03: $CD $C0 $3B
     jp   label_019_7CA2                           ; $4E06: $C3 $A2 $7C
 
     ld   a, $02                                   ; $4E09: $3E $02
@@ -2687,7 +2687,7 @@ jr_019_4FDA:
     jp   nc, $DB11                                ; $5012: $D2 $11 $DB
 
     ld   c, a                                     ; $5015: $4F
-    call label_3BC0                               ; $5016: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5016: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $5019: $21 $D0 $C2
     add  hl, bc                                   ; $501C: $09
     ld   a, [hl]                                  ; $501D: $7E
@@ -2878,7 +2878,7 @@ jr_019_5107:
     add  hl, bc                                   ; $5121: $09
     res  4, [hl]                                  ; $5122: $CB $A6
     ld   de, $4FFB                                ; $5124: $11 $FB $4F
-    call label_3BC0                               ; $5127: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5127: $CD $C0 $3B
     call label_3D8A                               ; $512A: $CD $8A $3D
     call func_019_7D3D                            ; $512D: $CD $3D $7D
     ldh  a, [hFrameCounter]                       ; $5130: $F0 $E7
@@ -3414,7 +3414,7 @@ jr_019_546E:
     ld   hl, $C5A0                                ; $546F: $21 $A0 $C5
     inc  [hl]                                     ; $5472: $34
     ld   de, $53E0                                ; $5473: $11 $E0 $53
-    call label_3BC0                               ; $5476: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5476: $CD $C0 $3B
     call func_019_7D3D                            ; $5479: $CD $3D $7D
     call label_3B44                               ; $547C: $CD $44 $3B
     call func_019_7DBB                            ; $547F: $CD $BB $7D
@@ -3529,7 +3529,7 @@ label_019_54FD:
     add  e                                        ; $5510: $83
     ldh  [hActiveEntityUnknownG], a               ; $5511: $E0 $F1
     ld   de, $54DD                                ; $5513: $11 $DD $54
-    call label_3BC0                               ; $5516: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5516: $CD $C0 $3B
 
 jr_019_5519:
     call func_019_7D3D                            ; $5519: $CD $3D $7D
@@ -3549,7 +3549,7 @@ jr_019_552C:
 
 jr_019_552D:
     ld   de, $54F5                                ; $552D: $11 $F5 $54
-    call label_3BC0                               ; $5530: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5530: $CD $C0 $3B
     ldh  a, [hFrameCounter]                       ; $5533: $F0 $E7
     rra                                           ; $5535: $1F
     rra                                           ; $5536: $1F
@@ -3851,7 +3851,7 @@ jr_019_56AF:
     ld   e, b                                     ; $56C3: $58
     ld   [hl+], a                                 ; $56C4: $22
     ld   de, $56BD                                ; $56C5: $11 $BD $56
-    call label_3BC0                               ; $56C8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $56C8: $CD $C0 $3B
     call func_019_7D3D                            ; $56CB: $CD $3D $7D
     call label_C56                                ; $56CE: $CD $56 $0C
     call label_3B39                               ; $56D1: $CD $39 $3B
@@ -4026,7 +4026,7 @@ jr_019_575F:
     add  $08                                      ; $57BC: $C6 $08
     ldh  [wActiveEntityPosX], a                   ; $57BE: $E0 $EE
     ld   de, $5788                                ; $57C0: $11 $88 $57
-    call label_3BC0                               ; $57C3: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $57C3: $CD $C0 $3B
     call label_3D8A                               ; $57C6: $CD $8A $3D
     ld   hl, $5768                                ; $57C9: $21 $68 $57
     ld   c, $08                                   ; $57CC: $0E $08
@@ -4201,7 +4201,7 @@ jr_019_58D8:
     reti                                          ; $58DE: $D9
 
     ld   e, b                                     ; $58DF: $58
-    call label_3BC0                               ; $58E0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $58E0: $CD $C0 $3B
     call func_019_7D3D                            ; $58E3: $CD $3D $7D
     ldh  a, [hActiveEntityWalking]                ; $58E6: $F0 $F0
     rst  $00                                      ; $58E8: $C7
@@ -4389,14 +4389,14 @@ jr_019_59B7:
     ld   hl, $C3E0                                ; $59E5: $21 $E0 $C3
     add  hl, bc                                   ; $59E8: $09
     ld   [hl], a                                  ; $59E9: $77
-    ld   hl, $C220                                ; $59EA: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $59EA: $21 $20 $C2
     add  hl, bc                                   ; $59ED: $09
     ld   [hl], b                                  ; $59EE: $70
-    ld   hl, $C230                                ; $59EF: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $59EF: $21 $30 $C2
     add  hl, bc                                   ; $59F2: $09
     ld   [hl], b                                  ; $59F3: $70
     ld   de, $59BC                                ; $59F4: $11 $BC $59
-    call label_3BC0                               ; $59F7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $59F7: $CD $C0 $3B
     ldh  a, [hActiveEntityState]                  ; $59FA: $F0 $EA
     cp   $07                                      ; $59FC: $FE $07
     jp   z, label_019_5B3C                        ; $59FE: $CA $3C $5B
@@ -4738,7 +4738,7 @@ jr_019_5B9D:
 
     and  b                                        ; $5BC1: $A0
     ld   e, e                                     ; $5BC2: $5B
-    call label_3BC0                               ; $5BC3: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5BC3: $CD $C0 $3B
     call func_019_7D3D                            ; $5BC6: $CD $3D $7D
     call func_019_7DB8                            ; $5BC9: $CD $B8 $7D
     call func_019_7DF1                            ; $5BCC: $CD $F1 $7D
@@ -5236,10 +5236,10 @@ label_019_5E09:
     ld   hl, $C3E0                                ; $5E22: $21 $E0 $C3
     add  hl, bc                                   ; $5E25: $09
     ld   [hl], a                                  ; $5E26: $77
-    ld   hl, $C220                                ; $5E27: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $5E27: $21 $20 $C2
     add  hl, bc                                   ; $5E2A: $09
     ld   [hl], b                                  ; $5E2B: $70
-    ld   hl, $C230                                ; $5E2C: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $5E2C: $21 $30 $C2
     add  hl, bc                                   ; $5E2F: $09
     ld   [hl], b                                  ; $5E30: $70
     ldh  a, [hFrameCounter]                       ; $5E31: $F0 $E7
@@ -5248,7 +5248,7 @@ label_019_5E09:
     jr   nz, jr_019_5E3E                          ; $5E36: $20 $06
 
     ld   de, $5DF8                                ; $5E38: $11 $F8 $5D
-    call label_3BC0                               ; $5E3B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5E3B: $CD $C0 $3B
 
 jr_019_5E3E:
     ld   hl, wEntitiesUnknownTableC               ; $5E3E: $21 $C0 $C2
@@ -7547,7 +7547,7 @@ jr_019_6AC8:
 
 jr_019_6ACE:
     ld   de, $6A8D                                ; $6ACE: $11 $8D $6A
-    call label_3BC0                               ; $6AD1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6AD1: $CD $C0 $3B
 
 jr_019_6AD4:
     call func_019_7D3D                            ; $6AD4: $CD $3D $7D
@@ -7633,7 +7633,7 @@ jr_019_6B41:
     ld   h, [hl]                                  ; $6B50: $66
     ld   hl, $2164                                ; $6B51: $21 $64 $21
     ld   de, $6B44                                ; $6B54: $11 $44 $6B
-    call label_3BC0                               ; $6B57: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6B57: $CD $C0 $3B
     call func_019_7D3D                            ; $6B5A: $CD $3D $7D
     ld   hl, wEntity0SpeedX                       ; $6B5D: $21 $40 $C2
     add  hl, bc                                   ; $6B60: $09
@@ -7723,7 +7723,7 @@ jr_019_6BC6:
 
 jr_019_6BD3:
     ld   de, $6B44                                ; $6BD3: $11 $44 $6B
-    call label_3BC0                               ; $6BD6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6BD6: $CD $C0 $3B
     call func_019_7D3D                            ; $6BD9: $CD $3D $7D
     ld   hl, wEntity0SpeedX                       ; $6BDC: $21 $40 $C2
     add  hl, bc                                   ; $6BDF: $09
@@ -7907,7 +7907,7 @@ func_019_6CD3:
 
 label_019_6CE7:
     ld   de, $6CE3                                ; $6CE7: $11 $E3 $6C
-    call label_3BC0                               ; $6CEA: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6CEA: $CD $C0 $3B
     call func_019_7DF1                            ; $6CED: $CD $F1 $7D
     ld   hl, wEntitiesSpeedZTable                 ; $6CF0: $21 $20 $C3
     add  hl, bc                                   ; $6CF3: $09
@@ -9111,7 +9111,7 @@ func_019_73BD:
     ld   a, $80                                   ; $73C9: $3E $80
     ldh  [wActiveEntityPosY], a                   ; $73CB: $E0 $EC
     ld   de, $73A9                                ; $73CD: $11 $A9 $73
-    call label_3BC0                               ; $73D0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $73D0: $CD $C0 $3B
     ld   hl, $C3D0                                ; $73D3: $21 $D0 $C3
     add  hl, bc                                   ; $73D6: $09
     ld   a, [hl]                                  ; $73D7: $7E
@@ -9122,7 +9122,7 @@ func_019_73BD:
 
 jr_019_73DE:
     ld   de, $73A9                                ; $73DE: $11 $A9 $73
-    call label_3BC0                               ; $73E1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $73E1: $CD $C0 $3B
     ldh  a, [wActiveEntityPosY]                   ; $73E4: $F0 $EC
     add  $10                                      ; $73E6: $C6 $10
     ldh  [wActiveEntityPosY], a                   ; $73E8: $E0 $EC
@@ -9152,11 +9152,11 @@ jr_019_73EE:
     ld   a, $78                                   ; $7404: $3E $78
     ldh  [wActiveEntityPosX], a                   ; $7406: $E0 $EE
     ld   de, $73AD                                ; $7408: $11 $AD $73
-    call label_3BC0                               ; $740B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $740B: $CD $C0 $3B
     ld   a, $98                                   ; $740E: $3E $98
     ldh  [wActiveEntityPosX], a                   ; $7410: $E0 $EE
     ld   de, $73AD                                ; $7412: $11 $AD $73
-    jp   label_3BC0                               ; $7415: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $7415: $C3 $C0 $3B
 
     ret  c                                        ; $7418: $D8
 
@@ -9369,7 +9369,7 @@ jr_019_74F9:
     and  $03                                      ; $74FF: $E6 $03
     ldh  [hActiveEntityUnknownG], a               ; $7501: $E0 $F1
     ld   de, $73AD                                ; $7503: $11 $AD $73
-    jp   label_3BC0                               ; $7506: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $7506: $C3 $C0 $3B
 
 jr_019_7509:
     call GetEntityTransitionCountdown             ; $7509: $CD $05 $0C
@@ -9465,7 +9465,7 @@ jr_019_7597:
     xor  a                                        ; $7597: $AF
     ldh  [hActiveEntityUnknownG], a               ; $7598: $E0 $F1
     ld   de, $756B                                ; $759A: $11 $6B $75
-    jp   label_3BC0                               ; $759D: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $759D: $C3 $C0 $3B
 
     ld   hl, sp+$00                               ; $75A0: $F8 $00
     ld   l, [hl]                                  ; $75A2: $6E
@@ -10024,7 +10024,7 @@ jr_019_784B:
     ret  nz                                       ; $7880: $C0
 
     ld   de, $7879                                ; $7881: $11 $79 $78
-    call label_3BC0                               ; $7884: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7884: $CD $C0 $3B
     call func_019_7DBB                            ; $7887: $CD $BB $7D
     ld   hl, wEntity0SpeedY                       ; $788A: $21 $50 $C2
     add  hl, bc                                   ; $788D: $09
@@ -10232,7 +10232,7 @@ jr_019_7985:
     add  [hl]                                     ; $7994: $86
     rl   d                                        ; $7995: $CB $12
     ld   [hl], a                                  ; $7997: $77
-    ld   hl, $C220                                ; $7998: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $7998: $21 $20 $C2
     add  hl, bc                                   ; $799B: $09
     ldh  a, [hScratchB]                           ; $799C: $F0 $D8
     rr   d                                        ; $799E: $CB $1A
@@ -10244,7 +10244,7 @@ jr_019_7985:
     add  [hl]                                     ; $79A8: $86
     rl   d                                        ; $79A9: $CB $12
     ld   [hl], a                                  ; $79AB: $77
-    ld   hl, $C230                                ; $79AC: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $79AC: $21 $30 $C2
     add  hl, bc                                   ; $79AF: $09
     ldh  a, [hScratchD]                           ; $79B0: $F0 $DA
     rr   d                                        ; $79B2: $CB $1A

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -1,3 +1,4 @@
+
 ; Disassembly of "game.gbc"
 ; This file was created with mgbdis v1.3 - Game Boy ROM disassembler by Matt Currie.
 ; https://github.com/mattcurrie/mgbdis
@@ -10198,6 +10199,8 @@ jr_019_792F:
     jr   nc, @+$3E                                ; $7961: $30 $3C
 
     ld   c, b                                     ; $7963: $48
+
+UpdateEntityPositionForRoomTransition::
     ld   a, [wRoomTransitionState]                ; $7964: $FA $24 $C1
     cp   $04                                      ; $7967: $FE $04
     jr   nc, jr_019_796C                          ; $7969: $30 $01

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -4390,10 +4390,10 @@ jr_019_59B7:
     ld   hl, $C3E0                                ; $59E5: $21 $E0 $C3
     add  hl, bc                                   ; $59E8: $09
     ld   [hl], a                                  ; $59E9: $77
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $59EA: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $59EA: $21 $20 $C2
     add  hl, bc                                   ; $59ED: $09
     ld   [hl], b                                  ; $59EE: $70
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $59EF: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $59EF: $21 $30 $C2
     add  hl, bc                                   ; $59F2: $09
     ld   [hl], b                                  ; $59F3: $70
     ld   de, $59BC                                ; $59F4: $11 $BC $59
@@ -5237,10 +5237,10 @@ label_019_5E09:
     ld   hl, $C3E0                                ; $5E22: $21 $E0 $C3
     add  hl, bc                                   ; $5E25: $09
     ld   [hl], a                                  ; $5E26: $77
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $5E27: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $5E27: $21 $20 $C2
     add  hl, bc                                   ; $5E2A: $09
     ld   [hl], b                                  ; $5E2B: $70
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $5E2C: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $5E2C: $21 $30 $C2
     add  hl, bc                                   ; $5E2F: $09
     ld   [hl], b                                  ; $5E30: $70
     ldh  a, [hFrameCounter]                       ; $5E31: $F0 $E7
@@ -10235,7 +10235,7 @@ jr_019_7985:
     add  [hl]                                     ; $7994: $86
     rl   d                                        ; $7995: $CB $12
     ld   [hl], a                                  ; $7997: $77
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $7998: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $7998: $21 $20 $C2
     add  hl, bc                                   ; $799B: $09
     ldh  a, [hScratchB]                           ; $799C: $F0 $D8
     rr   d                                        ; $799E: $CB $1A
@@ -10247,7 +10247,7 @@ jr_019_7985:
     add  [hl]                                     ; $79A8: $86
     rl   d                                        ; $79A9: $CB $12
     ld   [hl], a                                  ; $79AB: $77
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $79AC: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $79AC: $21 $30 $C2
     add  hl, bc                                   ; $79AF: $09
     ldh  a, [hScratchD]                           ; $79B0: $F0 $DA
     rr   d                                        ; $79B2: $CB $1A

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -533,7 +533,7 @@ jr_003_4A4D:
 
 jr_003_4A4F:
     call func_003_4995                            ; $4A4F: $CD $95 $49
-    ld   de, wEntitiesTransitionIntersectingXTable                                ; $4A52: $11 $20 $C2
+    ld   de, wEntitiesPosXSignTable                                ; $4A52: $11 $20 $C2
     ld   hl, wEntity0PosX                         ; $4A55: $21 $00 $C2
     jp   label_003_4F92                           ; $4A58: $C3 $92 $4F
 
@@ -1415,10 +1415,10 @@ jr_003_4F67:
 
 func_003_4F83::
 jr_003_4F83:
-    ld   de, wEntitiesTransitionIntersectingXTable                                ; $4F83: $11 $20 $C2
+    ld   de, wEntitiesPosXSignTable                                ; $4F83: $11 $20 $C2
     ld   hl, wEntity0PosX                         ; $4F86: $21 $00 $C2
     call func_003_4F92                            ; $4F89: $CD $92 $4F
-    ld   de, wEntitiesTransitionIntersectingYTable                                ; $4F8C: $11 $30 $C2
+    ld   de, wEntitiesPosYSignTable                                ; $4F8C: $11 $30 $C2
     ld   hl, wEntity0PosY                         ; $4F8F: $21 $10 $C2
 
 func_003_4F92::
@@ -1438,7 +1438,7 @@ jr_003_4F92:
     ld   [hl], a                                  ; $4F9F: $77
     ret                                           ; $4FA0: $C9
 
-    ld   de, wEntitiesTransitionIntersectingXTable                                ; $4FA1: $11 $20 $C2
+    ld   de, wEntitiesPosXSignTable                                ; $4FA1: $11 $20 $C2
     ld   hl, wEntity0PosX                         ; $4FA4: $21 $00 $C2
     jr   jr_003_4F92                              ; $4FA7: $18 $E9
 
@@ -5204,16 +5204,16 @@ jr_003_64E0:
     ld   hl, $C410                                ; $6507: $21 $10 $C4
     add  hl, de                                   ; $650A: $19
     ld   [hl], $01                                ; $650B: $36 $01
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $650D: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $650D: $21 $20 $C2
     add  hl, bc                                   ; $6510: $09
     ld   a, [hl]                                  ; $6511: $7E
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $6512: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $6512: $21 $20 $C2
     add  hl, de                                   ; $6515: $19
     ld   [hl], a                                  ; $6516: $77
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $6517: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $6517: $21 $30 $C2
     add  hl, bc                                   ; $651A: $09
     ld   a, [hl]                                  ; $651B: $7E
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $651C: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $651C: $21 $30 $C2
     add  hl, de                                   ; $651F: $19
     ld   [hl], a                                  ; $6520: $77
     scf                                           ; $6521: $37

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -533,7 +533,7 @@ jr_003_4A4D:
 
 jr_003_4A4F:
     call func_003_4995                            ; $4A4F: $CD $95 $49
-    ld   de, $C220                                ; $4A52: $11 $20 $C2
+    ld   de, wEntitiesTransitionIntersectingXTable                                ; $4A52: $11 $20 $C2
     ld   hl, wEntity0PosX                         ; $4A55: $21 $00 $C2
     jp   label_003_4F92                           ; $4A58: $C3 $92 $4F
 
@@ -883,7 +883,7 @@ EntityDestructionHandler::
     and  $01                                      ; $4C56: $E6 $01
     ldh  [hActiveEntityUnknownG], a               ; $4C58: $E0 $F1
     ld   de, Data_003_4C44                        ; $4C5A: $11 $44 $4C
-    call label_3BC0                               ; $4C5D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4C5D: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableG               ; $4C60: $21 $B0 $C3
     add  hl, bc                                   ; $4C63: $09
     ld   a, [hl]                                  ; $4C64: $7E
@@ -1038,7 +1038,7 @@ jr_003_4D29:
     xor  a                                        ; $4D46: $AF
     ldh  [hActiveEntityUnknownG], a               ; $4D47: $E0 $F1
     ld   de, Data_003_4CB2                        ; $4D49: $11 $B2 $4C
-    call label_3BC0                               ; $4D4C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4D4C: $CD $C0 $3B
     jr   jr_003_4D57                              ; $4D4F: $18 $06
 
 jr_003_4D51:
@@ -1415,10 +1415,10 @@ jr_003_4F67:
 
 func_003_4F83::
 jr_003_4F83:
-    ld   de, $C220                                ; $4F83: $11 $20 $C2
+    ld   de, wEntitiesTransitionIntersectingXTable                                ; $4F83: $11 $20 $C2
     ld   hl, wEntity0PosX                         ; $4F86: $21 $00 $C2
     call func_003_4F92                            ; $4F89: $CD $92 $4F
-    ld   de, $C230                                ; $4F8C: $11 $30 $C2
+    ld   de, wEntitiesTransitionIntersectingYTable                                ; $4F8C: $11 $30 $C2
     ld   hl, wEntity0PosY                         ; $4F8F: $21 $10 $C2
 
 func_003_4F92::
@@ -1438,7 +1438,7 @@ jr_003_4F92:
     ld   [hl], a                                  ; $4F9F: $77
     ret                                           ; $4FA0: $C9
 
-    ld   de, $C220                                ; $4FA1: $11 $20 $C2
+    ld   de, wEntitiesTransitionIntersectingXTable                                ; $4FA1: $11 $20 $C2
     ld   hl, wEntity0PosX                         ; $4FA4: $21 $00 $C2
     jr   jr_003_4F92                              ; $4FA7: $18 $E9
 
@@ -1894,7 +1894,7 @@ Entity06Handler::
     ld   de, data_003_5245                        ; $525A: $11 $45 $52
 
 jr_003_525D:
-    call label_3BC0                               ; $525D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $525D: $CD $C0 $3B
     call func_003_7F78                            ; $5260: $CD $78 $7F
     call func_003_7F25                            ; $5263: $CD $25 $7F
     call func_003_52D4                            ; $5266: $CD $D4 $52
@@ -2135,7 +2135,7 @@ jr_003_53B3:
     ld   de, $5398                                ; $53B3: $11 $98 $53
 
 jr_003_53B6:
-    call label_3BC0                               ; $53B6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $53B6: $CD $C0 $3B
     call func_003_7F78                            ; $53B9: $CD $78 $7F
     ld   a, $0B                                   ; $53BC: $3E $0B
     ld   [$C19E], a                               ; $53BE: $EA $9E $C1
@@ -2955,7 +2955,7 @@ jr_003_5835:
     ld   de, $5917                                ; $5839: $11 $17 $59
 
 func_003_583C::
-    call label_3BC0                               ; $583C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $583C: $CD $C0 $3B
     call func_003_7F78                            ; $583F: $CD $78 $7F
     ld   hl, $C410                                ; $5842: $21 $10 $C4
     add  hl, bc                                   ; $5845: $09
@@ -3259,7 +3259,7 @@ HeartContainerTilesTable::
 ; Loop run every frame heart container is on screen
 LoadHeartContainer::
     ld   de, HeartContainerTilesTable             ; $59DC: $11 $D8 $59
-    call label_3BC0                               ; $59DF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $59DF: $CD $C0 $3B
     call GetEntityTransitionCountdown                 ; $59E2: $CD $05 $0C
     jp   z, label_003_60AA                        ; $59E5: $CA $AA $60
 
@@ -3380,7 +3380,7 @@ jr_003_5A17:
 
     call func_003_5A17                            ; $5A98: $CD $17 $5A
     ld   de, $5A4D                                ; $5A9B: $11 $4D $5A
-    call label_3BC0                               ; $5A9E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5A9E: $CD $C0 $3B
     call func_003_5B2B                            ; $5AA1: $CD $2B $5B
     ld   hl, $C3D0                                ; $5AA4: $21 $D0 $C3
     add  hl, bc                                   ; $5AA7: $09
@@ -3401,7 +3401,7 @@ jr_003_5ABA:
 
     call func_003_5A17                            ; $5ABB: $CD $17 $5A
     ld   de, $5A4D                                ; $5ABE: $11 $4D $5A
-    call label_3BC0                               ; $5AC1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5AC1: $CD $C0 $3B
     xor  a                                        ; $5AC4: $AF
     ld   [$C1AB], a                               ; $5AC5: $EA $AB $C1
     call func_003_5B2B                            ; $5AC8: $CD $2B $5B
@@ -3434,7 +3434,7 @@ jr_003_5AED:
 
     call func_003_5A17                            ; $5AF0: $CD $17 $5A
     ld   de, $5A4D                                ; $5AF3: $11 $4D $5A
-    call label_3BC0                               ; $5AF6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5AF6: $CD $C0 $3B
     ld   a, [wDialogState]                        ; $5AF9: $FA $9F $C1
     and  a                                        ; $5AFC: $A7
     ret  nz                                       ; $5AFD: $C0
@@ -3496,10 +3496,10 @@ jr_003_5B41:
     ld   a, $8E                                   ; $5B48: $3E $8E
     ldh  [wActiveEntityPosX], a                   ; $5B4A: $E0 $EE
     ld   de, $5B17                                ; $5B4C: $11 $17 $5B
-    jp   label_3BC0                               ; $5B4F: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $5B4F: $C3 $C0 $3B
 
     ld   de, $5A4D                                ; $5B52: $11 $4D $5A
-    call label_3BC0                               ; $5B55: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B55: $CD $C0 $3B
     jp   label_003_60AA                           ; $5B58: $C3 $AA $60
 
     xor  [hl]                                     ; $5B5B: $AE
@@ -3517,7 +3517,7 @@ jr_003_5B41:
     inc  d                                        ; $5B6B: $14
     inc  [hl]                                     ; $5B6C: $34
     ld   de, $5B65                                ; $5B6D: $11 $65 $5B
-    call label_3BC0                               ; $5B70: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B70: $CD $C0 $3B
     ldh  a, [hFrameCounter]                       ; $5B73: $F0 $E7
     rra                                           ; $5B75: $1F
     rra                                           ; $5B76: $1F
@@ -3538,7 +3538,7 @@ jr_003_5B7D:
 
     add  b                                        ; $5B89: $80
     ld   e, e                                     ; $5B8A: $5B
-    call label_3BC0                               ; $5B8B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B8B: $CD $C0 $3B
     call func_003_7F78                            ; $5B8E: $CD $78 $7F
     call func_003_62AF                            ; $5B91: $CD $AF $62
     ret                                           ; $5B94: $C9
@@ -3828,7 +3828,7 @@ jr_003_5D34:
     jp   nz, ClearEntityType                           ; $5D52: $C2 $8D $3F
 
     ld   de, $5D47                                ; $5D55: $11 $47 $5D
-    call label_3BC0                               ; $5D58: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5D58: $CD $C0 $3B
     call GetEntityTransitionCountdown                 ; $5D5B: $CD $05 $0C
     jp   z, label_003_60AA                        ; $5D5E: $CA $AA $60
 
@@ -4062,7 +4062,7 @@ jr_003_5E8A:
     ld   l, [hl]                                  ; $5E91: $6E
     nop                                           ; $5E92: $00
     ld   de, $5E8B                                ; $5E93: $11 $8B $5E
-    call label_3BC0                               ; $5E96: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5E96: $CD $C0 $3B
     call func_003_7F25                            ; $5E99: $CD $25 $7F
     call GetEntityTransitionCountdown                 ; $5E9C: $CD $05 $0C
     jp   z, ClearEntityType                            ; $5E9F: $CA $8D $3F
@@ -4088,7 +4088,7 @@ jr_003_5EAE:
     ldh  [hActiveEntityUnknownG], a               ; $5EBD: $E0 $F1
     call label_394D                               ; $5EBF: $CD $4D $39
     ld   de, $5D83                                ; $5EC2: $11 $83 $5D
-    call label_3BC0                               ; $5EC5: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5EC5: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $5EC8: $F0 $F0
     rst  $00                                      ; $5ECA: $C7
     push de                                       ; $5ECB: $D5
@@ -4375,7 +4375,7 @@ jr_003_606A:
     call func_003_61DE                            ; $607D: $CD $DE $61
     call func_003_608C                            ; $6080: $CD $8C $60
     ld   de, $6079                                ; $6083: $11 $79 $60
-    call label_3BC0                               ; $6086: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6086: $CD $C0 $3B
     jp   label_003_60AA                           ; $6089: $C3 $AA $60
 
 func_003_608C::
@@ -5204,16 +5204,16 @@ jr_003_64E0:
     ld   hl, $C410                                ; $6507: $21 $10 $C4
     add  hl, de                                   ; $650A: $19
     ld   [hl], $01                                ; $650B: $36 $01
-    ld   hl, $C220                                ; $650D: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $650D: $21 $20 $C2
     add  hl, bc                                   ; $6510: $09
     ld   a, [hl]                                  ; $6511: $7E
-    ld   hl, $C220                                ; $6512: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $6512: $21 $20 $C2
     add  hl, de                                   ; $6515: $19
     ld   [hl], a                                  ; $6516: $77
-    ld   hl, $C230                                ; $6517: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $6517: $21 $30 $C2
     add  hl, bc                                   ; $651A: $09
     ld   a, [hl]                                  ; $651B: $7E
-    ld   hl, $C230                                ; $651C: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $651C: $21 $30 $C2
     add  hl, de                                   ; $651F: $19
     ld   [hl], a                                  ; $6520: $77
     scf                                           ; $6521: $37
@@ -5506,7 +5506,7 @@ jr_003_668B:
 
 jr_003_668C:
     ld   de, $5484                                ; $668C: $11 $84 $54
-    call label_3BC0                               ; $668F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $668F: $CD $C0 $3B
     call func_003_7F78                            ; $6692: $CD $78 $7F
     ret                                           ; $6695: $C9
 
@@ -6081,7 +6081,7 @@ FlameEntityHandler::
     jp   z, ClearEntityType                            ; $69D0: $CA $8D $3F
 
     ld   de, Data_003_4C44                        ; $69D3: $11 $44 $4C
-    jp   label_3BC0                               ; $69D6: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $69D6: $C3 $C0 $3B
 
 jr_003_69D9:
     ld   de, $69AA                                ; $69D9: $11 $AA $69
@@ -6226,7 +6226,7 @@ jr_003_6A96:
     pop  af                                       ; $6AB9: $F1
     ldh  [hActiveEntityUnknownG], a               ; $6ABA: $E0 $F1
     ld   de, $6BC6                                ; $6ABC: $11 $C6 $6B
-    call label_3BC0                               ; $6ABF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6ABF: $CD $C0 $3B
     ld   a, $0C                                   ; $6AC2: $3E $0C
     ld   [$C19E], a                               ; $6AC4: $EA $9E $C1
     call func_003_75A2                            ; $6AC7: $CD $A2 $75
@@ -6244,7 +6244,7 @@ jr_003_6AD4:
 
 func_003_6AD7::
 label_003_6AD7:
-    call label_3BC0                               ; $6AD7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6AD7: $CD $C0 $3B
 
 jr_003_6ADA:
     call func_003_7F78                            ; $6ADA: $CD $78 $7F

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -14,7 +14,7 @@ label_036_4000:
     jr   c, jr_036_4011                           ; $4009: $38 $06
 
     ld   de, $490A                                ; $400B: $11 $0A $49
-    call label_3BC0                               ; $400E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $400E: $CD $C0 $3B
 
 jr_036_4011:
     call func_036_6A40                            ; $4011: $CD $40 $6A
@@ -263,7 +263,7 @@ jr_036_4144:
 
 label_036_4178:
     ld   de, $48F2                                ; $4178: $11 $F2 $48
-    call label_3BC0                               ; $417B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $417B: $CD $C0 $3B
     call func_036_6B5C                            ; $417E: $CD $5C $6B
     call func_036_6A46                            ; $4181: $CD $46 $6A
     ldh  a, [hActiveEntityWalking]                ; $4184: $F0 $F0
@@ -1303,7 +1303,7 @@ label_036_4791:
     ret  nz                                       ; $4795: $C0
 
     ld   de, $48FA                                ; $4796: $11 $FA $48
-    call label_3BC0                               ; $4799: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4799: $CD $C0 $3B
     call func_036_6A40                            ; $479C: $CD $40 $6A
     ld   a, [wGameplayType]                       ; $479F: $FA $95 $DB
     cp   $0B                                      ; $47A2: $FE $0B
@@ -1578,7 +1578,7 @@ jr_036_4859:
     jr   nz, jr_036_4925                          ; $491C: $20 $07
 
     ld   de, $48E2                                ; $491E: $11 $E2 $48
-    call label_3BC0                               ; $4921: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4921: $CD $C0 $3B
     ret                                           ; $4924: $C9
 
 jr_036_4925:
@@ -1608,7 +1608,7 @@ jr_036_492F:
     jp   c, ClearEntityTypeAndReturn              ; $494D: $DA $8D $3F
 
     ld   de, $48CE                                ; $4950: $11 $CE $48
-    call label_3BC0                               ; $4953: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4953: $CD $C0 $3B
     call func_036_6A40                            ; $4956: $CD $40 $6A
     ldh  a, [hActiveEntityWalking]                ; $4959: $F0 $F0
     rst  $00                                      ; $495B: $C7
@@ -4334,7 +4334,7 @@ jr_036_5870:
     jr   z, jr_036_588C                           ; $5882: $28 $08
 
     ld   de, $5877                                ; $5884: $11 $77 $58
-    call label_3BC0                               ; $5887: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5887: $CD $C0 $3B
     jr   jr_036_5892                              ; $588A: $18 $06
 
 jr_036_588C:
@@ -4756,7 +4756,7 @@ func_036_5AC8:
     ld   e, [hl]                                  ; $5AD5: $5E
     inc  hl                                       ; $5AD6: $23
     ld   d, [hl]                                  ; $5AD7: $56
-    call label_3BC0                               ; $5AD8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5AD8: $CD $C0 $3B
     ret                                           ; $5ADB: $C9
 
     ld   b, b                                     ; $5ADC: $40
@@ -4766,7 +4766,7 @@ func_036_5AC8:
 
 label_036_5AE4:
     ld   de, $5ADC                                ; $5AE4: $11 $DC $5A
-    call label_3BC0                               ; $5AE7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5AE7: $CD $C0 $3B
     call func_036_6A40                            ; $5AEA: $CD $40 $6A
     call label_C56                                ; $5AED: $CD $56 $0C
     call label_3B39                               ; $5AF0: $CD $39 $3B
@@ -4801,7 +4801,7 @@ label_036_5AE4:
 
 jr_036_5B1C:
     ld   de, $5AFC                                ; $5B1C: $11 $FC $5A
-    call label_3BC0                               ; $5B1F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B1F: $CD $C0 $3B
     call func_036_6A40                            ; $5B22: $CD $40 $6A
     call label_C56                                ; $5B25: $CD $56 $0C
     call label_3B39                               ; $5B28: $CD $39 $3B
@@ -4868,7 +4868,7 @@ jr_036_5B73:
     jp   nz, label_036_5AE4                       ; $5B7B: $C2 $E4 $5A
 
     ld   de, $5B42                                ; $5B7E: $11 $42 $5B
-    call label_3BC0                               ; $5B81: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B81: $CD $C0 $3B
     call func_036_6A40                            ; $5B84: $CD $40 $6A
     call label_C56                                ; $5B87: $CD $56 $0C
     call label_3B39                               ; $5B8A: $CD $39 $3B
@@ -6332,7 +6332,7 @@ func_036_6382:
 
 func_036_63C2:
     ld   de, $6392                                ; $63C2: $11 $92 $63
-    call label_3BC0                               ; $63C5: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $63C5: $CD $C0 $3B
     ret                                           ; $63C8: $C9
 
     call func_036_6629                            ; $63C9: $CD $29 $66
@@ -8378,7 +8378,7 @@ jr_036_6E3F:
     and  $03                                      ; $6E4C: $E6 $03
     call label_3B0C                               ; $6E4E: $CD $0C $3B
     ld   de, $6DA7                                ; $6E51: $11 $A7 $6D
-    call label_3BC0                               ; $6E54: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6E54: $CD $C0 $3B
 
 jr_036_6E57:
     ld   hl, $C3D0                                ; $6E57: $21 $D0 $C3

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -432,7 +432,7 @@ func_004_42B3:
     add  $0A                                      ; $42D7: $C6 $0A
     ldh  [wActiveEntityPosY], a                               ; $42D9: $E0 $EC
     xor  a                                        ; $42DB: $AF
-    ldh  [$FFF1], a                               ; $42DC: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $42DC: $E0 $F1
     ld   de, $42B1                                ; $42DE: $11 $B1 $42
     call label_3C77                               ; $42E1: $CD $77 $3C
     jp   label_3D8A                               ; $42E4: $C3 $8A $3D
@@ -1073,7 +1073,7 @@ jr_004_4713:
     rra                                           ; $473E: $1F
     rra                                           ; $473F: $1F
     and  $01                                      ; $4740: $E6 $01
-    ldh  [$FFF1], a                               ; $4742: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $4742: $E0 $F1
     ld   de, $46F5                                ; $4744: $11 $F5 $46
     call label_3C77                               ; $4747: $CD $77 $3C
     jp   label_3D8A                               ; $474A: $C3 $8A $3D
@@ -1176,7 +1176,7 @@ jr_004_48A6:
     ld   a, [hl]                                  ; $48B4: $7E
     jp   label_3B0C                               ; $48B5: $C3 $0C $3B
 
-    ldh  a, [$FFF1]                               ; $48B8: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $48B8: $F0 $F1
     rla                                           ; $48BA: $17
     rla                                           ; $48BB: $17
     rla                                           ; $48BC: $17
@@ -3504,7 +3504,7 @@ jr_004_5924:
     ld   a, [hl]                                  ; $5953: $7E
     ldh  [wActiveEntityPosY], a                               ; $5954: $E0 $EC
     ld   a, $00                                   ; $5956: $3E $00
-    ldh  [$FFF1], a                               ; $5958: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $5958: $E0 $F1
     ld   de, $58F2                                ; $595A: $11 $F2 $58
     call label_3BC0                               ; $595D: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $5960: $21 $D0 $C2
@@ -3527,7 +3527,7 @@ jr_004_5924:
     ld   a, [hl]                                  ; $597D: $7E
     ldh  [wActiveEntityPosY], a                               ; $597E: $E0 $EC
     ld   a, $00                                   ; $5980: $3E $00
-    ldh  [$FFF1], a                               ; $5982: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $5982: $E0 $F1
     ld   de, $58F2                                ; $5984: $11 $F2 $58
     call label_3BC0                               ; $5987: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $598A: $21 $D0 $C2
@@ -3550,7 +3550,7 @@ jr_004_5924:
     ld   a, [hl]                                  ; $59A6: $7E
     ldh  [wActiveEntityPosY], a                               ; $59A7: $E0 $EC
     ld   a, $01                                   ; $59A9: $3E $01
-    ldh  [$FFF1], a                               ; $59AB: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $59AB: $E0 $F1
     ld   de, $58F2                                ; $59AD: $11 $F2 $58
     call label_3BC0                               ; $59B0: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $59B3: $21 $D0 $C2
@@ -3578,7 +3578,7 @@ jr_004_5924:
     rra                                           ; $59D5: $1F
     and  $01                                      ; $59D6: $E6 $01
     add  $02                                      ; $59D8: $C6 $02
-    ldh  [$FFF1], a                               ; $59DA: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $59DA: $E0 $F1
     ldh  a, [hFrameCounter]                       ; $59DC: $F0 $E7
     rla                                           ; $59DE: $17
     rla                                           ; $59DF: $17
@@ -3863,7 +3863,7 @@ jr_004_5B7E:
     ld   a, [hl]                                  ; $5BBF: $7E
     ldh  [wActiveEntityPosY], a                               ; $5BC0: $E0 $EC
     ld   a, $08                                   ; $5BC2: $3E $08
-    ldh  [$FFF1], a                               ; $5BC4: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $5BC4: $E0 $F1
     ld   de, Data_004_5A49                        ; $5BC6: $11 $49 $5A
     call label_3BC0                               ; $5BC9: $CD $C0 $3B
     pop  de                                       ; $5BCC: $D1
@@ -3890,7 +3890,7 @@ jr_004_5B7E:
     ld   a, [hl]                                  ; $5BEC: $7E
     ldh  [wActiveEntityPosY], a                               ; $5BED: $E0 $EC
     ld   a, $09                                   ; $5BEF: $3E $09
-    ldh  [$FFF1], a                               ; $5BF1: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $5BF1: $E0 $F1
     ld   de, Data_004_5A49                        ; $5BF3: $11 $49 $5A
     call label_3BC0                               ; $5BF6: $CD $C0 $3B
     jp   label_3D8A                               ; $5BF9: $C3 $8A $3D
@@ -4243,7 +4243,7 @@ jr_004_5D25:
     ld   bc, $0178                                ; $5DEA: $01 $78 $01
     ld   a, b                                     ; $5DED: $78
     ld   hl, $2176                                ; $5DEE: $21 $76 $21
-    ldh  a, [$FFF1]                               ; $5DF1: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $5DF1: $F0 $F1
     cp   $03                                      ; $5DF3: $FE $03
     jr   nz, jr_004_5E1C                          ; $5DF5: $20 $25
 
@@ -4251,7 +4251,7 @@ jr_004_5D25:
     sub  $08                                      ; $5DF9: $D6 $08
     ldh  [wActiveEntityPosX], a                               ; $5DFB: $E0 $EE
     ld   a, $06                                   ; $5DFD: $3E $06
-    ldh  [$FFF1], a                               ; $5DFF: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $5DFF: $E0 $F1
     ld   de, $5DD1                                ; $5E01: $11 $D1 $5D
     call label_3BC0                               ; $5E04: $CD $C0 $3B
     ldh  a, [wActiveEntityPosX]                               ; $5E07: $F0 $EE
@@ -4260,7 +4260,7 @@ label_004_5E09:
     add  $10                                      ; $5E09: $C6 $10
     ldh  [wActiveEntityPosX], a                               ; $5E0B: $E0 $EE
     ld   a, $07                                   ; $5E0D: $3E $07
-    ldh  [$FFF1], a                               ; $5E0F: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $5E0F: $E0 $F1
     ld   de, $5DD1                                ; $5E11: $11 $D1 $5D
     call label_3BC0                               ; $5E14: $CD $C0 $3B
     call label_3D8A                               ; $5E17: $CD $8A $3D
@@ -4708,7 +4708,7 @@ jr_004_60E0:
     ret                                           ; $611F: $C9
 
 jr_004_6120:
-    ldh  a, [$FFF1]                               ; $6120: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $6120: $F0 $F1
     ld   e, a                                     ; $6122: $5F
     ld   d, b                                     ; $6123: $50
     ld   hl, $6074                                ; $6124: $21 $74 $60
@@ -4820,7 +4820,7 @@ label_004_61BA:
     add  [hl]                                     ; $61D5: $86
     ldh  [wActiveEntityPosY], a                               ; $61D6: $E0 $EC
     xor  a                                        ; $61D8: $AF
-    ldh  [$FFF1], a                               ; $61D9: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $61D9: $E0 $F1
     ld   de, $626D                                ; $61DB: $11 $6D $62
     call label_3BC0                               ; $61DE: $CD $C0 $3B
     jp   label_3D8A                               ; $61E1: $C3 $8A $3D
@@ -5246,9 +5246,9 @@ Data_004_641A::
     and  a                                        ; $643F: $A7
     jr   nz, jr_004_6448                          ; $6440: $20 $06
 
-    ldh  a, [$FFF1]                               ; $6442: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $6442: $F0 $F1
     add  $04                                      ; $6444: $C6 $04
-    ldh  [$FFF1], a                               ; $6446: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $6446: $E0 $F1
 
 jr_004_6448:
     ld   de, Data_004_641A                        ; $6448: $11 $1A $64
@@ -5469,7 +5469,7 @@ jr_004_6575:
     ldh  a, [wActiveEntityPosX]                               ; $6584: $F0 $EE
     add  [hl]                                     ; $6586: $86
     ldh  [wActiveEntityPosX], a                               ; $6587: $E0 $EE
-    ld   hl, $FFF1                                ; $6589: $21 $F1 $FF
+    ld   hl, hActiveEntityUnknownG                                ; $6589: $21 $F1 $FF
     ld   [hl], b                                  ; $658C: $70
     ld   de, $6576                                ; $658D: $11 $76 $65
     call label_3C77                               ; $6590: $CD $77 $3C
@@ -5729,9 +5729,9 @@ Data_004_6701::
     and  a                                        ; $6726: $A7
     jr   nz, jr_004_672F                          ; $6727: $20 $06
 
-    ldh  a, [$FFF1]                               ; $6729: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $6729: $F0 $F1
     add  $04                                      ; $672B: $C6 $04
-    ldh  [$FFF1], a                               ; $672D: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $672D: $E0 $F1
 
 jr_004_672F:
     ld   de, Data_004_6701                        ; $672F: $11 $01 $67
@@ -6473,7 +6473,7 @@ jr_004_6B31:
 
 jr_004_6B51:
     ld   a, $02                                   ; $6B51: $3E $02
-    ldh  [$FFF1], a                               ; $6B53: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $6B53: $E0 $F1
     ld   de, $6AA7                                ; $6B55: $11 $A7 $6A
     call label_3BC0                               ; $6B58: $CD $C0 $3B
     ld   hl, $C440                                ; $6B5B: $21 $40 $C4
@@ -7074,7 +7074,7 @@ func_004_6E92:
     ldh  [hJingle], a                             ; $6EAC: $E0 $F2
 
 jr_004_6EAE:
-    ldh  a, [$FFF1]                               ; $6EAE: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $6EAE: $F0 $F1
     inc  a                                        ; $6EB0: $3C
     jr   z, jr_004_6ECA                           ; $6EB1: $28 $17
 
@@ -7986,7 +7986,7 @@ func_004_73FE:
     add  $08                                      ; $740A: $C6 $08
     ldh  [wActiveEntityPosY], a                               ; $740C: $E0 $EC
     ld   a, [$D201]                               ; $740E: $FA $01 $D2
-    ldh  [$FFF1], a                               ; $7411: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $7411: $E0 $F1
     ld   de, Data_004_73E2                        ; $7413: $11 $E2 $73
     call label_3BC0                               ; $7416: $CD $C0 $3B
     ld   a, [$D204]                               ; $7419: $FA $04 $D2
@@ -7994,7 +7994,7 @@ func_004_73FE:
     ld   a, [$D205]                               ; $741E: $FA $05 $D2
     ldh  [wActiveEntityPosY], a                               ; $7421: $E0 $EC
     ld   a, [$D200]                               ; $7423: $FA $00 $D2
-    ldh  [$FFF1], a                               ; $7426: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $7426: $E0 $F1
     ld   de, Data_004_73E2                        ; $7428: $11 $E2 $73
     call label_3BC0                               ; $742B: $CD $C0 $3B
     ld   a, [$D206]                               ; $742E: $FA $06 $D2
@@ -8007,7 +8007,7 @@ func_004_73FE:
     add  $10                                      ; $743D: $C6 $10
     ldh  [wActiveEntityPosY], a                               ; $743F: $E0 $EC
     ld   a, $05                                   ; $7441: $3E $05
-    ldh  [$FFF1], a                               ; $7443: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $7443: $E0 $F1
     ld   de, Data_004_73E2                        ; $7445: $11 $E2 $73
     call label_3BC0                               ; $7448: $CD $C0 $3B
 
@@ -8022,7 +8022,7 @@ jr_004_744B:
     add  $20                                      ; $7459: $C6 $20
     ldh  [wActiveEntityPosY], a                               ; $745B: $E0 $EC
     xor  a                                        ; $745D: $AF
-    ldh  [$FFF1], a                               ; $745E: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $745E: $E0 $F1
     ld   de, Data_004_73FA                        ; $7460: $11 $FA $73
     ld   a, [$C3C0]                               ; $7463: $FA $C0 $C3
     push af                                       ; $7466: $F5
@@ -8120,7 +8120,7 @@ jr_004_74B2:
     inc  hl                                       ; $74D8: $23
 
 label_004_74D9:
-    ldh  a, [$FFF1]                               ; $74D9: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $74D9: $F0 $F1
     cp   $06                                      ; $74DB: $FE $06
     jr   c, jr_004_74F1                           ; $74DD: $38 $12
 
@@ -8328,7 +8328,7 @@ jr_004_75C6:
     ld   [hl], a                                  ; $75E9: $77
 
 jr_004_75EA:
-    ldh  a, [$FFF1]                               ; $75EA: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $75EA: $F0 $F1
     cp   $06                                      ; $75EC: $FE $06
     jr   c, jr_004_75F8                           ; $75EE: $38 $08
 
@@ -8361,7 +8361,7 @@ jr_004_75F8:
     ret  nz                                       ; $7619: $C0
 
     ld   [hl], $18                                ; $761A: $36 $18
-    ldh  a, [$FFF1]                               ; $761C: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $761C: $F0 $F1
     cp   $00                                      ; $761E: $FE $00
     jr   nz, jr_004_762D                          ; $7620: $20 $0B
 
@@ -8374,14 +8374,14 @@ jr_004_762D:
     call func_004_6D7A                            ; $762D: $CD $7A $6D
     ld   hl, hWaveSfx                             ; $7630: $21 $F3 $FF
     ld   [hl], WAVE_SFX_SEASHELL                  ; $7633: $36 $01
-    ldh  a, [$FFF1]                               ; $7635: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $7635: $F0 $F1
     ld   e, a                                     ; $7637: $5F
     ld   d, b                                     ; $7638: $50
     ld   hl, $75B6                                ; $7639: $21 $B6 $75
     add  hl, de                                   ; $763C: $19
     ld   a, [hl]                                  ; $763D: $7E
     call OpenDialog                               ; $763E: $CD $85 $23
-    ldh  a, [$FFF1]                               ; $7641: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $7641: $F0 $F1
     dec  a                                        ; $7643: $3D
     jr   nz, jr_004_7647                          ; $7644: $20 $01
 
@@ -9400,7 +9400,7 @@ jr_004_7B72:
     jr   z, jr_004_7BAC                           ; $7B7C: $28 $2E
 
     dec  a                                        ; $7B7E: $3D
-    ldh  [$FFF1], a                               ; $7B7F: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $7B7F: $E0 $F1
     ld   hl, $7B55                                ; $7B81: $21 $55 $7B
     ldh  a, [hFreeWarpDataAddress]                               ; $7B84: $F0 $E6
     ld   e, a                                     ; $7B86: $5F
@@ -9409,7 +9409,7 @@ jr_004_7B72:
     ldh  [wActiveEntityPosX], a                               ; $7B89: $E0 $EE
     ld   a, $32                                   ; $7B8B: $3E $32
     ldh  [wActiveEntityPosY], a                               ; $7B8D: $E0 $EC
-    ldh  a, [$FFF1]                               ; $7B8F: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $7B8F: $F0 $F1
     cp   $01                                      ; $7B91: $FE $01
     jr   nz, jr_004_7B9A                          ; $7B93: $20 $05
 
@@ -9442,7 +9442,7 @@ func_004_7BB7:
     ret  z                                        ; $7BBB: $C8
 
     dec  a                                        ; $7BBC: $3D
-    ldh  [$FFF1], a                               ; $7BBD: $E0 $F1
+    ldh  [hActiveEntityUnknownG], a                               ; $7BBD: $E0 $F1
     ld   a, $01                                   ; $7BBF: $3E $01
     ld   [wC15C], a                               ; $7BC1: $EA $5C $C1
     call label_CAF                                ; $7BC4: $CD $AF $0C
@@ -9451,7 +9451,7 @@ func_004_7BB7:
     ldh  a, [hLinkPositionY]                      ; $7BCB: $F0 $99
     sub  $0E                                      ; $7BCD: $D6 $0E
     ldh  [wActiveEntityPosY], a                               ; $7BCF: $E0 $EC
-    ldh  a, [$FFF1]                               ; $7BD1: $F0 $F1
+    ldh  a, [hActiveEntityUnknownG]                               ; $7BD1: $F0 $F1
     cp   $05                                      ; $7BD3: $FE $05
     jr   nz, jr_004_7BDD                          ; $7BD5: $20 $06
 

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -1203,7 +1203,7 @@ jr_004_48A6:
 
 EntityTableBHandler3::
     ld   de, $48D1                                ; $48D9: $11 $D1 $48
-    call label_3BC0                               ; $48DC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $48DC: $CD $C0 $3B
     call func_004_7FA3                            ; $48DF: $CD $A3 $7F
     ldh  a, [hFrameCounter]                       ; $48E2: $F0 $E7
     rra                                           ; $48E4: $1F
@@ -1266,7 +1266,7 @@ jr_004_4938:
 
 EntityTableBHandler4::
     ld   de, $48D1                                ; $493E: $11 $D1 $48
-    call label_3BC0                               ; $4941: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4941: $CD $C0 $3B
     call func_004_7FA3                            ; $4944: $CD $A3 $7F
     ldh  a, [hFrameCounter]                       ; $4947: $F0 $E7
     rra                                           ; $4949: $1F
@@ -2833,7 +2833,7 @@ func_004_542F:
     nop                                           ; $5464: $00
     nop                                           ; $5465: $00
     ld   de, $5446                                ; $5466: $11 $46 $54
-    call label_3BC0                               ; $5469: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5469: $CD $C0 $3B
     call func_004_7FA3                            ; $546C: $CD $A3 $7F
     call GetEntityTransitionCountdown                 ; $546F: $CD $05 $0C
     jp   z, label_004_6D7A                        ; $5472: $CA $7A $6D
@@ -2941,7 +2941,7 @@ jr_004_54F0:
     ld   de, $54F9                                ; $5519: $11 $F9 $54
 
 jr_004_551C:
-    call label_3BC0                               ; $551C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $551C: $CD $C0 $3B
     call label_C56                                ; $551F: $CD $56 $0C
     ld   hl, $C420                                ; $5522: $21 $20 $C4
     add  hl, bc                                   ; $5525: $09
@@ -3027,7 +3027,7 @@ jr_004_5596:
     ld   a, [rNR21]                               ; $5599: $F0 $16
     ldh  a, [$FF36]                               ; $559B: $F0 $36
     ld   de, $5599                                ; $559D: $11 $99 $55
-    call label_3BC0                               ; $55A0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $55A0: $CD $C0 $3B
     ld   hl, $C420                                ; $55A3: $21 $20 $C4
     add  hl, bc                                   ; $55A6: $09
     ld   a, [hl]                                  ; $55A7: $7E
@@ -3506,7 +3506,7 @@ jr_004_5924:
     ld   a, $00                                   ; $5956: $3E $00
     ldh  [hActiveEntityUnknownG], a                               ; $5958: $E0 $F1
     ld   de, $58F2                                ; $595A: $11 $F2 $58
-    call label_3BC0                               ; $595D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $595D: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $5960: $21 $D0 $C2
     add  hl, bc                                   ; $5963: $09
     ld   a, [hl]                                  ; $5964: $7E
@@ -3529,7 +3529,7 @@ jr_004_5924:
     ld   a, $00                                   ; $5980: $3E $00
     ldh  [hActiveEntityUnknownG], a                               ; $5982: $E0 $F1
     ld   de, $58F2                                ; $5984: $11 $F2 $58
-    call label_3BC0                               ; $5987: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5987: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $598A: $21 $D0 $C2
     add  hl, bc                                   ; $598D: $09
     ld   a, [hl]                                  ; $598E: $7E
@@ -3552,7 +3552,7 @@ jr_004_5924:
     ld   a, $01                                   ; $59A9: $3E $01
     ldh  [hActiveEntityUnknownG], a                               ; $59AB: $E0 $F1
     ld   de, $58F2                                ; $59AD: $11 $F2 $58
-    call label_3BC0                               ; $59B0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $59B0: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $59B3: $21 $D0 $C2
     add  hl, bc                                   ; $59B6: $09
     ld   a, [hl]                                  ; $59B7: $7E
@@ -3587,7 +3587,7 @@ jr_004_5924:
     xor  [hl]                                     ; $59E5: $AE
     ld   [hl], a                                  ; $59E6: $77
     ld   de, $58F2                                ; $59E7: $11 $F2 $58
-    call label_3BC0                               ; $59EA: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $59EA: $CD $C0 $3B
     ld   hl, $C420                                ; $59ED: $21 $20 $C4
     add  hl, bc                                   ; $59F0: $09
     ld   a, [hl]                                  ; $59F1: $7E
@@ -3824,7 +3824,7 @@ jr_004_5B7E:
     ret                                           ; $5B7E: $C9
 
     ld   de, Data_004_5A49                        ; $5B7F: $11 $49 $5A
-    call label_3BC0                               ; $5B82: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B82: $CD $C0 $3B
     call func_004_7FA3                            ; $5B85: $CD $A3 $7F
     ld   hl, $C3D0                                ; $5B88: $21 $D0 $C3
     add  hl, bc                                   ; $5B8B: $09
@@ -3865,7 +3865,7 @@ jr_004_5B7E:
     ld   a, $08                                   ; $5BC2: $3E $08
     ldh  [hActiveEntityUnknownG], a                               ; $5BC4: $E0 $F1
     ld   de, Data_004_5A49                        ; $5BC6: $11 $49 $5A
-    call label_3BC0                               ; $5BC9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5BC9: $CD $C0 $3B
     pop  de                                       ; $5BCC: $D1
     push de                                       ; $5BCD: $D5
     ld   hl, $D000                                ; $5BCE: $21 $00 $D0
@@ -3892,7 +3892,7 @@ jr_004_5B7E:
     ld   a, $09                                   ; $5BEF: $3E $09
     ldh  [hActiveEntityUnknownG], a                               ; $5BF1: $E0 $F1
     ld   de, Data_004_5A49                        ; $5BF3: $11 $49 $5A
-    call label_3BC0                               ; $5BF6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5BF6: $CD $C0 $3B
     jp   label_3D8A                               ; $5BF9: $C3 $8A $3D
 
     ld   e, b                                     ; $5BFC: $58
@@ -3912,7 +3912,7 @@ jr_004_5B7E:
 
     call func_004_7F90                            ; $5C0D: $CD $90 $7F
     ld   de, $5BFC                                ; $5C10: $11 $FC $5B
-    call label_3BC0                               ; $5C13: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5C13: $CD $C0 $3B
 
 jr_004_5C16:
     ldh  a, [hActiveEntityWalking]                               ; $5C16: $F0 $F0
@@ -4253,7 +4253,7 @@ jr_004_5D25:
     ld   a, $06                                   ; $5DFD: $3E $06
     ldh  [hActiveEntityUnknownG], a                               ; $5DFF: $E0 $F1
     ld   de, $5DD1                                ; $5E01: $11 $D1 $5D
-    call label_3BC0                               ; $5E04: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5E04: $CD $C0 $3B
     ldh  a, [wActiveEntityPosX]                               ; $5E07: $F0 $EE
 
 label_004_5E09:
@@ -4262,13 +4262,13 @@ label_004_5E09:
     ld   a, $07                                   ; $5E0D: $3E $07
     ldh  [hActiveEntityUnknownG], a                               ; $5E0F: $E0 $F1
     ld   de, $5DD1                                ; $5E11: $11 $D1 $5D
-    call label_3BC0                               ; $5E14: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5E14: $CD $C0 $3B
     call label_3D8A                               ; $5E17: $CD $8A $3D
     jr   jr_004_5E22                              ; $5E1A: $18 $06
 
 jr_004_5E1C:
     ld   de, $5DD1                                ; $5E1C: $11 $D1 $5D
-    call label_3BC0                               ; $5E1F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5E1F: $CD $C0 $3B
 
 jr_004_5E22:
     call func_004_7FA3                            ; $5E22: $CD $A3 $7F
@@ -4427,7 +4427,7 @@ jr_004_5EE5:
 
     db   $f4                                      ; $5EFD: $F4
     ld   e, [hl]                                  ; $5EFE: $5E
-    call label_3BC0                               ; $5EFF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5EFF: $CD $C0 $3B
     call func_004_7FA3                            ; $5F02: $CD $A3 $7F
     ldh  a, [hFrameCounter]                       ; $5F05: $F0 $E7
     rra                                           ; $5F07: $1F
@@ -4465,7 +4465,7 @@ Data_004_5F28::
     add  $04                                      ; $5F66: $C6 $04
     ldh  [wActiveEntityPosY], a                               ; $5F68: $E0 $EC
     ld   de, $5F58                                ; $5F6A: $11 $58 $5F
-    call label_3BC0                               ; $5F6D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5F6D: $CD $C0 $3B
     call func_004_6DCA                            ; $5F70: $CD $CA $6D
     call func_004_6E03                            ; $5F73: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                                ; $5F76: $21 $20 $C3
@@ -4726,7 +4726,7 @@ jr_004_6120:
     add  [hl]                                     ; $613A: $86
     ldh  [wActiveEntityPosY], a                               ; $613B: $E0 $EC
     ld   de, Data_004_604C                        ; $613D: $11 $4C $60
-    call label_3BC0                               ; $6140: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6140: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                               ; $6143: $F0 $F0
     JP_TABLE                                      ; $6145: $C7
     ld   d, h                                     ; $6146: $54
@@ -4822,7 +4822,7 @@ label_004_61BA:
     xor  a                                        ; $61D8: $AF
     ldh  [hActiveEntityUnknownG], a                               ; $61D9: $E0 $F1
     ld   de, $626D                                ; $61DB: $11 $6D $62
-    call label_3BC0                               ; $61DE: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $61DE: $CD $C0 $3B
     jp   label_3D8A                               ; $61E1: $C3 $8A $3D
 
     ret                                           ; $61E4: $C9
@@ -4944,7 +4944,7 @@ jr_004_6267:
     ld   a, c                                     ; $6281: $79
     ld   [$D003], a                               ; $6282: $EA $03 $D0
     ld   de, $626D                                ; $6285: $11 $6D $62
-    call label_3BC0                               ; $6288: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6288: $CD $C0 $3B
     ldh  a, [wActiveEntityPosX]                               ; $628B: $F0 $EE
     ld   [$D000], a                               ; $628D: $EA $00 $D0
     ldh  a, [$FFEF]                               ; $6290: $F0 $EF
@@ -5252,7 +5252,7 @@ Data_004_641A::
 
 jr_004_6448:
     ld   de, Data_004_641A                        ; $6448: $11 $1A $64
-    call label_3BC0                               ; $644B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $644B: $CD $C0 $3B
 
 label_004_644E:
     call func_004_7FA3                            ; $644E: $CD $A3 $7F
@@ -5735,7 +5735,7 @@ Data_004_6701::
 
 jr_004_672F:
     ld   de, Data_004_6701                        ; $672F: $11 $01 $67
-    call label_3BC0                               ; $6732: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6732: $CD $C0 $3B
     jp   label_004_644E                           ; $6735: $C3 $4E $64
 
 label_004_6738:
@@ -5921,7 +5921,7 @@ label_004_67FB:
     ld   de, $681C                                ; $6831: $11 $1C $68
 
 jr_004_6834:
-    call label_3BC0                               ; $6834: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6834: $CD $C0 $3B
     call func_004_7FA3                            ; $6837: $CD $A3 $7F
     call label_3B70                               ; $683A: $CD $70 $3B
     ldh  a, [hActiveEntityWalking]                               ; $683D: $F0 $F0
@@ -6373,7 +6373,7 @@ jr_004_6AA6:
     ld   b, $03                                   ; $6AC4: $06 $03
     ld   bc, $A711                                ; $6AC6: $01 $11 $A7
     ld   l, d                                     ; $6AC9: $6A
-    call label_3BC0                               ; $6ACA: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6ACA: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableD               ; $6ACD: $21 $D0 $C2
     add  hl, bc                                   ; $6AD0: $09
     ld   a, [hl]                                  ; $6AD1: $7E
@@ -6475,7 +6475,7 @@ jr_004_6B51:
     ld   a, $02                                   ; $6B51: $3E $02
     ldh  [hActiveEntityUnknownG], a                               ; $6B53: $E0 $F1
     ld   de, $6AA7                                ; $6B55: $11 $A7 $6A
-    call label_3BC0                               ; $6B58: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6B58: $CD $C0 $3B
     ld   hl, $C440                                ; $6B5B: $21 $40 $C4
     add  hl, bc                                   ; $6B5E: $09
     ld   a, [hl]                                  ; $6B5F: $7E
@@ -6654,7 +6654,7 @@ label_004_6C20:
     jp   nz, label_004_6D0F                       ; $6C64: $C2 $0F $6D
 
     ld   de, $6C2D                                ; $6C67: $11 $2D $6C
-    call label_3BC0                               ; $6C6A: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6C6A: $CD $C0 $3B
     call func_004_7FA3                            ; $6C6D: $CD $A3 $7F
     call label_3B44                               ; $6C70: $CD $44 $3B
     call label_3B23                               ; $6C73: $CD $23 $3B
@@ -7090,7 +7090,7 @@ jr_004_6EAE:
 jr_004_6EC1:
     call func_004_7C98                            ; $6EC1: $CD $98 $7C
     ld   de, $76CB                                ; $6EC4: $11 $CB $76
-    call label_3BC0                               ; $6EC7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6EC7: $CD $C0 $3B
 
 jr_004_6ECA:
     call func_004_73FE                            ; $6ECA: $CD $FE $73
@@ -7988,7 +7988,7 @@ func_004_73FE:
     ld   a, [$D201]                               ; $740E: $FA $01 $D2
     ldh  [hActiveEntityUnknownG], a                               ; $7411: $E0 $F1
     ld   de, Data_004_73E2                        ; $7413: $11 $E2 $73
-    call label_3BC0                               ; $7416: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7416: $CD $C0 $3B
     ld   a, [$D204]                               ; $7419: $FA $04 $D2
     ldh  [wActiveEntityPosX], a                               ; $741C: $E0 $EE
     ld   a, [$D205]                               ; $741E: $FA $05 $D2
@@ -7996,7 +7996,7 @@ func_004_73FE:
     ld   a, [$D200]                               ; $7423: $FA $00 $D2
     ldh  [hActiveEntityUnknownG], a                               ; $7426: $E0 $F1
     ld   de, Data_004_73E2                        ; $7428: $11 $E2 $73
-    call label_3BC0                               ; $742B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $742B: $CD $C0 $3B
     ld   a, [$D206]                               ; $742E: $FA $06 $D2
     cp   $08                                      ; $7431: $FE $08
     jr   c, jr_004_744B                           ; $7433: $38 $16
@@ -8009,7 +8009,7 @@ func_004_73FE:
     ld   a, $05                                   ; $7441: $3E $05
     ldh  [hActiveEntityUnknownG], a                               ; $7443: $E0 $F1
     ld   de, Data_004_73E2                        ; $7445: $11 $E2 $73
-    call label_3BC0                               ; $7448: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7448: $CD $C0 $3B
 
 jr_004_744B:
     ldh  a, [hFrameCounter]                       ; $744B: $F0 $E7
@@ -8026,7 +8026,7 @@ jr_004_744B:
     ld   de, Data_004_73FA                        ; $7460: $11 $FA $73
     ld   a, [$C3C0]                               ; $7463: $FA $C0 $C3
     push af                                       ; $7466: $F5
-    call label_3BC0                               ; $7467: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7467: $CD $C0 $3B
     pop  af                                       ; $746A: $F1
     ld   e, a                                     ; $746B: $5F
     ld   d, b                                     ; $746C: $50
@@ -8158,7 +8158,7 @@ jr_004_74FE:
     ld   de, $74CD                                ; $7509: $11 $CD $74
 
 jr_004_750C:
-    call label_3BC0                               ; $750C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $750C: $CD $C0 $3B
     jr   jr_004_7517                              ; $750F: $18 $06
 
 jr_004_7511:
@@ -8540,7 +8540,7 @@ jr_004_7705:
 jr_004_770E:
     call func_004_7C98                            ; $770E: $CD $98 $7C
     ld   de, $76CB                                ; $7711: $11 $CB $76
-    call label_3BC0                               ; $7714: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7714: $CD $C0 $3B
     call func_004_7B70                            ; $7717: $CD $70 $7B
     ldh  a, [hActiveEntityWalking]                               ; $771A: $F0 $F0
     cp   $04                                      ; $771C: $FE $04
@@ -9421,7 +9421,7 @@ jr_004_7B9A:
     jr   nz, jr_004_7BA6                          ; $7B9C: $20 $08
 
     ld   de, $7B58                                ; $7B9E: $11 $58 $7B
-    call label_3BC0                               ; $7BA1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7BA1: $CD $C0 $3B
     jr   jr_004_7BAC                              ; $7BA4: $18 $06
 
 jr_004_7BA6:
@@ -9456,7 +9456,7 @@ func_004_7BB7:
     jr   nz, jr_004_7BDD                          ; $7BD5: $20 $06
 
     ld   de, $7B58                                ; $7BD7: $11 $58 $7B
-    jp   label_3BC0                               ; $7BDA: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $7BDA: $C3 $C0 $3B
 
 jr_004_7BDD:
     ld   de, $7B5A                                ; $7BDD: $11 $5A $7B
@@ -9659,7 +9659,7 @@ jr_004_7D2B:
     rla                                           ; $7D30: $17
     and  $10                                      ; $7D31: $E6 $10
     ldh  [$FFED], a                               ; $7D33: $E0 $ED
-    call label_3BC0                               ; $7D35: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7D35: $CD $C0 $3B
     call func_004_7FA3                            ; $7D38: $CD $A3 $7F
     ld   hl, $C410                                ; $7D3B: $21 $10 $C4
     add  hl, bc                                   ; $7D3E: $09
@@ -9806,7 +9806,7 @@ label_004_7E09:
     ld   de, $7DFD                                ; $7E16: $11 $FD $7D
 
 jr_004_7E19:
-    call label_3BC0                               ; $7E19: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7E19: $CD $C0 $3B
     call func_004_7FA3                            ; $7E1C: $CD $A3 $7F
     call func_004_6D80                            ; $7E1F: $CD $80 $6D
     call IsEntityUnknownFZero                                ; $7E22: $CD $00 $0C
@@ -9964,7 +9964,7 @@ jr_004_7EE4:
     ld   d, b                                     ; $7EF3: $50
     ld   [hl+], a                                 ; $7EF4: $22
     ld   de, $7EE5                                ; $7EF5: $11 $E5 $7E
-    call label_3BC0                               ; $7EF8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7EF8: $CD $C0 $3B
     call func_004_7FA3                            ; $7EFB: $CD $A3 $7F
     call func_004_6D80                            ; $7EFE: $CD $80 $6D
     call func_004_6DCA                            ; $7F01: $CD $CA $6D

--- a/src/code/entities/bank5.asm
+++ b/src/code/entities/bank5.asm
@@ -69,10 +69,10 @@ Data_005_4000::
     ld   hl, $C3E0                                ; $4045: $21 $E0 $C3
     add  hl, bc                                   ; $4048: $09
     ld   [hl], a                                  ; $4049: $77
-    ld   hl, $C220                                ; $404A: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $404A: $21 $20 $C2
     add  hl, bc                                   ; $404D: $09
     ld   [hl], b                                  ; $404E: $70
-    ld   hl, $C230                                ; $404F: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $404F: $21 $30 $C2
     add  hl, bc                                   ; $4052: $09
     ld   [hl], b                                  ; $4053: $70
 
@@ -85,7 +85,7 @@ jr_005_4054:
     ld   de, $4000                                ; $405D: $11 $00 $40
 
 jr_005_4060:
-    call label_3BC0                               ; $4060: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4060: $CD $C0 $3B
     ld   a, [wRoomTransitionState]                ; $4063: $FA $24 $C1
     and  a                                        ; $4066: $A7
     jr   z, jr_005_407C                           ; $4067: $28 $13
@@ -1004,7 +1004,7 @@ jr_005_4509:
 
 jr_005_4538:
     ld   de, $4514                                ; $4538: $11 $14 $45
-    call label_3BC0                               ; $453B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $453B: $CD $C0 $3B
     ldh  a, [hActiveEntityState]                   ; $453E: $F0 $EA
     cp   $07                                      ; $4540: $FE $07
     jr   nz, jr_005_4557                          ; $4542: $20 $13
@@ -1808,7 +1808,7 @@ jr_005_49CC:
 
 jr_005_49D1:
     ld   de, $4912                                ; $49D1: $11 $12 $49
-    call label_3BC0                               ; $49D4: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $49D4: $CD $C0 $3B
     call func_005_7A3A                            ; $49D7: $CD $3A $7A
     ldh  a, [hActiveEntityWalking]                ; $49DA: $F0 $F0
     rst  $00                                      ; $49DC: $C7
@@ -2235,7 +2235,7 @@ jr_005_4C24:
     jr   z, jr_005_4C3E                           ; $4C36: $28 $06
 
     ld   de, $4946                                ; $4C38: $11 $46 $49
-    call label_3BC0                               ; $4C3B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4C3B: $CD $C0 $3B
 
 jr_005_4C3E:
     ld   de, $4942                                ; $4C3E: $11 $42 $49
@@ -2256,7 +2256,7 @@ jr_005_4C54:
     ld   de, $4932                                ; $4C54: $11 $32 $49
 
 jr_005_4C57:
-    call label_3BC0                               ; $4C57: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4C57: $CD $C0 $3B
     call func_005_7A3A                            ; $4C5A: $CD $3A $7A
     call func_005_54C3                            ; $4C5D: $CD $C3 $54
 
@@ -2546,7 +2546,7 @@ jr_005_4DF3:
     ldh  [wActiveEntityPosY], a                   ; $4DF7: $E0 $EC
     xor  a                                        ; $4DF9: $AF
     ldh  [hActiveEntityUnknownG], a               ; $4DFA: $E0 $F1
-    call label_3BC0                               ; $4DFC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4DFC: $CD $C0 $3B
     call label_3D8A                               ; $4DFF: $CD $8A $3D
     ld   hl, wEntitiesUnknownTableG               ; $4E02: $21 $B0 $C3
     add  hl, bc                                   ; $4E05: $09
@@ -2738,7 +2738,7 @@ jr_005_4F39:
     ld   a, c                                     ; $4F39: $79
     ld   [$C50F], a                               ; $4F3A: $EA $0F $C5
     ld   de, $4E2A                                ; $4F3D: $11 $2A $4E
-    call label_3BC0                               ; $4F40: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4F40: $CD $C0 $3B
     call func_005_54C3                            ; $4F43: $CD $C3 $54
     ld   a, [wGameplayType]                       ; $4F46: $FA $95 $DB
     cp   $07                                      ; $4F49: $FE $07
@@ -3196,7 +3196,7 @@ jr_005_51A1:
     add  hl, bc                                   ; $51E6: $09
     ld   [hl], $7A                                ; $51E7: $36 $7A
     ld   de, $51CA                                ; $51E9: $11 $CA $51
-    call label_3BC0                               ; $51EC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $51EC: $CD $C0 $3B
     call func_005_7A3A                            ; $51EF: $CD $3A $7A
     call func_005_5506                            ; $51F2: $CD $06 $55
     ret  nc                                       ; $51F5: $D0
@@ -3255,7 +3255,7 @@ jr_005_5237:
 jr_005_5245:
     call func_005_54EA                            ; $5245: $CD $EA $54
     ld   de, $4E0A                                ; $5248: $11 $0A $4E
-    call label_3BC0                               ; $524B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $524B: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $524E: $F0 $F0
     dec  a                                        ; $5250: $3D
     rst  $00                                      ; $5251: $C7
@@ -3348,7 +3348,7 @@ func_005_52AF:
     ld   a, $FF                                   ; $52C1: $3E $FF
     ldh  [hLinkAnimationState], a                 ; $52C3: $E0 $9D
     ld   de, $5258                                ; $52C5: $11 $58 $52
-    call label_3BC0                               ; $52C8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $52C8: $CD $C0 $3B
     ldh  a, [hIsGBC]                              ; $52CB: $F0 $FE
     and  a                                        ; $52CD: $A7
     jr   z, jr_005_52D8                           ; $52CE: $28 $08
@@ -3485,7 +3485,7 @@ jr_005_5359:
 jr_005_5372:
     call func_005_54EA                            ; $5372: $CD $EA $54
     ld   de, $533E                                ; $5375: $11 $3E $53
-    call label_3BC0                               ; $5378: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5378: $CD $C0 $3B
     call func_005_7A3A                            ; $537B: $CD $3A $7A
     call func_005_54C3                            ; $537E: $CD $C3 $54
     ldh  a, [hActiveEntityWalking]                ; $5381: $F0 $F0
@@ -3586,7 +3586,7 @@ jr_005_53FF:
     jr   nz, jr_005_53E9                          ; $5403: $20 $E4
 
     ld   de, $53D4                                ; $5405: $11 $D4 $53
-    call label_3BC0                               ; $5408: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5408: $CD $C0 $3B
     call func_005_7A3A                            ; $540B: $CD $3A $7A
     jp   label_005_54C3                           ; $540E: $C3 $C3 $54
 
@@ -3671,7 +3671,7 @@ jr_005_5483:
 jr_005_5487:
     call label_3D8A                               ; $5487: $CD $8A $3D
     ld   de, $53D4                                ; $548A: $11 $D4 $53
-    jp   label_3BC0                               ; $548D: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $548D: $C3 $C0 $3B
 
     ldh  a, [hFrameCounter]                       ; $5490: $F0 $E7
     rra                                           ; $5492: $1F
@@ -4483,7 +4483,7 @@ jr_005_592A:
     ld   [hl], h                                  ; $5938: $74
     dec  h                                        ; $5939: $25
     ld   de, $5932                                ; $593A: $11 $32 $59
-    call label_3BC0                               ; $593D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $593D: $CD $C0 $3B
     call func_005_7A3A                            ; $5940: $CD $3A $7A
     call label_C56                                ; $5943: $CD $56 $0C
     ld   hl, $C3D0                                ; $5946: $21 $D0 $C3
@@ -4538,7 +4538,7 @@ jr_005_5962:
     and  $20                                      ; $598C: $E6 $20
     ldh  [$FFED], a                               ; $598E: $E0 $ED
     ld   de, $5978                                ; $5990: $11 $78 $59
-    call label_3BC0                               ; $5993: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5993: $CD $C0 $3B
     call func_005_7A3A                            ; $5996: $CD $3A $7A
     call label_C56                                ; $5999: $CD $56 $0C
     ldh  a, [hFrameCounter]                       ; $599C: $F0 $E7
@@ -4857,7 +4857,7 @@ func_005_5B03:
 func_005_5B5A:
 label_005_5B5A:
     ld   de, $5B52                                ; $5B5A: $11 $52 $5B
-    jp   label_3BC0                               ; $5B5D: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $5B5D: $C3 $C0 $3B
 
     ld   [bc], a                                  ; $5B60: $02
     ld   [bc], a                                  ; $5B61: $02
@@ -6162,7 +6162,7 @@ jr_005_6246:
     ld   a, $02                                   ; $6256: $3E $02
     ldh  [$FFA1], a                               ; $6258: $E0 $A1
     ld   de, $624E                                ; $625A: $11 $4E $62
-    call label_3BC0                               ; $625D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $625D: $CD $C0 $3B
     call func_005_7A3A                            ; $6260: $CD $3A $7A
     ldh  a, [hFrameCounter]                       ; $6263: $F0 $E7
     rra                                           ; $6265: $1F
@@ -6251,7 +6251,7 @@ jr_005_62B0:
     ld   a, d                                     ; $62C6: $7A
     ld   b, d                                     ; $62C7: $42
     ld   de, $62B8                                ; $62C8: $11 $B8 $62
-    call label_3BC0                               ; $62CB: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $62CB: $CD $C0 $3B
     call func_005_7A3A                            ; $62CE: $CD $3A $7A
     call func_005_7AB1                            ; $62D1: $CD $B1 $7A
     ldh  a, [hActiveEntityWalking]                ; $62D4: $F0 $F0
@@ -7110,7 +7110,7 @@ jr_005_6783:
 
 label_005_6798:
     ld   de, $6788                                ; $6798: $11 $88 $67
-    call label_3BC0                               ; $679B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $679B: $CD $C0 $3B
     call func_005_7A3A                            ; $679E: $CD $3A $7A
     call label_3B44                               ; $67A1: $CD $44 $3B
     ldh  a, [hActiveEntityWalking]                ; $67A4: $F0 $F0
@@ -7166,7 +7166,7 @@ jr_005_67C8:
 
 label_005_67EA:
     ld   de, $67E2                                ; $67EA: $11 $E2 $67
-    call label_3BC0                               ; $67ED: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $67ED: $CD $C0 $3B
     call func_005_7A3A                            ; $67F0: $CD $3A $7A
     call func_005_7AB1                            ; $67F3: $CD $B1 $7A
     call func_005_7AEA                            ; $67F6: $CD $EA $7A
@@ -7625,7 +7625,7 @@ func_005_6A5F:
     ldh  [wActiveEntityPosY], a                   ; $6A9C: $E0 $EC
     pop  bc                                       ; $6A9E: $C1
     ld   de, $6A24                                ; $6A9F: $11 $24 $6A
-    jp   label_3BC0                               ; $6AA2: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $6AA2: $C3 $C0 $3B
 
 func_005_6AA5:
     ld   hl, $C3D0                                ; $6AA5: $21 $D0 $C3
@@ -7672,7 +7672,7 @@ func_005_6AA5:
     ld   a, $04                                   ; $6AE5: $3E $04
     ldh  [hActiveEntityUnknownG], a               ; $6AE7: $E0 $F1
     ld   de, $6A24                                ; $6AE9: $11 $24 $6A
-    call label_3BC0                               ; $6AEC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6AEC: $CD $C0 $3B
     ld   hl, wEntitiesUnknownTableG               ; $6AEF: $21 $B0 $C3
     add  hl, bc                                   ; $6AF2: $09
     ld   a, [hl]                                  ; $6AF3: $7E
@@ -9782,7 +9782,7 @@ func_005_766E:
     ld   a, $00                                   ; $76A4: $3E $00
     ldh  [hActiveEntityUnknownG], a               ; $76A6: $E0 $F1
     ld   de, $72CC                                ; $76A8: $11 $CC $72
-    call label_3BC0                               ; $76AB: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $76AB: $CD $C0 $3B
     ldh  a, [hScratchA]                           ; $76AE: $F0 $D7
     sub  $18                                      ; $76B0: $D6 $18
     and  $7F                                      ; $76B2: $E6 $7F
@@ -9799,7 +9799,7 @@ func_005_766E:
     ld   a, $00                                   ; $76C4: $3E $00
     ldh  [hActiveEntityUnknownG], a               ; $76C6: $E0 $F1
     ld   de, $72CC                                ; $76C8: $11 $CC $72
-    call label_3BC0                               ; $76CB: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $76CB: $CD $C0 $3B
     ldh  a, [hScratchA]                           ; $76CE: $F0 $D7
     sub  $24                                      ; $76D0: $D6 $24
     and  $7F                                      ; $76D2: $E6 $7F
@@ -9816,7 +9816,7 @@ func_005_766E:
     ld   a, $02                                   ; $76E4: $3E $02
     ldh  [hActiveEntityUnknownG], a               ; $76E6: $E0 $F1
     ld   de, $72CC                                ; $76E8: $11 $CC $72
-    jp   label_3BC0                               ; $76EB: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $76EB: $C3 $C0 $3B
 
     nop                                           ; $76EE: $00
     ld   b, $0C                                   ; $76EF: $06 $0C
@@ -10294,7 +10294,7 @@ jr_005_79B3:
     jr   nc, jr_005_7A1F                          ; $79C9: $30 $54
 
     ld   de, $72CC                                ; $79CB: $11 $CC $72
-    call label_3BC0                               ; $79CE: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $79CE: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $79D1: $F0 $F0
     cp   $04                                      ; $79D3: $FE $04
     jr   nc, jr_005_7A1D                          ; $79D5: $30 $46
@@ -11307,7 +11307,7 @@ jr_005_7F1B:
     jp   z, label_005_7B4B                        ; $7F32: $CA $4B $7B
 
     ld   de, $7F1E                                ; $7F35: $11 $1E $7F
-    call label_3BC0                               ; $7F38: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7F38: $CD $C0 $3B
     ld   a, [$C50F]                               ; $7F3B: $FA $0F $C5
     ld   e, a                                     ; $7F3E: $5F
     ld   d, b                                     ; $7F3F: $50

--- a/src/code/entities/bank5.asm
+++ b/src/code/entities/bank5.asm
@@ -69,10 +69,10 @@ Data_005_4000::
     ld   hl, $C3E0                                ; $4045: $21 $E0 $C3
     add  hl, bc                                   ; $4048: $09
     ld   [hl], a                                  ; $4049: $77
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $404A: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $404A: $21 $20 $C2
     add  hl, bc                                   ; $404D: $09
     ld   [hl], b                                  ; $404E: $70
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $404F: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $404F: $21 $30 $C2
     add  hl, bc                                   ; $4052: $09
     ld   [hl], b                                  ; $4053: $70
 

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -9,7 +9,7 @@ Data_006_4000::
     ld   a, $21                                   ; $4020: $3E $21
     ldh  [wActiveEntityPosY], a                   ; $4022: $E0 $EC
     ld   de, Data_006_4000                        ; $4024: $11 $00 $40
-    call label_3BC0                               ; $4027: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4027: $CD $C0 $3B
     call func_006_64C6                            ; $402A: $CD $C6 $64
     ldh  a, [hFrameCounter]                       ; $402D: $F0 $E7
     and  $1F                                      ; $402F: $E6 $1F
@@ -226,7 +226,7 @@ jr_006_40FC:
     add  hl, bc                                   ; $415A: $09
     ld   [hl], $FF                                ; $415B: $36 $FF
     ld   de, $4126                                ; $415D: $11 $26 $41
-    call label_3BC0                               ; $4160: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4160: $CD $C0 $3B
     call func_006_64C6                            ; $4163: $CD $C6 $64
     call label_C56                                ; $4166: $CD $56 $0C
     ldh  a, [hActiveEntityWalking]                ; $4169: $F0 $F0
@@ -771,7 +771,7 @@ jr_006_440C:
     jr   nc, jr_006_44F1                          ; $44BA: $30 $35
 
     ld   de, $4436                                ; $44BC: $11 $36 $44
-    call label_3BC0                               ; $44BF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $44BF: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $44C2: $F0 $F0
     cp   $02                                      ; $44C4: $FE $02
     ret  nz                                       ; $44C6: $C0
@@ -1228,7 +1228,7 @@ label_006_4781:
     add  hl, bc                                   ; $478A: $09
     ld   [hl], $FF                                ; $478B: $36 $FF
     ld   de, $477D                                ; $478D: $11 $7D $47
-    call label_3BC0                               ; $4790: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4790: $CD $C0 $3B
     call func_006_64C6                            ; $4793: $CD $C6 $64
     call label_C56                                ; $4796: $CD $56 $0C
     call label_3B70                               ; $4799: $CD $70 $3B
@@ -1525,7 +1525,7 @@ jr_006_4910:
     add  hl, bc                                   ; $4934: $09
     ld   [hl], $20                                ; $4935: $36 $20
     ld   de, $4911                                ; $4937: $11 $11 $49
-    call label_3BC0                               ; $493A: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $493A: $CD $C0 $3B
     call func_006_64C6                            ; $493D: $CD $C6 $64
     call label_C56                                ; $4940: $CD $56 $0C
     call func_006_6541                            ; $4943: $CD $41 $65
@@ -1802,7 +1802,7 @@ label_006_4AA7:
 
     xor  b                                        ; $4AB5: $A8
     ld   c, d                                     ; $4AB6: $4A
-    call label_3BC0                               ; $4AB7: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4AB7: $CD $C0 $3B
     call func_006_64C6                            ; $4ABA: $CD $C6 $64
     call func_006_64F7                            ; $4ABD: $CD $F7 $64
     call label_3B39                               ; $4AC0: $CD $39 $3B
@@ -2318,7 +2318,7 @@ func_006_4E64:
 
 label_006_4E88:
     ld   de, $4E78                                ; $4E88: $11 $78 $4E
-    call label_3BC0                               ; $4E8B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4E8B: $CD $C0 $3B
     call func_006_64C6                            ; $4E8E: $CD $C6 $64
     call GetEntityTransitionCountdown             ; $4E91: $CD $05 $0C
     jp   z, label_006_65DB                        ; $4E94: $CA $DB $65
@@ -2346,7 +2346,7 @@ label_006_4E88:
 label_006_4EB7:
 jr_006_4EB7:
     ld   de, $4E9D                                ; $4EB7: $11 $9D $4E
-    call label_3BC0                               ; $4EBA: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4EBA: $CD $C0 $3B
     call func_006_64C6                            ; $4EBD: $CD $C6 $64
     ldh  a, [$FFBA]                               ; $4EC0: $F0 $BA
     cp   $02                                      ; $4EC2: $FE $02
@@ -2448,7 +2448,7 @@ jr_006_4F0E:
     ld   de, $4F34                                ; $4F45: $11 $34 $4F
 
 jr_006_4F48:
-    call label_3BC0                               ; $4F48: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4F48: $CD $C0 $3B
     call func_006_64C6                            ; $4F4B: $CD $C6 $64
     call func_006_64F7                            ; $4F4E: $CD $F7 $64
     call label_3B39                               ; $4F51: $CD $39 $3B
@@ -4113,7 +4113,7 @@ func_006_58C9:
     jr   nz, jr_006_58D8                          ; $58D0: $20 $06
 
     ld   de, $589F                                ; $58D2: $11 $9F $58
-    call label_3BC0                               ; $58D5: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $58D5: $CD $C0 $3B
 
 jr_006_58D8:
     ld   hl, $C3D0                                ; $58D8: $21 $D0 $C3
@@ -4176,7 +4176,7 @@ jr_006_58F3:
 jr_006_592E:
     ldh  [hActiveEntityUnknownG], a               ; $592E: $E0 $F1
     ld   de, $589F                                ; $5930: $11 $9F $58
-    call label_3BC0                               ; $5933: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5933: $CD $C0 $3B
 
 jr_006_5936:
     ld   e, $FF                                   ; $5936: $1E $FF
@@ -4395,7 +4395,7 @@ jr_006_5A36:
     ldh  [hActiveEntityUnknownG], a               ; $5A41: $E0 $F1
 
 jr_006_5A43:
-    call label_3BC0                               ; $5A43: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5A43: $CD $C0 $3B
     call func_006_64C6                            ; $5A46: $CD $C6 $64
     call label_C56                                ; $5A49: $CD $56 $0C
     call func_006_657A                            ; $5A4C: $CD $7A $65
@@ -4612,7 +4612,7 @@ jr_006_5B83:
 jr_006_5B91:
     call func_006_6441                            ; $5B91: $CD $41 $64
     ld   de, $5B56                                ; $5B94: $11 $56 $5B
-    call label_3BC0                               ; $5B97: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5B97: $CD $C0 $3B
     ld   a, [wIsBowWowFollowingLink]              ; $5B9A: $FA $56 $DB
     cp   $80                                      ; $5B9D: $FE $80
     jr   nz, jr_006_5BC4                          ; $5B9F: $20 $23
@@ -4826,7 +4826,7 @@ jr_006_5CBE:
 
 jr_006_5CCC:
     ld   de, $5C89                                ; $5CCC: $11 $89 $5C
-    call label_3BC0                               ; $5CCF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5CCF: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $5CD2: $F0 $F0
     and  a                                        ; $5CD4: $A7
     jr   nz, jr_006_5CE5                          ; $5CD5: $20 $0E
@@ -5522,7 +5522,7 @@ jr_006_60BC:
     ld   de, $605D                                ; $60BE: $11 $5D $60
 
 jr_006_60C1:
-    call label_3BC0                               ; $60C1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $60C1: $CD $C0 $3B
 
 jr_006_60C4:
     call func_006_65A4                            ; $60C4: $CD $A4 $65
@@ -5652,7 +5652,7 @@ label_006_6170:
     or   [hl]                                     ; $6176: $B6
     ldh  [hActiveEntityUnknownG], a               ; $6177: $E0 $F1
     ld   de, $606D                                ; $6179: $11 $6D $60
-    call label_3BC0                               ; $617C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $617C: $CD $C0 $3B
     call func_006_64C6                            ; $617F: $CD $C6 $64
     call func_006_6230                            ; $6182: $CD $30 $62
     call func_006_657A                            ; $6185: $CD $7A $65
@@ -5759,7 +5759,7 @@ jr_006_620A:
 
 jr_006_621C:
     ld   de, $604D                                ; $621C: $11 $4D $60
-    call label_3BC0                               ; $621F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $621F: $CD $C0 $3B
     call func_006_64C6                            ; $6222: $CD $C6 $64
     ldh  a, [hFrameCounter]                       ; $6225: $F0 $E7
     rra                                           ; $6227: $1F
@@ -6034,7 +6034,7 @@ func_006_6376:
 
 jr_006_63B5:
     ld   de, $638F                                ; $63B5: $11 $8F $63
-    call label_3BC0                               ; $63B8: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $63B8: $CD $C0 $3B
     call GetEntityTransitionCountdown             ; $63BB: $CD $05 $0C
     jr   z, jr_006_63CE                           ; $63BE: $28 $0E
 
@@ -6081,7 +6081,7 @@ jr_006_63DD:
     ld   d, d                                     ; $63FA: $52
     ld   [hl+], a                                 ; $63FB: $22
     ld   de, $63F4                                ; $63FC: $11 $F4 $63
-    call label_3BC0                               ; $63FF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $63FF: $CD $C0 $3B
     call func_006_64C6                            ; $6402: $CD $C6 $64
     call label_C56                                ; $6405: $CD $56 $0C
     call label_3B70                               ; $6408: $CD $70 $3B
@@ -6478,7 +6478,7 @@ label_006_65DB:
     and  $10                                      ; $65F5: $E6 $10
     ldh  [$FFED], a                               ; $65F7: $E0 $ED
     ld   de, $65E1                                ; $65F9: $11 $E1 $65
-    call label_3BC0                               ; $65FC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $65FC: $CD $C0 $3B
     call func_006_64C6                            ; $65FF: $CD $C6 $64
     call label_3B4F                               ; $6602: $CD $4F $3B
     call func_006_6541                            ; $6605: $CD $41 $65
@@ -6518,7 +6518,7 @@ label_006_65DB:
     and  $01                                      ; $663C: $E6 $01
     ldh  [hActiveEntityUnknownG], a               ; $663E: $E0 $F1
     ld   de, $6615                                ; $6640: $11 $15 $66
-    call label_3BC0                               ; $6643: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6643: $CD $C0 $3B
     call func_006_64C6                            ; $6646: $CD $C6 $64
     call func_006_64F7                            ; $6649: $CD $F7 $64
     call label_3B44                               ; $664C: $CD $44 $3B
@@ -6692,7 +6692,7 @@ jr_006_6719:
     ld   de, $6710                                ; $6739: $11 $10 $67
 
 jr_006_673C:
-    call label_3BC0                               ; $673C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $673C: $CD $C0 $3B
     call func_006_64C6                            ; $673F: $CD $C6 $64
     call func_006_64F7                            ; $6742: $CD $F7 $64
     call label_3B39                               ; $6745: $CD $39 $3B
@@ -7223,7 +7223,7 @@ jr_006_6A36:
     jr   nc, jr_006_6A5B                          ; $6A53: $30 $06
 
     ld   de, $6A37                                ; $6A55: $11 $37 $6A
-    jp   label_3BC0                               ; $6A58: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $6A58: $C3 $C0 $3B
 
 jr_006_6A5B:
     ld   hl, $6A3F                                ; $6A5B: $21 $3F $6A
@@ -7251,7 +7251,7 @@ jr_006_6A71:
     sub  $05                                      ; $6A7E: $D6 $05
     ldh  [wActiveEntityPosY], a                   ; $6A80: $E0 $EC
     ld   de, $6A78                                ; $6A82: $11 $78 $6A
-    call label_3BC0                               ; $6A85: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6A85: $CD $C0 $3B
     call func_006_64C6                            ; $6A88: $CD $C6 $64
     call func_006_645D                            ; $6A8B: $CD $5D $64
     ret  nc                                       ; $6A8E: $D0
@@ -8201,7 +8201,7 @@ jr_006_6FDA:
 
 jr_006_6FEE:
     ld   de, $6ED5                                ; $6FEE: $11 $D5 $6E
-    call label_3BC0                               ; $6FF1: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $6FF1: $CD $C0 $3B
     ldh  a, [wActiveEntityPosY]                   ; $6FF4: $F0 $EC
     add  $10                                      ; $6FF6: $C6 $10
     ldh  [wActiveEntityPosY], a                   ; $6FF8: $E0 $EC
@@ -8607,7 +8607,7 @@ jr_006_725A:
     ld   de, $7224                                ; $7263: $11 $24 $72
 
 jr_006_7266:
-    call label_3BC0                               ; $7266: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7266: $CD $C0 $3B
     call func_006_64C6                            ; $7269: $CD $C6 $64
     ld   a, [wIsIndoor]                           ; $726C: $FA $A5 $DB
     and  a                                        ; $726F: $A7
@@ -8818,7 +8818,7 @@ label_006_7372:
 
 jr_006_73AD:
     ld   de, $7373                                ; $73AD: $11 $73 $73
-    call label_3BC0                               ; $73B0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $73B0: $CD $C0 $3B
     call func_006_64C6                            ; $73B3: $CD $C6 $64
     call func_006_64F7                            ; $73B6: $CD $F7 $64
     call func_006_6541                            ; $73B9: $CD $41 $65
@@ -8916,7 +8916,7 @@ jr_006_741F:
     ld   h, [hl]                                  ; $744C: $66
     rlca                                          ; $744D: $07
     ld   de, $7446                                ; $744E: $11 $46 $74
-    call label_3BC0                               ; $7451: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7451: $CD $C0 $3B
     call func_006_64C6                            ; $7454: $CD $C6 $64
     call func_006_64F7                            ; $7457: $CD $F7 $64
     xor  a                                        ; $745A: $AF
@@ -9045,7 +9045,7 @@ jr_006_74EF:
 
     ld   bc, $BEE0                                ; $7511: $01 $E0 $BE
     ld   de, $74FA                                ; $7514: $11 $FA $74
-    call label_3BC0                               ; $7517: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7517: $CD $C0 $3B
     call func_006_64C6                            ; $751A: $CD $C6 $64
     call label_C56                                ; $751D: $CD $56 $0C
     call label_3B39                               ; $7520: $CD $39 $3B
@@ -9228,7 +9228,7 @@ jr_006_75B5:
     nop                                           ; $7625: $00
     ldh  [rNR41], a                               ; $7626: $E0 $20
     ld   de, $7604                                ; $7628: $11 $04 $76
-    call label_3BC0                               ; $762B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $762B: $CD $C0 $3B
     call func_006_64C6                            ; $762E: $CD $C6 $64
     call func_006_64F7                            ; $7631: $CD $F7 $64
     call func_006_6541                            ; $7634: $CD $41 $65
@@ -9713,7 +9713,7 @@ jr_006_783F:
     ld   e, d                                     ; $7874: $5A
     inc  [hl]                                     ; $7875: $34
     ld   de, $786E                                ; $7876: $11 $6E $78
-    call label_3BC0                               ; $7879: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7879: $CD $C0 $3B
     call func_006_64C6                            ; $787C: $CD $C6 $64
 
 jr_006_787F:
@@ -9772,7 +9772,7 @@ jr_006_78AD:
     db   $10                                      ; $78C4: $10
     ldh  a, [hActiveEntityWalking]                ; $78C5: $F0 $F0
     ld   de, $78B7                                ; $78C7: $11 $B7 $78
-    call label_3BC0                               ; $78CA: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $78CA: $CD $C0 $3B
 
 jr_006_78CD:
     call func_006_64C6                            ; $78CD: $CD $C6 $64
@@ -9930,7 +9930,7 @@ jr_006_7982:
     ld   l, [hl]                                  ; $79A7: $6E
     nop                                           ; $79A8: $00
     ld   de, $7989                                ; $79A9: $11 $89 $79
-    call label_3BC0                               ; $79AC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $79AC: $CD $C0 $3B
     call func_006_64C6                            ; $79AF: $CD $C6 $64
     call func_006_64F7                            ; $79B2: $CD $F7 $64
     call func_006_6541                            ; $79B5: $CD $41 $65
@@ -10235,7 +10235,7 @@ jr_006_7B3D:
     jr   nz, jr_006_7B5B                          ; $7B51: $20 $08
 
     ld   de, $7AD3                                ; $7B53: $11 $D3 $7A
-    call label_3BC0                               ; $7B56: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7B56: $CD $C0 $3B
     jr   jr_006_7B61                              ; $7B59: $18 $06
 
 jr_006_7B5B:
@@ -10393,7 +10393,7 @@ jr_006_7BF0:
     ld   de, $7C11                                ; $7C28: $11 $11 $7C
 
 jr_006_7C2B:
-    call label_3BC0                               ; $7C2B: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7C2B: $CD $C0 $3B
 
 jr_006_7C2E:
     ld   hl, $C1AE                                ; $7C2E: $21 $AE $C1
@@ -10679,7 +10679,7 @@ jr_006_7DD3:
     ld   a, [hl]                                  ; $7DD8: $7E
     ld   bc, $217E                                ; $7DD9: $01 $7E $21
     ld   de, $7DD4                                ; $7DDC: $11 $D4 $7D
-    call label_3BC0                               ; $7DDF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7DDF: $CD $C0 $3B
     call func_006_64C6                            ; $7DE2: $CD $C6 $64
     call func_006_64F7                            ; $7DE5: $CD $F7 $64
     ld   hl, wEntitiesUnknownTableD               ; $7DE8: $21 $D0 $C2
@@ -10804,7 +10804,7 @@ jr_006_7E55:
     ld   de, $7E77                                ; $7E8E: $11 $77 $7E
 
 jr_006_7E91:
-    call label_3BC0                               ; $7E91: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7E91: $CD $C0 $3B
     call func_006_64C6                            ; $7E94: $CD $C6 $64
     call label_C56                                ; $7E97: $CD $56 $0C
     call label_3B39                               ; $7E9A: $CD $39 $3B

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -84,7 +84,7 @@ jr_007_4053:
     ld   de, $401A                                ; $406C: $11 $1A $40
 
 jr_007_406F:
-    call label_3BC0                               ; $406F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $406F: $CD $C0 $3B
     call label_3D8A                               ; $4072: $CD $8A $3D
     ld   hl, wEntitiesUnknownTableC               ; $4075: $21 $C0 $C2
     add  hl, bc                                   ; $4078: $09
@@ -97,7 +97,7 @@ jr_007_406F:
     ld   a, [hl]                                  ; $4081: $7E
     ldh  [hActiveEntityUnknownG], a               ; $4082: $E0 $F1
     ld   de, $400A                                ; $4084: $11 $0A $40
-    call label_3BC0                               ; $4087: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4087: $CD $C0 $3B
 
 jr_007_408A:
     call func_007_7D96                            ; $408A: $CD $96 $7D
@@ -322,7 +322,7 @@ jr_007_41C8:
 
 label_007_41F0:
     ld   de, $400A                                ; $41F0: $11 $0A $40
-    call label_3BC0                               ; $41F3: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $41F3: $CD $C0 $3B
     call func_007_7D96                            ; $41F6: $CD $96 $7D
     call func_007_7DC3                            ; $41F9: $CD $C3 $7D
     ldh  a, [hFrameCounter]                       ; $41FC: $F0 $E7
@@ -1175,7 +1175,7 @@ jr_007_46E6:
 
 jr_007_4702:
     ld   de, $4683                                ; $4702: $11 $83 $46
-    call label_3BC0                               ; $4705: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4705: $CD $C0 $3B
     call label_3D8A                               ; $4708: $CD $8A $3D
 
 jr_007_470B:
@@ -1193,7 +1193,7 @@ jr_007_4715:
     xor  a                                        ; $471B: $AF
     ldh  [hActiveEntityUnknownG], a               ; $471C: $E0 $F1
     ld   de, $4693                                ; $471E: $11 $93 $46
-    call label_3BC0                               ; $4721: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4721: $CD $C0 $3B
     call label_3D8A                               ; $4724: $CD $8A $3D
 
 jr_007_4727:
@@ -1701,7 +1701,7 @@ jr_007_4A30:
     ld   de, $49EF                                ; $4A40: $11 $EF $49
 
 jr_007_4A43:
-    call label_3BC0                               ; $4A43: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4A43: $CD $C0 $3B
     ldh  a, [hFrameCounter]                       ; $4A46: $F0 $E7
     rra                                           ; $4A48: $1F
     rra                                           ; $4A49: $1F
@@ -1739,7 +1739,7 @@ jr_007_4A69:
     ld   de, $4A07                                ; $4A7B: $11 $07 $4A
 
 jr_007_4A7E:
-    call label_3BC0                               ; $4A7E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4A7E: $CD $C0 $3B
     ld   a, [wTradeSequenceItem]                  ; $4A81: $FA $0E $DB
     cp   $08                                      ; $4A84: $FE $08
     jr   nc, jr_007_4AA0                          ; $4A86: $30 $18
@@ -1753,7 +1753,7 @@ jr_007_4A7E:
     xor  a                                        ; $4A94: $AF
     ldh  [hActiveEntityUnknownG], a               ; $4A95: $E0 $F1
     ld   de, $4A17                                ; $4A97: $11 $17 $4A
-    call label_3BC0                               ; $4A9A: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4A9A: $CD $C0 $3B
     call label_3D8A                               ; $4A9D: $CD $8A $3D
 
 jr_007_4AA0:
@@ -1939,11 +1939,11 @@ jr_007_4B44:
     ld   a, $4A                                   ; $4BB8: $3E $4A
     ldh  [wActiveEntityPosY], a                   ; $4BBA: $E0 $EC
     ld   de, $4BAD                                ; $4BBC: $11 $AD $4B
-    call label_3BC0                               ; $4BBF: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4BBF: $CD $C0 $3B
     ld   a, $68                                   ; $4BC2: $3E $68
     ldh  [wActiveEntityPosX], a                   ; $4BC4: $E0 $EE
     ld   de, $4BB1                                ; $4BC6: $11 $B1 $4B
-    call label_3BC0                               ; $4BC9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4BC9: $CD $C0 $3B
     ld   a, [wTradeSequenceItem]                  ; $4BCC: $FA $0E $DB
     cp   $06                                      ; $4BCF: $FE $06
     jr   nz, jr_007_4BE1                          ; $4BD1: $20 $0E
@@ -2096,7 +2096,7 @@ label_007_4C83:
 
 jr_007_4CB6:
     ld   de, $4C93                                ; $4CB6: $11 $93 $4C
-    call label_3BC0                               ; $4CB9: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4CB9: $CD $C0 $3B
     call func_007_7D96                            ; $4CBC: $CD $96 $7D
     ldh  a, [hActiveEntityWalking]                ; $4CBF: $F0 $F0
     rst  $00                                      ; $4CC1: $C7
@@ -2473,7 +2473,7 @@ jr_007_4EC5:
     jp   z, label_007_7EA4                        ; $4ECA: $CA $A4 $7E
 
     ld   de, $4E8D                                ; $4ECD: $11 $8D $4E
-    call label_3BC0                               ; $4ED0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4ED0: $CD $C0 $3B
     call func_007_7D96                            ; $4ED3: $CD $96 $7D
     call func_007_7E43                            ; $4ED6: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                                ; $4ED9: $21 $20 $C3
@@ -2568,7 +2568,7 @@ jr_007_4F4D:
     sub  $10                                      ; $4F69: $D6 $10
     ldh  [wActiveEntityPosY], a                   ; $4F6B: $E0 $EC
     ld   de, $4F4E                                ; $4F6D: $11 $4E $4F
-    call label_3BC0                               ; $4F70: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4F70: $CD $C0 $3B
     call label_3D8A                               ; $4F73: $CD $8A $3D
     ld   a, $08                                   ; $4F76: $3E $08
     jp   label_3B0C                               ; $4F78: $C3 $0C $3B
@@ -2602,7 +2602,7 @@ jr_007_4FA5:
     sub  $0C                                      ; $4FAB: $D6 $0C
     ldh  [wActiveEntityPosX], a                   ; $4FAD: $E0 $EE
     ld   de, $4F4E                                ; $4FAF: $11 $4E $4F
-    call label_3BC0                               ; $4FB2: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $4FB2: $CD $C0 $3B
     call label_3D8A                               ; $4FB5: $CD $8A $3D
     call GetEntityTransitionCountdown                 ; $4FB8: $CD $05 $0C
     rra                                           ; $4FBB: $1F
@@ -2673,7 +2673,7 @@ jr_007_5012:
 
 jr_007_501B:
     ld   de, $4F4E                                ; $501B: $11 $4E $4F
-    call label_3BC0                               ; $501E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $501E: $CD $C0 $3B
     call label_3D8A                               ; $5021: $CD $8A $3D
     call GetEntityTransitionCountdown                 ; $5024: $CD $05 $0C
     ld   e, $02                                   ; $5027: $1E $02
@@ -2840,7 +2840,7 @@ jr_007_50DF:
     ld   b, d                                     ; $510A: $42
     ld   [hl+], a                                 ; $510B: $22
     ld   de, $5104                                ; $510C: $11 $04 $51
-    call label_3BC0                               ; $510F: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $510F: $CD $C0 $3B
     call func_007_7D96                            ; $5112: $CD $96 $7D
     ldh  a, [hFrameCounter]                       ; $5115: $F0 $E7
     rra                                           ; $5117: $1F
@@ -3418,7 +3418,7 @@ jr_007_541F:
 
 func_007_5453:
     ld   de, $542B                                ; $5453: $11 $2B $54
-    call label_3BC0                               ; $5456: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5456: $CD $C0 $3B
     ldh  a, [hActiveEntityWalking]                ; $5459: $F0 $F0
     cp   $03                                      ; $545B: $FE $03
     ret  c                                        ; $545D: $D8
@@ -3628,7 +3628,7 @@ jr_007_556F:
     ld   de, $54D0                                ; $556F: $11 $D0 $54
 
 jr_007_5572:
-    call label_3BC0                               ; $5572: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5572: $CD $C0 $3B
     call GetEntityTransitionCountdown                 ; $5575: $CD $05 $0C
     jr   nz, jr_007_559A                          ; $5578: $20 $20
 
@@ -3784,7 +3784,7 @@ jr_007_5622:
     ld   e, b                                     ; $564B: $58
     ld   [hl+], a                                 ; $564C: $22
     ld   de, $562D                                ; $564D: $11 $2D $56
-    call label_3BC0                               ; $5650: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5650: $CD $C0 $3B
     call $5805                                    ; $5653: $CD $05 $58
     call func_007_7D96                            ; $5656: $CD $96 $7D
     ld   hl, $C410                                ; $5659: $21 $10 $C4
@@ -4146,7 +4146,7 @@ jr_007_5827:
     ld   de, $582E                                ; $5854: $11 $2E $58
 
 jr_007_5857:
-    call label_3BC0                               ; $5857: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5857: $CD $C0 $3B
     ld   hl, $C480                                ; $585A: $21 $80 $C4
     add  hl, bc                                   ; $585D: $09
     ld   a, [hl]                                  ; $585E: $7E
@@ -4159,7 +4159,7 @@ jr_007_5857:
     sub  $0E                                      ; $5867: $D6 $0E
     ldh  [wActiveEntityPosY], a                   ; $5869: $E0 $EC
     ld   de, $594D                                ; $586B: $11 $4D $59
-    call label_3BC0                               ; $586E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $586E: $CD $C0 $3B
     call label_3D8A                               ; $5871: $CD $8A $3D
 
 jr_007_5874:
@@ -4770,7 +4770,7 @@ jr_007_5BE8:
 
     pop  af                                       ; $5BFA: $F1
     ld   e, e                                     ; $5BFB: $5B
-    call label_3BC0                               ; $5BFC: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5BFC: $CD $C0 $3B
     call func_007_7D96                            ; $5BFF: $CD $96 $7D
     call func_007_7DC3                            ; $5C02: $CD $C3 $7D
     call label_3B39                               ; $5C05: $CD $39 $3B
@@ -5402,7 +5402,7 @@ jr_007_5F44:
 
 label_007_5F4D:
     ld   de, $5F45                                ; $5F4D: $11 $45 $5F
-    call label_3BC0                               ; $5F50: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $5F50: $CD $C0 $3B
     call GetEntityTransitionCountdown                 ; $5F53: $CD $05 $0C
     jp   z, label_007_7EA4                        ; $5F56: $CA $A4 $7E
 
@@ -5536,16 +5536,16 @@ jr_007_6019:
     ld   hl, $C3E0                                ; $601B: $21 $E0 $C3
     add  hl, bc                                   ; $601E: $09
     ld   [hl], a                                  ; $601F: $77
-    ld   hl, $C220                                ; $6020: $21 $20 $C2
+    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $6020: $21 $20 $C2
     add  hl, bc                                   ; $6023: $09
     ld   [hl], b                                  ; $6024: $70
-    ld   hl, $C230                                ; $6025: $21 $30 $C2
+    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $6025: $21 $30 $C2
     add  hl, bc                                   ; $6028: $09
     ld   [hl], b                                  ; $6029: $70
 
 jr_007_602A:
     ld   de, $6003                                ; $602A: $11 $03 $60
-    call label_3BC0                               ; $602D: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $602D: $CD $C0 $3B
     ld   a, [wRoomTransitionState]                ; $6030: $FA $24 $C1
     and  a                                        ; $6033: $A7
     ret  nz                                       ; $6034: $C0
@@ -5836,7 +5836,7 @@ jr_007_61CD:
     ld   d, b                                     ; $61D0: $50
     daa                                           ; $61D1: $27
     ld   de, $61CE                                ; $61D2: $11 $CE $61
-    call label_3BC0                               ; $61D5: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $61D5: $CD $C0 $3B
     call func_007_7D96                            ; $61D8: $CD $96 $7D
     call func_007_639E                            ; $61DB: $CD $9E $63
     ld   hl, wEntitiesUnknownTableD               ; $61DE: $21 $D0 $C2
@@ -6572,7 +6572,7 @@ jr_007_65CB:
     jp   nz, $6523                                ; $65E0: $C2 $23 $65
 
     ld   de, $65CE                                ; $65E3: $11 $CE $65
-    call label_3BC0                               ; $65E6: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $65E6: $CD $C0 $3B
     call func_007_7D96                            ; $65E9: $CD $96 $7D
     call func_007_7DC3                            ; $65EC: $CD $C3 $7D
     ldh  a, [hIsSideScrolling]                    ; $65EF: $F0 $F9
@@ -6769,7 +6769,7 @@ func_007_66FE:
     ld   b, d                                     ; $6707: $42
     ld   [hl+], a                                 ; $6708: $22
     ld   de, $6701                                ; $6709: $11 $01 $67
-    call label_3BC0                               ; $670C: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $670C: $CD $C0 $3B
     call func_007_7D96                            ; $670F: $CD $96 $7D
     call func_007_7DC3                            ; $6712: $CD $C3 $7D
     call label_3B39                               ; $6715: $CD $39 $3B
@@ -7016,7 +7016,7 @@ jr_007_683D:
     add  [hl]                                     ; $6854: $86
     ldh  [hActiveEntityUnknownG], a               ; $6855: $E0 $F1
     ld   de, $683E                                ; $6857: $11 $3E $68
-    call label_3BC0                               ; $685A: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $685A: $CD $C0 $3B
     call func_007_7D96                            ; $685D: $CD $96 $7D
     call func_007_7DC3                            ; $6860: $CD $C3 $7D
     call label_3B39                               ; $6863: $CD $39 $3B
@@ -8396,7 +8396,7 @@ func_007_703A:
     ld   a, $06                                   ; $705F: $3E $06
     ld   [$D5C3], a                               ; $7061: $EA $C3 $D5
     ld   de, $6F15                                ; $7064: $11 $15 $6F
-    call label_3BC0                               ; $7067: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7067: $CD $C0 $3B
     ld   a, $02                                   ; $706A: $3E $02
     jp   label_007_7034                           ; $706C: $C3 $34 $70
 
@@ -8724,7 +8724,7 @@ jr_007_7246:
     ld   a, h                                     ; $7257: $7C
     ld   bc, $017C                                ; $7258: $01 $7C $01
     ld   de, $7247                                ; $725B: $11 $47 $72
-    call label_3BC0                               ; $725E: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $725E: $CD $C0 $3B
     call func_007_7D96                            ; $7261: $CD $96 $7D
     call func_007_7DC3                            ; $7264: $CD $C3 $7D
     call label_3B39                               ; $7267: $CD $39 $3B
@@ -8796,7 +8796,7 @@ jr_007_7291:
 
 jr_007_72BD:
     ld   de, $729B                                ; $72BD: $11 $9B $72
-    call label_3BC0                               ; $72C0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $72C0: $CD $C0 $3B
 
 jr_007_72C3:
     call func_007_7D96                            ; $72C3: $CD $96 $7D
@@ -9239,7 +9239,7 @@ jr_007_752C:
 
     dec  l                                        ; $7536: $2D
     ld   [hl], l                                  ; $7537: $75
-    call label_3BC0                               ; $7538: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7538: $CD $C0 $3B
     call func_007_7D96                            ; $753B: $CD $96 $7D
     call func_007_7DC3                            ; $753E: $CD $C3 $7D
     ldh  a, [hFrameCounter]                       ; $7541: $F0 $E7
@@ -9388,7 +9388,7 @@ jr_007_75DD:
 
 jr_007_75FE:
     ld   de, $75DE                                ; $75FE: $11 $DE $75
-    call label_3BC0                               ; $7601: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7601: $CD $C0 $3B
     call func_007_7D96                            ; $7604: $CD $96 $7D
     call func_007_7E0A                            ; $7607: $CD $0A $7E
     call func_007_7E43                            ; $760A: $CD $43 $7E
@@ -9694,7 +9694,7 @@ jr_007_7783:
     ld   de, $7794                                ; $77AD: $11 $94 $77
 
 jr_007_77B0:
-    call label_3BC0                               ; $77B0: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $77B0: $CD $C0 $3B
     call func_007_7D96                            ; $77B3: $CD $96 $7D
 
 jr_007_77B6:
@@ -10276,7 +10276,7 @@ jr_007_7AC1:
 
 jr_007_7ACB:
     ld   de, $7A95                                ; $7ACB: $11 $95 $7A
-    call label_3BC0                               ; $7ACE: $CD $C0 $3B
+    call RenderAnimatedActiveEntity                               ; $7ACE: $CD $C0 $3B
 
 jr_007_7AD1:
     push bc                                       ; $7AD1: $C5
@@ -10332,7 +10332,7 @@ jr_007_7AD1:
     ret  z                                        ; $7B29: $C8
 
     ld   de, $7A95                                ; $7B2A: $11 $95 $7A
-    jp   label_3BC0                               ; $7B2D: $C3 $C0 $3B
+    jp   RenderAnimatedActiveEntity                               ; $7B2D: $C3 $C0 $3B
 
 func_007_7B30:
     xor  $01                                      ; $7B30: $EE $01

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -10259,7 +10259,7 @@ jr_007_7A6C:
     inc  hl                                       ; $7AB4: $23
 
 func_007_7AB5:
-    call AdjustEntityPositionDuringRoomTransition ; $7AB5: $CD $57 $3D
+    call SkipDisabledEntityDuringRoomTransition ; $7AB5: $CD $57 $3D
     ldh  a, [hActiveEntityUnknownG]               ; $7AB8: $F0 $F1
     cp   $02                                      ; $7ABA: $FE $02
     jr   nc, jr_007_7AC1                          ; $7ABC: $30 $03

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -5536,10 +5536,10 @@ jr_007_6019:
     ld   hl, $C3E0                                ; $601B: $21 $E0 $C3
     add  hl, bc                                   ; $601E: $09
     ld   [hl], a                                  ; $601F: $77
-    ld   hl, wEntitiesTransitionIntersectingXTable                                ; $6020: $21 $20 $C2
+    ld   hl, wEntitiesPosXSignTable                                ; $6020: $21 $20 $C2
     add  hl, bc                                   ; $6023: $09
     ld   [hl], b                                  ; $6024: $70
-    ld   hl, wEntitiesTransitionIntersectingYTable                                ; $6025: $21 $30 $C2
+    ld   hl, wEntitiesPosYSignTable                                ; $6025: $21 $30 $C2
     add  hl, bc                                   ; $6028: $09
     ld   [hl], b                                  ; $6029: $70
 

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -1078,11 +1078,11 @@ RenderIntroEntities::
     ld   a, [hl]
     ldh  [wActiveEntityPosY], a
 
-    ; $FFF1 = wEntitiesUnknownTableG[c]
+    ; hActiveEntityUnknownG = wEntitiesUnknownTableG[c]
     ld   hl, wEntitiesUnknownTableG
     add  hl, bc
     ld   a, [hl]
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
 
     ; hActiveEntityWalking = wEntitiesWalkingTable[c]
     ld   hl, wEntitiesWalkingTable
@@ -1510,7 +1510,7 @@ label_77ED::
     rra
     rra
     and  $07
-    ldh  [$FFF1], a
+    ldh  [hActiveEntityUnknownG], a
     xor  a
     ld   [$C340], a
     ld   de, label_77BD

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -1274,7 +1274,7 @@ RenderIntroMarin::
     xor  a
     ld   [$C340], a
     ld   de, data_764F
-    call label_3BC0
+    call RenderAnimatedActiveEntity
 
     ld   a, [$C3C0]
     add  a, $08
@@ -1514,7 +1514,7 @@ label_77ED::
     xor  a
     ld   [$C340], a
     ld   de, label_77BD
-    call label_3BC0
+    call RenderAnimatedActiveEntity
     ld   a, [$C3C0]
     add  a, $08
     ld   [$C3C0], a
@@ -1812,7 +1812,7 @@ RenderIntroInertLink::
 label_7A36::
     ld   [$C340], a
     ld   de, data_7A27
-    call label_3BC0
+    call RenderAnimatedActiveEntity
     ld   a, [$C3C0]
     add  a, $08
     ld   [$C3C0], a

--- a/src/constants/hram.asm
+++ b/src/constants/hram.asm
@@ -202,8 +202,17 @@ hScratchF          ; FFE1
 hBGMapOffsetLow::  ; FFE1
   ds 1
 
-; Unlabeled
-ds 4
+hScratchG:: ; FFE2
+  ds 1
+
+hScratchH:: ; FFE3
+  ds 1
+
+hScratchI:: ; FFE4
+  ds 1
+
+hScratchJ:: ; FFE5
+  ds 1
 
 hFreeWarpDataAddress ; FFE6
   ; Address of the first free warp data slot

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -370,12 +370,16 @@ wEntityDPosY:: ds 1 ; C21D
 wEntityEPosY:: ds 1 ; C21E
 wEntityFPosY:: ds 1 ; C21F
 
-; Unlabeled entity attributes table
-wC220 equ $C220
+wEntitiesTransitionIntersectingXTable:: ; C220
+  ; Value attributed to entities during room transition
+  ; The purpose is not entirely clear yet.
+  ; If the value is != 0, the entity rendering is skipped.
   ds $10
 
-; Unlabeled entity attributes table
-wC230 equ $C230
+wEntitiesTransitionIntersectingYTable:: ; C230
+  ; Value attributed to entities during room transition
+  ; The purpose is not entirely clear yet.
+  ; If the value is != 0, the entity rendering is skipped.
   ds $10
 
 wEntitiesSpeedXTable:: ; C240
@@ -502,7 +506,12 @@ wEntitiesTypeTable:: ; C3A0
 wEntitiesUnknownTableG:: ; C3B0
   ; Entity custom state?
 
-ds $1B
+; Unlabeled
+wC3C0 equ $C3C0
+  ds 1
+
+; Unlabeled
+ds $1A
 
 wObjectAffectingBGPalette:: ; C3CB
   ; Type of the object affecting the background palette

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -532,8 +532,11 @@ wDroppedItemsCountdown:: ; C458
   ; Number of frame before a dropped item disappears
   ds 8
 
+wEntitiesLoadOrderTable:: ; C460
+  ds $10
+
 ; Unlabeled
-ds $A0
+ds $90
 
 wAlternateBackgroundEnabled:: ; C500
   ; If enabled, alternate between two Background position every frame.

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -370,16 +370,16 @@ wEntityDPosY:: ds 1 ; C21D
 wEntityEPosY:: ds 1 ; C21E
 wEntityFPosY:: ds 1 ; C21F
 
-wEntitiesTransitionIntersectingXTable:: ; C220
-  ; Value attributed to entities during room transition
-  ; The purpose is not entirely clear yet.
-  ; If the value is != 0, the entity rendering is skipped.
+wEntitiesPosXSignTable:: ; C220
+  ; Controls the sign of the X position
+  ; 00:  position is positive
+  ; FF:  position is negative
   ds $10
 
-wEntitiesTransitionIntersectingYTable:: ; C230
-  ; Value attributed to entities during room transition
-  ; The purpose is not entirely clear yet.
-  ; If the value is != 0, the entity rendering is skipped.
+wEntitiesPosYSignTable:: ; C230
+  ; Controls the sign of the Y position
+  ; 00:  position is positive
+  ; FF:  position is negative
   ds $10
 
 wEntitiesSpeedXTable:: ; C240


### PR DESCRIPTION
- Document `RenderAnimatedActiveEntity`, which converts an entity data into values for the OAM;
- Document `PrepareEntityPositionForRoomTransition`, which sets the initial coordinates of an entity about to be displayed;
- Document `UpdateEntityPositionForRoomTransition`, which updates the entity coordinates during a room transition.

I'm glad to have more documentation for the entities tables, for instance for `wEntityPosXSignTable` and `wEntityPosYSignTable`.