### PR TITLE
Separate build and test targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     docker:
       - image: kemenaran/rgbds:0.3.8
-
     steps:
       - checkout
       - run:
@@ -11,4 +10,28 @@ jobs:
           command: curl --fail https://www.winosx.com/hosted_files/zladx/Zelda.gbc --output Zelda.gbc
       - run:
           name: Building
-          command: make
+          command: make build
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - Zelda.gbc
+
+  test:
+    docker:
+      - image: kemenaran/rgbds:0.3.8
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Testing checksum
+          command: make test
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@ ASM    := rgbasm -E
 
 .SUFFIXES: .asm .o .gbc .png .2bpp
 
-# For now, we only need to build one rom (game.gbc).
-all: game.gbc
+# Default target
+all: build test
+
+build: game.gbc
+
+test: build
+	@md5sum -c ladx.md5
 
 clean:
 	rm -f $(obj)
@@ -47,4 +52,3 @@ src/main.o: $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files) Zelda.gbc
 game.gbc: $(obj)
 	rgblink -O Zelda.gbc -n $*.sym -m $*.map -o $@ $(obj)
 	rgbfix  -c -n 0 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -v $@
-	@md5sum -c ladx.md5


### PR DESCRIPTION
This allow to have a different reportings for either:

- The build failed (because of some invalid assembly)
- The build passed, but the checksum is incorrect