### PR TITLE
Labeled several functions, fixed typo

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -823,14 +823,14 @@ label_C9E::
     and  a
     ret
 
-label_CAF::
+ResetSpinAttack::
     xor  a
     ld   [wIsUsingSpinAttack], a
     ld   [wSwordCharge], a
 
-label_CB6::
+ResetPegasusBoots::
     xor  a
-    ld   [wPegagusBootsChargeMeter], a
+    ld   [wPegasusBootsChargeMeter], a
     ld   [wIsRunningWithPegasusBoots], a
     ret
 
@@ -1618,7 +1618,7 @@ LinkMotionInteractiveHandler::
     jr   nz, label_11BA
 
 label_11A5::
-    call func_1340
+    call SetShieldVals
     jr   label_11BA
 
 label_11AA::
@@ -1671,7 +1671,7 @@ label_11E8::
 
 label_11FA::
     xor  a
-    ld   [wPegagusBootsChargeMeter], a
+    ld   [wPegasusBootsChargeMeter], a
 
 label_11FE::
     ld   a, [wBButtonSlot]
@@ -1687,7 +1687,7 @@ label_120E::
 
 label_1210::
     xor  a
-    ld   [wPegagusBootsChargeMeter], a
+    ld   [wPegasusBootsChargeMeter], a
 
 label_1214::
     ld   a, [wBButtonSlot]
@@ -1703,7 +1703,7 @@ label_1214::
     jr   z, label_1235
     cp   $02
     jr   z, label_1235
-    call func_1340
+    call SetShieldVals
 
 label_1235::
     ld   a, [wAButtonSlot]
@@ -1714,7 +1714,7 @@ label_1235::
     ldh  a, [hPressedButtonsMask]
     and  $20
     jr   z, label_124B
-    call func_1340
+    call SetShieldVals
 
 label_124B::
     ldh  a, [$FFCC]
@@ -1854,7 +1854,7 @@ label_1321::
     ld   [$C5B0], a
     ret
 
-func_1340::
+SetShieldVals::
     ld   a, $01
     ld   [wIsUsingShield], a
     ld   a, [wShieldLevel]
@@ -2170,7 +2170,7 @@ label_1535::
     ld   a, [$C146]
     and  a
     jr   nz, label_1562
-    call label_CAF
+    call ResetSpinAttack
     call ClearLinkPositionIncrement
 
 label_1562::
@@ -2469,9 +2469,9 @@ label_1713::
     add  a, $02
     ld   [$C120], a
     call label_1756
-    ld   a, [wPegagusBootsChargeMeter]
+    ld   a, [wPegasusBootsChargeMeter]
     inc  a
-    ld   [wPegagusBootsChargeMeter], a
+    ld   [wPegasusBootsChargeMeter], a
     cp   $20
     ret  nz
     ld   [wIsRunningWithPegasusBoots], a

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -393,7 +393,7 @@ jr_002_43F4:
     ld   a, [$C199]                               ; $43F7: $FA $99 $C1
     add  $0C                                      ; $43FA: $C6 $0C
     ld   [$C199], a                               ; $43FC: $EA $99 $C1
-    call label_CAF                                ; $43FF: $CD $AF $0C
+    call ResetSpinAttack                                ; $43FF: $CD $AF $0C
 
 jr_002_4402:
     ld   a, [$C146]                               ; $4402: $FA $46 $C1
@@ -459,7 +459,7 @@ jr_002_4457:
     jr   label_002_4464                           ; $4457: $18 $0B
 
 jr_002_4459:
-    ld   a, [wPegagusBootsChargeMeter]                               ; $4459: $FA $4B $C1
+    ld   a, [wPegasusBootsChargeMeter]                               ; $4459: $FA $4B $C1
     and  a                                        ; $445C: $A7
     jr   nz, label_002_4464                       ; $445D: $20 $05
 
@@ -577,7 +577,7 @@ jr_002_44E3:
     jp   nz, label_002_45AC                       ; $44F7: $C2 $AC $45
 
 func_002_44FA::
-    call $21E1                                    ; $44FA: $CD $E1 $21
+    call func_21E1                                ; $44FA: $CD $E1 $21
     ldh  a, [$FFA3]                               ; $44FD: $F0 $A3
     sub  $02                                      ; $44FF: $D6 $02
     ldh  [$FFA3], a                               ; $4501: $E0 $A3
@@ -659,7 +659,7 @@ jr_002_4563:
     jr   z, label_002_45AC                        ; $456A: $28 $40
 
 jr_002_456C:
-    call label_CB6                                ; $456C: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $456C: $CD $B6 $0C
     ldh  [$FFA2], a                               ; $456F: $E0 $A2
     ld   [$C149], a                               ; $4571: $EA $49 $C1
     ldh  [$FFA3], a                               ; $4574: $E0 $A3
@@ -1200,7 +1200,7 @@ jr_002_4A7A:
 
 jr_002_4A7C:
     call ClearLinkPositionIncrement               ; $4A7C: $CD $8E $17
-    call label_CAF                                ; $4A7F: $CD $AF $0C
+    call ResetSpinAttack                                ; $4A7F: $CD $AF $0C
     ld   hl, wLinkPlayingOcarinaCountdown                                ; $4A82: $21 $66 $C1
     dec  [hl]                                     ; $4A85: $35
     jr   nz, jr_002_4AD1                          ; $4A86: $20 $49
@@ -2060,7 +2060,7 @@ jr_002_4EEF:
     ret                                           ; $4F3B: $C9
 
 jr_002_4F3C:
-    call label_CAF                                ; $4F3C: $CD $AF $0C
+    call ResetSpinAttack                                ; $4F3C: $CD $AF $0C
     ldh  [$FFA2], a                               ; $4F3F: $E0 $A2
     ld   [$C146], a                               ; $4F41: $EA $46 $C1
     ld   [$C19B], a                               ; $4F44: $EA $9B $C1
@@ -2309,7 +2309,7 @@ jr_002_50A2:
     ld   a, $01                                   ; $50A3: $3E $01
     ldh  [$FFA1], a                               ; $50A5: $E0 $A1
     call UpdateFinalLinkPosition                  ; $50A7: $CD $A8 $21
-    call $21E1                                    ; $50AA: $CD $E1 $21
+    call func_21E1                                ; $50AA: $CD $E1 $21
     ldh  a, [hLinkPositionX]                      ; $50AD: $F0 $98
     and  $F0                                      ; $50AF: $E6 $F0
     cp   $E0                                      ; $50B1: $FE $E0
@@ -2495,12 +2495,12 @@ HandleGotItemA::
     ldh  [hJingle], a                             ; $51C5: $E0 $F2
 
 HandleGotItemB::
-    call label_CAF                                ; $51C7: $CD $AF $0C
+    call ResetSpinAttack                                ; $51C7: $CD $AF $0C
     ld   [wC16A], a                               ; $51CA: $EA $6A $C1
     ld   [wSwordAnimationState], a                               ; $51CD: $EA $37 $C1
     ld   [$C13E], a                               ; $51D0: $EA $3E $C1
     call ApplyLinkMotionState                               ; $51D3: $CD $94 $17
-    call $21E1                                    ; $51D6: $CD $E1 $21
+    call func_21E1                                ; $51D6: $CD $E1 $21
     ldh  a, [$FFA3]                               ; $51D9: $F0 $A3
     sub  $02                                      ; $51DB: $D6 $02
     ldh  [$FFA3], a                               ; $51DD: $E0 $A3
@@ -2604,7 +2604,7 @@ jr_002_524F:
     ldh  [hScratchC], a                               ; $5262: $E0 $D9
     jp   label_1819                               ; $5264: $C3 $19 $18
 
-    call label_CAF                                ; $5267: $CD $AF $0C
+    call ResetSpinAttack                                ; $5267: $CD $AF $0C
     call ClearLinkPositionIncrement               ; $526A: $CD $8E $17
     ldh  a, [$FFB7]                               ; $526D: $F0 $B7
     and  a                                        ; $526F: $A7
@@ -5890,7 +5890,7 @@ jr_002_692B:
 
     ld   hl, hLinkDirection                                ; $6932: $21 $9E $FF
     res  1, [hl]                                  ; $6935: $CB $8E
-    call label_CB6                                ; $6937: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6937: $CD $B6 $0C
     ld   [$C146], a                               ; $693A: $EA $46 $C1
     ldh  a, [hFrameCounter]                       ; $693D: $F0 $E7
     and  $01                                      ; $693F: $E6 $01
@@ -5969,7 +5969,7 @@ jr_002_699C:
 jr_002_699E:
     jp   func_002_6B56                            ; $699E: $C3 $56 $6B
 
-    call label_CB6                                ; $69A1: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $69A1: $CD $B6 $0C
     ld   [$C146], a                               ; $69A4: $EA $46 $C1
     ld   [$C153], a                               ; $69A7: $EA $53 $C1
     ld   [$C152], a                               ; $69AA: $EA $52 $C1
@@ -6076,7 +6076,7 @@ jr_002_6A3E:
     ld   a, [$C199]                               ; $6A41: $FA $99 $C1
     add  $0C                                      ; $6A44: $C6 $0C
     ld   [$C199], a                               ; $6A46: $EA $99 $C1
-    call label_CAF                                ; $6A49: $CD $AF $0C
+    call ResetSpinAttack                                ; $6A49: $CD $AF $0C
 
 jr_002_6A4C:
     ld   a, [$C147]                               ; $6A4C: $FA $47 $C1
@@ -6139,7 +6139,7 @@ jr_002_6A94:
 
     ld   a, NOISE_SFX_FOOTSTEP                          ; $6A9A: $3E $07
     ldh  [hNoiseSfx], a                            ; $6A9C: $E0 $F4
-    call label_CB6                                ; $6A9E: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6A9E: $CD $B6 $0C
     ld   [$C146], a                               ; $6AA1: $EA $46 $C1
     ld   [$C152], a                               ; $6AA4: $EA $52 $C1
     ld   [$C153], a                               ; $6AA7: $EA $53 $C1
@@ -6173,7 +6173,7 @@ jr_002_6ACB:
     jr   label_002_6ADB                           ; $6ACF: $18 $0A
 
 jr_002_6AD1:
-    ld   a, [wPegagusBootsChargeMeter]                               ; $6AD1: $FA $4B $C1
+    ld   a, [wPegasusBootsChargeMeter]                               ; $6AD1: $FA $4B $C1
     and  a                                        ; $6AD4: $A7
     jr   nz, label_002_6ADB                       ; $6AD5: $20 $04
 
@@ -6396,7 +6396,7 @@ jr_002_6BF6:
     and  a                                        ; $6C03: $A7
     ret  z                                        ; $6C04: $C8
 
-    call label_CAF                                ; $6C05: $CD $AF $0C
+    call ResetSpinAttack                                ; $6C05: $CD $AF $0C
     ldh  a, [hLinkPositionXIncrement]                               ; $6C08: $F0 $9A
     cpl                                           ; $6C0A: $2F
     inc  a                                        ; $6C0B: $3C
@@ -6785,7 +6785,7 @@ CheckPositionForMapTransition::
 
     ; Clear some state before the transition
     xor  a                                        ; $6DED: $AF
-    ld   [wPegagusBootsChargeMeter], a                               ; $6DEE: $EA $4B $C1
+    ld   [wPegasusBootsChargeMeter], a                               ; $6DEE: $EA $4B $C1
     ld   [wIsUsingSpinAttack], a                  ; $6DF1: $EA $21 $C1
     ld   [wIsRunningWithPegasusBoots], a                               ; $6DF4: $EA $4A $C1
     ld   [$C188], a                               ; $6DF7: $EA $88 $C1
@@ -6907,7 +6907,7 @@ jr_002_6EB5:
     ldh  a, [hLinkPositionY]                      ; $6EBD: $F0 $99
     sub  $08                                      ; $6EBF: $D6 $08
     ldh  [hLinkPositionY], a                      ; $6EC1: $E0 $99
-    jp   label_CB6                                ; $6EC3: $C3 $B6 $0C
+    jp   ResetPegasusBoots                                ; $6EC3: $C3 $B6 $0C
 
 jr_002_6EC6:
     ld   a, [wCollisionType]                               ; $6EC6: $FA $33 $C1
@@ -7236,7 +7236,7 @@ jr_002_7085:
     jp   c, label_002_7277                        ; $70B2: $DA $77 $72
 
 jr_002_70B5:
-    call label_CB6                                ; $70B5: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $70B5: $CD $B6 $0C
     ld   hl, $6E3D                                ; $70B8: $21 $3D $6E
     add  hl, de                                   ; $70BB: $19
     ld   a, [hl]                                  ; $70BC: $7E
@@ -7881,7 +7881,7 @@ jr_002_7472:
     ld   [$C198], a                               ; $7489: $EA $98 $C1
     ldh  [$FFA2], a                               ; $748C: $E0 $A2
     ldh  [$FFA3], a                               ; $748E: $E0 $A3
-    jp   label_CAF                                ; $7490: $C3 $AF $0C
+    jp   ResetSpinAttack                                ; $7490: $C3 $AF $0C
 
 jr_002_7493:
     cp   $C1                                      ; $7493: $FE $C1
@@ -7925,7 +7925,7 @@ label_002_74AD::
     ret  nz                                       ; $74C8: $C0
 
 jr_002_74C9:
-    call label_CAF                                ; $74C9: $CD $AF $0C
+    call ResetSpinAttack                                ; $74C9: $CD $AF $0C
     ldh  a, [hLinkPositionXIncrement]                               ; $74CC: $F0 $9A
     cpl                                           ; $74CE: $2F
     inc  a                                        ; $74CF: $3C
@@ -8128,7 +8128,7 @@ func_002_75F5::
     and  a                                        ; $75F8: $A7
     jr   nz, jr_002_7634                          ; $75F9: $20 $39
 
-    call label_CAF                                ; $75FB: $CD $AF $0C
+    call ResetSpinAttack                                ; $75FB: $CD $AF $0C
     ldh  a, [hLinkPositionXIncrement]                               ; $75FE: $F0 $9A
     cpl                                           ; $7600: $2F
     inc  a                                        ; $7601: $3C
@@ -8181,7 +8181,7 @@ jr_002_7644:
     jr   nz, label_002_76C0                       ; $764A: $20 $74
 
 jr_002_764C:
-    call label_CAF                                ; $764C: $CD $AF $0C
+    call ResetSpinAttack                                ; $764C: $CD $AF $0C
     ld   a, $07                                   ; $764F: $3E $07
     ld   [wLinkGroundStatus], a                               ; $7651: $EA $1F $C1
     ld   hl, $C1BB                                ; $7654: $21 $BB $C1
@@ -8241,7 +8241,7 @@ jr_002_7687:
 label_002_76AA::
     ld   a, LINK_MOTION_FALLING_DOWN              ; $76AA: $3E $06
     ld   [wLinkMotionState], a                    ; $76AC: $EA $1C $C1
-    call label_CAF                                ; $76AF: $CD $AF $0C
+    call ResetSpinAttack                                ; $76AF: $CD $AF $0C
     ld   [$C198], a                               ; $76B2: $EA $98 $C1
     ld   a, [$C181]                               ; $76B5: $FA $81 $C1
     ld   [$DBCB], a                               ; $76B8: $EA $CB $DB

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -253,7 +253,7 @@ jr_015_416F:
     cp   $1C                                      ; $4180: $FE $1C
     jr   nc, jr_015_41C9                          ; $4182: $30 $45
 
-    call label_CB6                                ; $4184: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $4184: $CD $B6 $0C
     call ClearLinkPositionIncrement               ; $4187: $CD $8E $17
     call func_015_7C0A                            ; $418A: $CD $0A $7C
     ld   a, e                                     ; $418D: $7B
@@ -1162,7 +1162,7 @@ jr_015_469C:
     push bc                                       ; $46A7: $C5
     call $0BF0                                    ; $46A8: $CD $F0 $0B
     pop  bc                                       ; $46AB: $C1
-    call label_CAF                                ; $46AC: $CD $AF $0C
+    call ResetSpinAttack                                ; $46AC: $CD $AF $0C
     ld   [wSwordAnimationState], a                ; $46AF: $EA $37 $C1
     ld   [wC16A], a                               ; $46B2: $EA $6A $C1
     ret                                           ; $46B5: $C9
@@ -9779,7 +9779,7 @@ jr_015_7619:
     cpl                                           ; $761B: $2F
     inc  a                                        ; $761C: $3C
     ld   [hl], a                                  ; $761D: $77
-    call label_CAF                                ; $761E: $CD $AF $0C
+    call ResetSpinAttack                                ; $761E: $CD $AF $0C
     ld   a, $10                                   ; $7621: $3E $10
     ld   [$C13E], a                               ; $7623: $EA $3E $C1
     ldh  a, [hLinkDirection]                      ; $7626: $F0 $9E
@@ -10535,7 +10535,7 @@ func_015_7A6E:
 jr_015_7A8D:
     ld   a, [wIsRunningWithPegasusBoots]          ; $7A8D: $FA $4A $C1
     ld   e, a                                     ; $7A90: $5F
-    call label_CB6                                ; $7A91: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7A91: $CD $B6 $0C
     call ClearLinkPositionIncrement               ; $7A94: $CD $8E $17
     ld   a, e                                     ; $7A97: $7B
     scf                                           ; $7A98: $37

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -57,7 +57,7 @@ jr_018_404A:
     ld   a, $4C                                   ; $4050: $3E $4C
     ldh  [hLinkPositionY], a                      ; $4052: $E0 $99
     call ClearLinkPositionIncrement               ; $4054: $CD $8E $17
-    call label_CAF                                ; $4057: $CD $AF $0C
+    call ResetSpinAttack                                ; $4057: $CD $AF $0C
     ld   e, $0B                                   ; $405A: $1E $0B
     ld   hl, wAButtonSlot                         ; $405C: $21 $00 $DB
 
@@ -1640,7 +1640,7 @@ jr_018_4A18:
     ret  nc                                       ; $4A23: $D0
 
     call CopyLinkFinalPositionToPosition          ; $4A24: $CD $BE $0C
-    jp   label_CB6                                ; $4A27: $C3 $B6 $0C
+    jp   ResetPegasusBoots                                ; $4A27: $C3 $B6 $0C
 
 jr_018_4A2A:
     call func_018_7DE8                            ; $4A2A: $CD $E8 $7D
@@ -3336,7 +3336,7 @@ jr_018_5417:
     ldh  [hLinkDirection], a                      ; $5426: $E0 $9E
     ld   a, $01                                   ; $5428: $3E $01
     ldh  [$FFA1], a                               ; $542A: $E0 $A1
-    call label_CAF                                ; $542C: $CD $AF $0C
+    call ResetSpinAttack                                ; $542C: $CD $AF $0C
     ldh  a, [wActiveEntityPosX]                   ; $542F: $F0 $EE
     ldh  [hLinkPositionX], a                      ; $5431: $E0 $98
     ldh  a, [wActiveEntityPosY]                   ; $5433: $F0 $EC
@@ -3579,7 +3579,7 @@ jr_018_558A:
     cp   $40                                      ; $5597: $FE $40
     ret  nc                                       ; $5599: $D0
 
-    call label_CAF                                ; $559A: $CD $AF $0C
+    call ResetSpinAttack                                ; $559A: $CD $AF $0C
     call ClearLinkPositionIncrement               ; $559D: $CD $8E $17
     ld   a, [$C146]                               ; $55A0: $FA $46 $C1
     and  a                                        ; $55A3: $A7
@@ -10252,7 +10252,7 @@ jr_018_7BD1:
     inc  a                                        ; $7BF5: $3C
     ld   [$C1A6], a                               ; $7BF6: $EA $A6 $C1
     xor  a                                        ; $7BF9: $AF
-    call label_CAF                                ; $7BFA: $CD $AF $0C
+    call ResetSpinAttack                                ; $7BFA: $CD $AF $0C
     ld   [$C13E], a                               ; $7BFD: $EA $3E $C1
     ldh  a, [hLinkDirection]                      ; $7C00: $F0 $9E
     ld   e, a                                     ; $7C02: $5F
@@ -10457,7 +10457,7 @@ func_018_7D36:
 
 func_018_7D3B:
     call CopyLinkFinalPositionToPosition          ; $7D3B: $CD $BE $0C
-    call label_CB6                                ; $7D3E: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7D3E: $CD $B6 $0C
     ld   a, [$C1A6]                               ; $7D41: $FA $A6 $C1
     and  a                                        ; $7D44: $A7
     jr   z, jr_018_7D58                           ; $7D45: $28 $11

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -369,7 +369,7 @@ jr_019_4226:
     ld   [wWarp0PositionTileIndex], a             ; $425F: $EA $16 $D4
     ld   a, $06                                   ; $4262: $3E $06
     ld   [wLinkMotionState], a                    ; $4264: $EA $1C $C1
-    call label_CAF                                ; $4267: $CD $AF $0C
+    call ResetSpinAttack                                ; $4267: $CD $AF $0C
     ld   [$C198], a                               ; $426A: $EA $98 $C1
     ld   a, $51                                   ; $426D: $3E $51
     ld   [$DBCB], a                               ; $426F: $EA $CB $DB
@@ -1225,7 +1225,7 @@ jr_019_476A:
     ldh  [hLinkAnimationState], a                 ; $477D: $E0 $9D
     ld   a, $02                                   ; $477F: $3E $02
     ldh  [$FFA1], a                               ; $4781: $E0 $A1
-    call label_CAF                                ; $4783: $CD $AF $0C
+    call ResetSpinAttack                                ; $4783: $CD $AF $0C
     ld   hl, wEntitiesUnknownTableB               ; $4786: $21 $B0 $C2
     add  hl, bc                                   ; $4789: $09
     ld   a, [hl]                                  ; $478A: $7E
@@ -3655,7 +3655,7 @@ jr_019_55A1:
     and  a                                        ; $55B9: $A7
     ret  z                                        ; $55BA: $C8
 
-    call label_CAF                                ; $55BB: $CD $AF $0C
+    call ResetSpinAttack                                ; $55BB: $CD $AF $0C
 
 jr_019_55BE:
     ldh  a, [hLinkPositionXIncrement]             ; $55BE: $F0 $9A
@@ -4326,7 +4326,7 @@ jr_019_598B:
     jp   label_019_7E61                           ; $5998: $C3 $61 $7E
 
 func_019_599B:
-    call label_CB6                                ; $599B: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $599B: $CD $B6 $0C
     ld   a, [$C146]                               ; $599E: $FA $46 $C1
     and  a                                        ; $59A1: $A7
     jr   nz, jr_019_59B7                          ; $59A2: $20 $13
@@ -8862,7 +8862,7 @@ jr_019_7215:
     jr   c, jr_019_7255                           ; $7245: $38 $0E
 
     call ClearLinkPositionIncrement               ; $7247: $CD $8E $17
-    call label_CAF                                ; $724A: $CD $AF $0C
+    call ResetSpinAttack                                ; $724A: $CD $AF $0C
     call IncrementEntityWalkingAttr               ; $724D: $CD $12 $3B
     call GetEntityTransitionCountdown             ; $7250: $CD $05 $0C
     ld   [hl], $58                                ; $7253: $36 $58
@@ -10898,7 +10898,7 @@ label_019_7CA2:
 jr_019_7CC1:
     ld   a, [wIsRunningWithPegasusBoots]          ; $7CC1: $FA $4A $C1
     ld   e, a                                     ; $7CC4: $5F
-    call label_CB6                                ; $7CC5: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7CC5: $CD $B6 $0C
     call ClearLinkPositionIncrement               ; $7CC8: $CD $8E $17
     ld   a, e                                     ; $7CCB: $7B
     scf                                           ; $7CCC: $37

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -4989,7 +4989,7 @@ jr_003_63DB:
     ld   hl, wEntity0State                         ; $63DB: $21 $80 $C2
     add  hl, bc                                   ; $63DE: $09
     ld   [hl], $05                                ; $63DF: $36 $05
-    jp   label_CAF                                ; $63E1: $C3 $AF $0C
+    jp   ResetSpinAttack                                ; $63E1: $C3 $AF $0C
 
     ld   a, $10                                   ; $63E4: $3E $10
     ld   [wWorldMusicTrack], a                    ; $63E6: $EA $68 $D3
@@ -6812,7 +6812,7 @@ jr_003_6DDD:
 func_003_6DDF::
 label_003_6DDF:
 jr_003_6DDF:
-    call label_CB6                                ; $6DDF: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6DDF: $CD $B6 $0C
     ld   a, $10                                   ; $6DE2: $3E $10
     ld   [$C13E], a                               ; $6DE4: $EA $3E $C1
     ldh  a, [hActiveEntityType]                     ; $6DE7: $F0 $EB
@@ -6966,7 +6966,7 @@ jr_003_6E8E:
 
     ld   a, [wIsRunningWithPegasusBoots]          ; $6EAC: $FA $4A $C1
     ldh  [hFFE9], a                               ; $6EAF: $E0 $E9
-    call label_CB6                                ; $6EB1: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6EB1: $CD $B6 $0C
     ldh  a, [hActiveEntityType]                     ; $6EB4: $F0 $EB
     cp   $E2                                      ; $6EB6: $FE $E2
     jr   nz, jr_003_6ED1                          ; $6EB8: $20 $17
@@ -7128,7 +7128,7 @@ func_003_6F93::
 label_003_6F93:
     ld   a, $09                                   ; $6F93: $3E $09
     ldh  [hJingle], a                             ; $6F95: $E0 $F2
-    call label_CB6                                ; $6F97: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6F97: $CD $B6 $0C
     ld   a, $0C                                   ; $6F9A: $3E $0C
     ld   [$C13E], a                               ; $6F9C: $EA $3E $C1
     ldh  a, [hActiveEntityType]                     ; $6F9F: $F0 $EB
@@ -7375,7 +7375,7 @@ jr_003_7102:
     cp   $8E                                      ; $7104: $FE $8E
     jr   nz, jr_003_710D                          ; $7106: $20 $05
 
-    call label_CB6                                ; $7108: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7108: $CD $B6 $0C
     jr   jr_003_714D                              ; $710B: $18 $40
 
 jr_003_710D:
@@ -7399,7 +7399,7 @@ jr_003_710D:
     cp   [hl]                                     ; $7126: $BE
     jr   z, jr_003_714D                           ; $7127: $28 $24
 
-    call label_CB6                                ; $7129: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7129: $CD $B6 $0C
     ld   a, $10                                   ; $712C: $3E $10
     ld   [$C13E], a                               ; $712E: $EA $3E $C1
     ld   a, $10                                   ; $7131: $3E $10
@@ -7957,7 +7957,7 @@ jr_003_7440:
     cp   e                                        ; $7449: $BB
     jp   nc, label_003_74E1                       ; $744A: $D2 $E1 $74
 
-    call label_CB6                                ; $744D: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $744D: $CD $B6 $0C
     ld   a, $08                                   ; $7450: $3E $08
     ld   [$C13E], a                               ; $7452: $EA $3E $C1
     ld   a, $12                                   ; $7455: $3E $12

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -704,7 +704,7 @@ jr_036_4429:
     cp   $78                                      ; $442B: $FE $78
     jr   c, jr_036_4444                           ; $442D: $38 $15
 
-    call label_CB6                                ; $442F: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $442F: $CD $B6 $0C
     ld   a, $77                                   ; $4432: $3E $77
     ldh  [hLinkPositionY], a                      ; $4434: $E0 $99
     ld   [wMapEntrancePositionY], a               ; $4436: $EA $9E $DB
@@ -7743,7 +7743,7 @@ func_036_6B5C:
 jr_036_6B7B:
     ld   a, [wIsRunningWithPegasusBoots]          ; $6B7B: $FA $4A $C1
     ld   e, a                                     ; $6B7E: $5F
-    call label_CB6                                ; $6B7F: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6B7F: $CD $B6 $0C
     call ClearLinkPositionIncrement               ; $6B82: $CD $8E $17
     ld   a, e                                     ; $6B85: $7B
     scf                                           ; $6B86: $37

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -108,7 +108,7 @@ jr_004_409E:
     call label_3B44                               ; $40A9: $CD $44 $3B
     jr   nc, jr_004_40C7                          ; $40AC: $30 $19
 
-    call label_CB6                                ; $40AE: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $40AE: $CD $B6 $0C
     ld   a, JINGLE_BUMP                           ; $40B1: $3E $09
     ldh  [hJingle], a                             ; $40B3: $E0 $F2
     ld   a, $10                                   ; $40B5: $3E $10
@@ -293,7 +293,7 @@ jr_004_41AC:
     cp   $20                                      ; $41C9: $FE $20
     jr   nc, jr_004_4210                          ; $41CB: $30 $43
 
-    call label_CB6                                ; $41CD: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $41CD: $CD $B6 $0C
     ld   a, [wAButtonSlot]                        ; $41D0: $FA $00 $DB
     cp   $03                                      ; $41D3: $FE $03
     jr   nz, jr_004_41DF                          ; $41D5: $20 $08
@@ -2903,7 +2903,7 @@ jr_004_547E:
     ldh  [hLinkPositionX], a                      ; $54D9: $E0 $98
     ld   a, $06                                   ; $54DB: $3E $06
     ld   [wLinkMotionState], a                    ; $54DD: $EA $1C $C1
-    call label_CAF                                ; $54E0: $CD $AF $0C
+    call ResetSpinAttack                                ; $54E0: $CD $AF $0C
     ld   [$C198], a                               ; $54E3: $EA $98 $C1
     call GetEntityTransitionCountdown                 ; $54E6: $CD $05 $0C
     ld   [hl], $40                                ; $54E9: $36 $40
@@ -6014,7 +6014,7 @@ jr_004_6884:
     ldh  [hLinkPositionY], a                      ; $68BD: $E0 $99
     ld   a, LINK_MOTION_FALLING_DOWN              ; $68BF: $3E $06
     ld   [wLinkMotionState], a                    ; $68C1: $EA $1C $C1
-    call label_CAF                                ; $68C4: $CD $AF $0C
+    call ResetSpinAttack                                ; $68C4: $CD $AF $0C
     ld   [$C198], a                               ; $68C7: $EA $98 $C1
     ld   a, $FF                                   ; $68CA: $3E $FF
     ld   [$DBCB], a                               ; $68CC: $EA $CB $DB
@@ -9445,7 +9445,7 @@ func_004_7BB7:
     ldh  [hActiveEntityUnknownG], a                               ; $7BBD: $E0 $F1
     ld   a, $01                                   ; $7BBF: $3E $01
     ld   [wC15C], a                               ; $7BC1: $EA $5C $C1
-    call label_CAF                                ; $7BC4: $CD $AF $0C
+    call ResetSpinAttack                                ; $7BC4: $CD $AF $0C
     ldh  a, [hLinkPositionX]                      ; $7BC7: $F0 $98
     ldh  [wActiveEntityPosX], a                               ; $7BC9: $E0 $EE
     ldh  a, [hLinkPositionY]                      ; $7BCB: $F0 $99
@@ -9467,7 +9467,7 @@ func_004_7BE3:
     jr   nc, jr_004_7C05                          ; $7BE6: $30 $1D
 
     call CopyLinkFinalPositionToPosition          ; $7BE8: $CD $BE $0C
-    call label_CB6                                ; $7BEB: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7BEB: $CD $B6 $0C
     ld   a, [$C1A6]                               ; $7BEE: $FA $A6 $C1
     and  a                                        ; $7BF1: $A7
     jr   z, jr_004_7C05                           ; $7BF2: $28 $11

--- a/src/code/entities/bank5.asm
+++ b/src/code/entities/bank5.asm
@@ -3712,7 +3712,7 @@ label_005_54C3:
     jr   nc, jr_005_54E5                          ; $54C6: $30 $1D
 
     call CopyLinkFinalPositionToPosition          ; $54C8: $CD $BE $0C
-    call label_CB6                                ; $54CB: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $54CB: $CD $B6 $0C
     ld   a, [$C1A6]                               ; $54CE: $FA $A6 $C1
     and  a                                        ; $54D1: $A7
     jr   z, jr_005_54E5                           ; $54D2: $28 $11

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -6103,7 +6103,7 @@ func_006_641A:
 
 label_006_641F:
     call CopyLinkFinalPositionToPosition          ; $641F: $CD $BE $0C
-    call label_CB6                                ; $6422: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $6422: $CD $B6 $0C
     ld   a, [$C1A6]                               ; $6425: $FA $A6 $C1
     and  a                                        ; $6428: $A7
     jr   z, jr_006_643C                           ; $6429: $28 $11

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -3645,7 +3645,7 @@ jr_007_5572:
     ld   [hl], a                                  ; $5590: $77
     ld   a, $66                                   ; $5591: $3E $66
     ld   [wC111], a                               ; $5593: $EA $11 $C1
-    jp   label_CAF                                ; $5596: $C3 $AF $0C
+    jp   ResetSpinAttack                                ; $5596: $C3 $AF $0C
 
 jr_007_5599:
     ret                                           ; $5599: $C9
@@ -10587,7 +10587,7 @@ func_007_7CF0:
     jr   nc, jr_007_7D14                          ; $7CF3: $30 $1F
 
     call CopyLinkFinalPositionToPosition          ; $7CF5: $CD $BE $0C
-    call label_CB6                                ; $7CF8: $CD $B6 $0C
+    call ResetPegasusBoots                                ; $7CF8: $CD $B6 $0C
     ld   a, [$C1A6]                               ; $7CFB: $FA $A6 $C1
     and  a                                        ; $7CFE: $A7
     jr   z, jr_007_7D12                           ; $7CFF: $28 $11

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -179,7 +179,7 @@ ds $6
 wIsRunningWithPegasusBoots:: ; C14A
   ds 1
 
-wPegagusBootsChargeMeter:: ; C14B
+wPegasusBootsChargeMeter:: ; C14B
   ; Pegasus Boots charge meter
   ; 0:  not charged
   ; 1F: fully charged


### PR DESCRIPTION
Identified and labeled the following functions:
ResetSpinAttack, ResetPegasusBoots, SetShieldVals

Also fixed typo and renamed "wPegagusBootsChargeMeter" to
"wPegasusBootsChargeMeter". Added label for function at $21E1