### PR TITLE
hram: give a consistent naming to scratch registers

### DIFF
--- a/src/code/audio/sfx.asm
+++ b/src/code/audio/sfx.asm
@@ -435,7 +435,7 @@ jr_01F_4438:
 func_01F_4471:
     nop                                           ; $4471: $00
     dec  a                                        ; $4472: $3D
-    ldh  a, [hScratchB]                           ; $4473: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4473: $F0 $D8
     rst  $00                                      ; $4475: $C7
     inc  bc                                       ; $4476: $03
     nop                                           ; $4477: $00

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -3316,11 +3316,11 @@ label_1F69::
     ld   a, [wIsIndoor]
     ld   d, a
     call label_2A26
-    ldh  [$FFDC], a
+    ldh  [hScratch5], a
     ldh  a, [hScratch0]
     cp   $9A
     jr   z, label_1FFE
-    ldh  a, [$FFDC]
+    ldh  a, [hScratch5]
     cp   $00
     jp   z, label_214E
     cp   $01

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -178,7 +178,7 @@ label_91D::
 
 label_92F::
     callsb GetBGAttributesAddressForObject
-    ldh  a, [hBGAttributesBank]
+    ldh  a, [hScratch8]
     ld   [MBC3SelectBank], a
     ld   hl, $DC91
     ld   a, [$DC90]
@@ -187,9 +187,9 @@ label_92F::
     ld   [$DC90], a
     ld   d, $00
     add  hl, de
-    ldh  a, [hScratchE]
+    ldh  a, [hScratch9]
     ld   d, a
-    ldh  a, [hScratchF]
+    ldh  a, [hScratchA]
     ld   e, a
     ldh  a, [$FFCF]
     ldi  [hl], a
@@ -238,17 +238,17 @@ label_978::
 ; Returns:
 ;   a   palette data
 label_983::
-    ; Retrieve and store palette data into hScratchE and hScratchF
+    ; Retrieve and store palette data into hScratch9 and hScratchA
     callsb func_01A_6710
 
     ; Switch to the bank containing this room's palettes
-    ldh  a, [hBGAttributesBank]
+    ldh  a, [hScratch8]
     ld   [MBC3SelectBank], a
 
-    ; Read value from address [hScratchF hScratchE]
-    ldh  a, [hScratchE]
+    ; Read value from address [hScratchA hScratch9]
+    ldh  a, [hScratch9]
     ld   h, a
-    ldh  a, [hScratchF]
+    ldh  a, [hScratchA]
     ld   l, a
     ld   a, [hl]
 
@@ -264,10 +264,10 @@ label_999::
     push bc
     call label_983
 
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     pop  bc
     call label_983
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   a, [$DC90]
     ld   c, a
     ld   b, $00
@@ -281,9 +281,9 @@ label_999::
     ldi  [hl], a
     ld   a, $01
     ldi  [hl], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ldi  [hl], a
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     ldi  [hl], a
     xor  a
     ldi  [hl], a
@@ -522,12 +522,12 @@ AdjustBankNumberForGBC::
 ; Copy a block of data from a given bank to a target address in WRAM2,
 ; then return to bank 20.
 ; Inputs:
-;   hScratchA : source bank
+;   hScratch0 : source bank
 ;   bc :        number of bytes to copy
 ;   de :        destination address
 ;   hl :        source address
 CopyObjectsAttributesToWRAM2::
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   [MBC3SelectBank], a
     ld   a, $02
     ld   [rSVBK], a
@@ -540,7 +540,7 @@ CopyObjectsAttributesToWRAM2::
     ret
 
 label_B2F::
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ldh  a, [hIsGBC]
     and  a
     ret  z
@@ -548,7 +548,7 @@ label_B2F::
     and  a
     ret  nz
     push bc
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch2]
     and  $80
     jr   nz, label_B4B
     ld   a, $20
@@ -565,7 +565,7 @@ label_B4B::
     ld   [rSVBK], a
 
 label_B54::
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch2]
     and  $7F
     ld   [MBC3SelectBank], a
     pop  bc
@@ -583,7 +583,7 @@ CopyData_trampoline::
 ; Inputs:
 ;   a           source bank
 ;   hl          source address
-;   hhScratchK  return bank to restore
+;   hhScratchF  return bank to restore
 CopyBGMapFromBank::
     push hl
     ld   [MBC3SelectBank], a
@@ -615,7 +615,7 @@ CopyBGMapFromBank::
     call label_BB5
 .photoAlbumEnd
 
-    ldh  a, [hScratchK]
+    ldh  a, [hScratchF]
     ld   [MBC3SelectBank], a
     ret
 
@@ -883,11 +883,11 @@ label_CEC::
     ld   hl, $C510
     add  hl, de
     ld   [hl], a
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     ld   hl, $C540
     add  hl, de
     ld   [hl], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   hl, $C530
     add  hl, de
     ld   [hl], a
@@ -899,10 +899,10 @@ label_CEC::
 label_D07::
     ld   a, [$C140]
     sub  a, $08
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, [$C142]
     sub  a, $08
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
 
 label_D15::
     ld   a, JINGLE_SWORD_POKING
@@ -1003,7 +1003,7 @@ LoadRoomSprites::
 
 .indoorOutdoorEnd
     xor  a
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ldh  a, [hMapRoom]
     ld   e, a
     ld   d, $00
@@ -1084,7 +1084,7 @@ label_E03::
     cp   $FF
     jr   z, label_E29
     ld   [bc], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     and  a
     jr   z, label_E1E
     ld   a, d
@@ -1095,7 +1095,7 @@ label_E03::
 
 label_E1E::
     inc  a
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, d
     ld   [$C197], a
     ld   a, $01
@@ -2419,12 +2419,12 @@ CheckItemsSwordCollision::
     add  hl, de
     ldh  a, [hLinkPositionX]
     add  a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, data_16BE
     add  hl, de
     ldh  a, [hLinkPositionY]
     add  a, [hl]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
 
 label_16DF::
     ld   a, $04
@@ -2511,7 +2511,7 @@ label_1756::
     or   [hl]
     ret  nz
     ldh  a, [hLinkPositionX]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, [$C181]
     cp   $05
     jr   z, label_1781
@@ -2519,13 +2519,13 @@ label_1756::
     ldh  [hNoiseSfx], a
     ldh  a, [hLinkPositionY]
     add  a, $06
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   a, $0B
     jp   label_CC7
 
 label_1781::
     ldh  a, [hLinkPositionY]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   a, JINGLE_WATER_DIVE
     ldh  [hJingle], a
     ld   a, $0C
@@ -2550,10 +2550,10 @@ ApplyLinkMotionState::
     ld   a, [$C145]
     ld   hl, $C13B
     add  a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ldh  a, [hLinkPositionX]
-    ldh  [hScratchB], a
-    ld   hl, hScratchD
+    ldh  [hScratch1], a
+    ld   hl, hScratch3
     ld   [hl], $00
     ld   a, [wSwordCharge]
     cp   $28
@@ -2570,7 +2570,7 @@ label_17C6::
     ld   a, [$C13A]
     ld   l, a
     ld   a, [wSwordDirection]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ldh  a, [hLinkPositionY]
     cp   $88
     ret  nc
@@ -2864,7 +2864,7 @@ label_19BF::
 SetSpawnLocation::
     ; Initialize counter
     ld   a, $00
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   de, wSpawnLocationData
 
     ; Copy warp data (5 bytes) from wWarp1 to wSpawnLocationData
@@ -2872,9 +2872,9 @@ SetSpawnLocation::
     ld   a, [hli]
     ld   [de], a
     inc  de
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     inc  a
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     cp   $05
     jr   nz, .loop
 
@@ -3304,20 +3304,20 @@ label_1F69::
     ldh  [hSwordIntersectedAreaY], a
     or   c
     ld   e, a
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   hl, wRoomObjects
     add  hl, de
     ld   a, h
     cp   $D7
     jp   nz, label_214E
     ld   a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   e, a
     ld   a, [wIsIndoor]
     ld   d, a
     call label_2A26
     ldh  [$FFDC], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     cp   $9A
     jr   z, label_1FFE
     ldh  a, [$FFDC]
@@ -3339,7 +3339,7 @@ label_1F69::
     jp   nc, label_214E
 
 label_1FE6::
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   e, a
     cp   $6F
     jr   z, label_1FF6
@@ -3534,7 +3534,7 @@ label_212C::
     jr   c, label_214D
     xor  a
     ldh  [$FFE5], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     cp   $8E
     jr   z, label_2153
     cp   $20
@@ -3542,7 +3542,7 @@ label_212C::
     ld   a, [wIsIndoor]
     and  a
     jr   nz, label_214D
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     cp   $5C
     jr   z, label_2161
 
@@ -3566,9 +3566,9 @@ label_2161::
     ldh  [$FFE5], a
 
 label_2165::
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     ld   e, a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ldh  [$FFAF], a
     call label_2178
     ldh  a, [hLinkDirection]
@@ -3618,7 +3618,7 @@ UpdateFinalLinkPosition::
     call ComputeLinkPosition
     ; Compute next Link horizontal position
     ld   c, $00
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
 
 ; Inputs:
 ;   c : direction (0: horizontal ; 1: vertical)
@@ -3746,14 +3746,14 @@ DoUpdateBGRegion::
     push bc
     push de
 
-    ; hl = wRoomObjects + hScratchC
-    ldh  a, [hScratchC]
+    ; hl = wRoomObjects + hScratch2
+    ldh  a, [hScratch2]
     ld   c, a
     ld   b, $00
     ld   hl, wRoomObjects
     add  hl, bc
 
-    ; c = wRoomObjects[hScratchC]
+    ; c = wRoomObjects[hScratch2]
     ld   b, $00
     ld   c, [hl]
 
@@ -3814,7 +3814,7 @@ DoUpdateBGRegion::
     ;
 
 .configurePalettes
-    ; Set the BG attributes bank in hBGAttributesBank,
+    ; Set the BG attributes bank in hScratch8,
     ; and the target BG attributes address in FFE0-FFE1
     callsb GetBGAttributesAddressForObject
 .palettesDone
@@ -3847,7 +3847,7 @@ DoUpdateBGRegion::
     ld   [MBC3SelectBank], a
     call $49D9
     ; Select BG attributes bank
-    ldh  a, [hBGAttributesBank]
+    ldh  a, [hScratch8]
     ld   [MBC3SelectBank], a
     ; Increment again the source and target destination
     call IncrementBGMapSourceAndDestination_Vertical
@@ -3880,7 +3880,7 @@ DoUpdateBGRegion::
     ld   [MBC3SelectBank], a
     call $49D9
     ; Select BG attributes bank
-    ldh  a, [hBGAttributesBank]
+    ldh  a, [hScratch8]
     ld   [MBC3SelectBank], a
     call IncrementBGMapSourceAndDestination_Horizontal
     ld   a, b
@@ -3906,9 +3906,9 @@ DoUpdateBGRegion::
     ld   b, $00
     ld   hl, BGRegionIncrement
     add  hl, bc
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch2]
     add  a, [hl]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     pop  bc
 
     ; Decrement loop counter
@@ -4766,7 +4766,7 @@ label_2E84::
     xor  a
 
 label_2E85::
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, $C193
     ld   e, a
     ld   d, $00
@@ -4837,7 +4837,7 @@ label_2ED4::
 
 label_2EF2::
     ld   [MBC3SelectBank], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   d, a
     ld   e, $00
     ld   hl, $8400
@@ -4850,7 +4850,7 @@ label_2EF2::
     call CopyData
 
 label_2F0A::
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     inc  a
     cp   $04
     jp   nz, label_2E85
@@ -5083,11 +5083,11 @@ doCopyObjectToBG:
 
     ; Copy tile attributes to BG map for tiles on the upper row
     push hl
-    ldh  a, [hBGAttributesBank]
+    ldh  a, [hScratch8]
     ld   [MBC3SelectBank], a
-    ldh  a, [hScratchE]
+    ldh  a, [hScratch9]
     ld   h, a
-    ldh  a, [hScratchF]
+    ldh  a, [hScratchA]
     ld   l, a
     ld   a, $01
     ld   [rVBK], a
@@ -5100,9 +5100,9 @@ doCopyObjectToBG:
 
     ; Update palette offset
     ld   a, h
-    ldh  [hScratchE], a
+    ldh  [hScratch9], a
     ld   a, l
-    ldh  [hScratchF], a
+    ldh  [hScratchA], a
     pop  hl
 
     ; Move BG target down by one row
@@ -5119,11 +5119,11 @@ doCopyObjectToBG:
     pop  de
 
     ; Copy palettes from WRAM1 for tiles on the lower row
-    ldh  a, [hBGAttributesBank]
+    ldh  a, [hScratch8]
     ld   [MBC3SelectBank], a
-    ldh  a, [hScratchE]
+    ldh  a, [hScratch9]
     ld   h, a
-    ldh  a, [hScratchF]
+    ldh  a, [hScratchA]
     ld   l, a
     ld   a, $01
     ld   [rVBK], a
@@ -5580,9 +5580,9 @@ LoadRoom::
 ;   ds 1 ; type
 ;
 LoadRoomObject::
-    ; Clear hScratchA
+    ; Clear hScratch0
     xor  a
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
 
     ; If object type first bit is 1…
     ld   a, [bc]
@@ -5593,8 +5593,8 @@ LoadRoomObject::
     jr   nz, .threeBytesObjectEnd
     ; … this is a three-bytes object, that spans more than one block.
     ; The first byte encodes the direction and length of the block:
-    ; save it to hScratchA.
-    ldh  [hScratchA], a
+    ; save it to hScratch0.
+    ldh  [hScratch0], a
     ; Skip the parsed direction-and-length byte
     inc  bc
 .threeBytesObjectEnd
@@ -5772,9 +5772,9 @@ LoadRoomObject::
     push af
 .bushGroundStairsEnd
 
-    ; hScratchE = object type
+    ; hScratch9 = object type
     ld   a, d
-    ldh  [hScratchE], a
+    ldh  [hScratch9], a
 
     ; If object is an entrance to somewhere else…
     cp   OBJECT_CLOSED_GATE
@@ -5812,7 +5812,7 @@ LoadRoomObject::
 .overworldDoorEnd
 
     ; a = object type
-    ldh  a, [hScratchE]
+    ldh  a, [hScratch9]
 
     cp   $C5
     jp   z, .configureStairs
@@ -5823,7 +5823,7 @@ LoadRoomObject::
 .loadNonDoorIndoorObject
     ; Re-increment a to be the object type
     add  a, OBJECT_KEY_DOOR_TOP
-    ldh  [hScratchE], a
+    ldh  [hScratch9], a
 
     ; If object type is a conveyor belt…
     push af
@@ -5846,7 +5846,7 @@ LoadRoomObject::
     ldh  a, [hMapRoom]
     cp   $C4
     ; … and the object type is not zero…
-    ldh  a, [hScratchE]
+    ldh  a, [hScratch9]
     jr   z, .torchEnd
     ; …then increment the number of torches in the room
     ld   hl, wTorchesCount
@@ -6060,7 +6060,7 @@ LoadRoomObject::
 
     ldh  a, [hMapId]
     cp   MAP_CAVE_B
-    ldh  a, [hScratchE]
+    ldh  a, [hScratch9]
     jr   c, .bombableBlockEnd
     cp   OBJECT_BOMBABLE_BLOCK
     jr   z, .configureBreakableObject
@@ -6097,7 +6097,7 @@ LoadRoomObject::
 
     ; a = multiple-blocks object direction and length
     ld   d, $00
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ; If there are no coordinates for a multiple-blocks object…
     and  a
     ; … this is a single-block object:
@@ -6113,7 +6113,7 @@ LoadRoomObject::
     ld   hl, wRoomObjects
     add  hl, de
     ; e = count
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     and  $0F
     ld   e, a
     ; d = object type
@@ -6126,14 +6126,14 @@ LoadRoomObject::
 ;   d      object type
 ;   e      count
 ;   hl     destination address
-;   hScratchA  object data (including the direction)
+;   hScratch0  object data (including the direction)
 FillRoomWithConsecutiveObjects::
     ; Copy object type to the active room map
     ld   a, d
     ldi  [hl], a
 
     ; If the object direction is vertical…
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     and  $40
     jr   z, .verticalEnd
     ; … increment the target address to move to the next column
@@ -6695,7 +6695,7 @@ LoadRoomEntities::
 
     ; Reset the entities load order
     xor  a
-    ldh  [hScratchI], a
+    ldh  [hScratchD], a
 
     ldh  a, [hMapRoom]
     ld   c, a
@@ -7537,11 +7537,11 @@ label_3CF6::
     ld   d, h
     pop  hl
     ld   a, c
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, [wLinkWalkingFrameCount]
     ld   c, a
     call SkipDisabledEntityDuringRoomTransition
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   c, a
 
 label_3D06::
@@ -7823,9 +7823,9 @@ label_3E8E::
     and  $03
     ret  nz
     ldh  a, [wActiveEntityPosX]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ldh  a, [wActiveEntityPosY]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   a, $08
     call label_CC7
     ld   hl, $C520
@@ -7843,7 +7843,7 @@ label_3EAF::
     inc  a
 
 label_3EBA::
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, $C400
     add  hl, bc
     ld   a, [hl]
@@ -7854,7 +7854,7 @@ label_3EBA::
 
 label_3EC7::
     ld   e, $03
-    ld   hl, hScratchA
+    ld   hl, hScratch0
     cp   [hl]
     jr   c, label_3ED1
     ld   e, $0C

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -475,7 +475,7 @@ func_4852::
     ld   a, $05
 
 .loop
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, [de]
     and  a
     ld   a, $7E
@@ -493,7 +493,7 @@ func_4852::
 
     ldi  [hl], a
     inc  de
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     dec  a
     jr   nz, .loop
     ld   a, b
@@ -507,7 +507,7 @@ func_4852::
     ld   a, $05
 
 label_4894::
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, [de]
     and  a
     jr   label_489D
@@ -526,7 +526,7 @@ label_489D::
 label_48A9::
     ldi  [hl], a
     inc  de
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     dec  a
     jr   nz, label_4894
     xor  a
@@ -1266,10 +1266,10 @@ label_5519::
     jr   nz, label_5519
     push de
     xor  a
-    ldh  [hScratchA], a
-    ldh  [hScratchB], a
-    ldh  [hScratchC], a
-    ldh  [hScratchD], a
+    ldh  [hScratch0], a
+    ldh  [hScratch1], a
+    ldh  [hScratch2], a
+    ldh  [hScratch3], a
     ld   c, a
     ld   b, a
     ld   e, a
@@ -1299,19 +1299,19 @@ label_5544::
     ld   hl, label_53D8
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, label_53E8
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   hl, label_53F8
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ld   hl, label_5408
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     pop  hl
     call label_5619
     push hl
@@ -1326,10 +1326,10 @@ label_5544::
     xor  a
     ld   [hl], a
     xor  a
-    ldh  [hScratchA], a
-    ldh  [hScratchB], a
-    ldh  [hScratchC], a
-    ldh  [hScratchD], a
+    ldh  [hScratch0], a
+    ldh  [hScratch1], a
+    ldh  [hScratch2], a
+    ldh  [hScratch3], a
     ld   c, a
     ld   b, a
     ld   e, a
@@ -1383,17 +1383,17 @@ label_55C0::
     ld   hl, label_5418
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, label_545C
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     xor  a
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ld   hl, label_54A0
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     pop  hl
     call label_5619
     push hl
@@ -1420,18 +1420,18 @@ label_55F5::
     ld   hl, label_54E4
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, label_54E6
 
 label_5600::
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   a, $01
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ldh  a, [hMapId]
     add  a, $B1
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     pop  hl
     call label_5619
     inc  hl
@@ -1442,13 +1442,13 @@ label_5600::
     ret
 
 label_5619::
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ldi  [hl], a
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     ldi  [hl], a
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch2]
     ldi  [hl], a
-    ldh  a, [hScratchD]
+    ldh  a, [hScratch3]
     ld   [hl], a
     ret
 
@@ -1913,7 +1913,7 @@ label_5A6E::
 
 label_5A71::
     ld   a, [$DBB4]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   a, [$C1B3]
     ld   hl, $C1B2
     or   [hl]
@@ -1968,7 +1968,7 @@ label_5AA0::
     add  hl, de
     ld   a, [$DBB4]
     add  a, [hl]
-    ld   hl, hScratchA
+    ld   hl, hScratch0
     ld   [$DBB4], a
     cp   [hl]
     jr   z, label_5B3F
@@ -1987,7 +1987,7 @@ label_5AA0::
     jr   nz, label_5AF5
     ld   a, JINGLE_BUMP
     ldh  [hJingle], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   [$DBB4], a
     jr   label_5B3F
 
@@ -2367,15 +2367,15 @@ label_5D77::
     ld   hl, $D604
     add  hl, de
     ld   c, $00
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch2]
     and  a
     jr   z, label_5DAB
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
 
 label_5D8B::
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     sub  a, $08
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     jr   c, label_5DA2
     ld   a, $AE
     ldi  [hl], a
@@ -2398,7 +2398,7 @@ label_5DA2::
     jr   label_5DB3
 
 label_5DAB::
-    ldh  a, [hScratchD]
+    ldh  a, [hScratch3]
     cp   c
     jr   z, label_5DBF
     ld   a, $AE
@@ -2615,12 +2615,12 @@ PrepareEntityPositionForRoomTransition::
     ; Set the entity load order
     ld   hl, wEntitiesLoadOrderTable
     add  hl, de
-    ldh  a, [hScratchI]
+    ldh  a, [hScratchD]
     ld   [hl], a
 
     ; Increment the load order
     inc  a
-    ldh  [hScratchI], a
+    ldh  [hScratchD], a
 
     push bc
     ; bc = wRoomTransitionDirection
@@ -2628,58 +2628,58 @@ PrepareEntityPositionForRoomTransition::
     ld   c, a
     ld   b, $00
 
-    ; hScratchA = EntityPosXOffsetTable[wRoomTransitionDirection]
+    ; hScratch0 = EntityPosXOffsetTable[wRoomTransitionDirection]
     ld   hl, EntityPosXOffsetTable
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
 
-    ; hScratchB = EntityPosXSignTable[wRoomTransitionDirection]
+    ; hScratch1 = EntityPosXSignTable[wRoomTransitionDirection]
     ld   hl, EntityPosXSignTable
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
 
-    ; hScratchC = EntityPosYOffsetTable[wRoomTransitionDirection]
+    ; hScratch2 = EntityPosYOffsetTable[wRoomTransitionDirection]
     ld   hl, EntityPosYOffsetTable
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
 
-    ; hScratchD = EntityPosYSignTable[wRoomTransitionDirection]
+    ; hScratch3 = EntityPosYSignTable[wRoomTransitionDirection]
     ld   hl, EntityPosYSignTable
     add  hl, bc
     ld   a, [hl]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
 
-    ; [wEntitiesPosXTable + de] += [hScratchA]
+    ; [wEntitiesPosXTable + de] += [hScratch0]
     ld   hl, wEntitiesPosXTable
     add  hl, de
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     add  a, [hl]
     ld   [hl], a
 
-    ; [wEntitiesPosXSignTable + de] += [hScratchB] + carry
+    ; [wEntitiesPosXSignTable + de] += [hScratch1] + carry
     rr   c
     ld   hl, wEntitiesPosXSignTable
     add  hl, de
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     rl   c
     adc  a, [hl]
     ld   [hl], a
 
-    ; [wEntitiesPosYTable + de] += [hScratchC]
+    ; [wEntitiesPosYTable + de] += [hScratch2]
     ld   hl, wEntitiesPosYTable
     add  hl, de
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch2]
     add  a, [hl]
     ld   [hl], a
 
-    ; [wEntitiesPosYSignTable + de] += [hScratchD] + carry
+    ; [wEntitiesPosYSignTable + de] += [hScratch3] + carry
     rr   c
     ld   hl, wEntitiesPosYSignTable
     add  hl, de
-    ldh  a, [hScratchD]
+    ldh  a, [hScratch3]
     rl   c
     adc  a, [hl]
     ld   [hl], a
@@ -3626,15 +3626,15 @@ label_6BF0::
 
 label_6BF4::
     ld   a, c
-    ldh  [hScratchE], a
+    ldh  [hScratch9], a
     ld   d, $00
 
 label_6BF9::
     xor  a
-    ldh  [hScratchA], a
-    ldh  [hScratchB], a
-    ldh  [hScratchC], a
-    ldh  [hScratchD], a
+    ldh  [hScratch0], a
+    ldh  [hScratch1], a
+    ldh  [hScratch2], a
+    ldh  [hScratch3], a
     ld   hl, $DB65
     add  hl, de
     ld   a, [hl]
@@ -3649,13 +3649,13 @@ label_6BF9::
     ld   h, $9D
     push hl
     ld   a, $7C
-    ldh  [hScratchA], a
-    ldh  [hScratchB], a
-    ldh  [hScratchC], a
+    ldh  [hScratch0], a
+    ldh  [hScratch1], a
+    ldh  [hScratch2], a
     ld   hl, label_6BD7
     add  hl, de
     ld   a, [hl]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     pop  hl
     jr   label_6C48
 
@@ -3671,32 +3671,32 @@ label_6C2A::
     ld   hl, label_6BDF
     add  hl, de
     ld   a, [hl]
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     inc  a
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     add  a, $0F
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     inc  a
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     pop  hl
 
 label_6C48::
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   [hl], a
     call label_6C69
-    ldh  a, [hScratchB]
-    ld   [hl], a
-    inc  c
-    call label_6C69
-    ldh  a, [hScratchC]
+    ldh  a, [hScratch1]
     ld   [hl], a
     inc  c
     call label_6C69
-    ldh  a, [hScratchD]
+    ldh  a, [hScratch2]
+    ld   [hl], a
+    inc  c
+    call label_6C69
+    ldh  a, [hScratch3]
     ld   [hl], a
     inc  e
     ld   a, e
-    ld   hl, hScratchE
+    ld   hl, hScratch9
     cp   [hl]
     jp   nz, label_6BF9
     ret

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -813,7 +813,7 @@ UpdatePaletteEffectForInteractiveObjects::
 
     ; If Link's motion state doesn't allow for palette effects, return
     xor  a                                        ; $4C5D: $AF
-    ldh  [hScratchA], a                           ; $4C5E: $E0 $D7
+    ldh  [hScratch0], a                           ; $4C5E: $E0 $D7
     ld   d, a                                     ; $4C60: $57
     ld   a, [wLinkMotionState]                    ; $4C61: $FA $1C $C1
     ld   e, a                                     ; $4C64: $5F
@@ -834,7 +834,7 @@ UpdatePaletteEffectForInteractiveObjects::
     jr   nz, .jr_014_4C82                         ; $4C7B: $20 $05
 
     ld   a, [wC3CD]                               ; $4C7D: $FA $CD $C3
-    ldh  [hScratchA], a                           ; $4C80: $E0 $D7
+    ldh  [hScratch0], a                           ; $4C80: $E0 $D7
 
 .jr_014_4C82
     ld   a, [wBGPaletteEffectAddress]             ; $4C82: $FA $CC $C3
@@ -857,7 +857,7 @@ UpdatePaletteEffectForInteractiveObjects::
     and  $01                                      ; $4C9E: $E6 $01
     jr   nz, .return                              ; $4CA0: $20 $0F
 
-    ldh  a, [hScratchA]                           ; $4CA2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4CA2: $F0 $D7
     ld   hl, wBGPaletteEffectAddress              ; $4CA4: $21 $CC $C3
     sub  [hl]                                     ; $4CA7: $96
     jr   z, .return                               ; $4CA8: $28 $07
@@ -880,7 +880,7 @@ jr_014_4CB2:
     or   [hl]                                     ; $4CB8: $B6
     ret  nz                                       ; $4CB9: $C0
 
-    ldh  a, [hScratchA]                           ; $4CBA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4CBA: $F0 $D7
     ld   hl, wBGPaletteEffectAddress              ; $4CBC: $21 $CC $C3
     sub  [hl]                                     ; $4CBF: $96
     jr   nz, jr_014_4CC7                          ; $4CC0: $20 $05
@@ -1584,7 +1584,7 @@ jr_014_5036:
 RenderTransitionEffect::
     srl  a                                        ; $5038: $CB $3F
     srl  a                                        ; $503A: $CB $3F
-    ldh  [hScratchA], a                           ; $503C: $E0 $D7
+    ldh  [hScratch0], a                           ; $503C: $E0 $D7
     ld   a, [wTransitionGfxFrameCount]            ; $503E: $FA $80 $C1
     nop                                           ; $5041: $00
     and  $E0                                      ; $5042: $E6 $E0
@@ -1599,20 +1599,20 @@ RenderTransitionEffect::
 
 jr_014_5050:
     ld   a, e                                     ; $5050: $7B
-    ldh  [hScratchB], a                           ; $5051: $E0 $D8
+    ldh  [hScratch1], a                           ; $5051: $E0 $D8
     ld   hl, $C17C                                ; $5053: $21 $7C $C1
     xor  a                                        ; $5056: $AF
     ld   [hl+], a                                 ; $5057: $22
     ld   [hl+], a                                 ; $5058: $22
     ld   [hl+], a                                 ; $5059: $22
     ld   a, $58                                   ; $505A: $3E $58
-    ldh  [hScratchC], a                           ; $505C: $E0 $D9
+    ldh  [hScratch2], a                           ; $505C: $E0 $D9
     ldh  a, [hIsGBC]                              ; $505E: $F0 $FE
     and  a                                        ; $5060: $A7
     jr   z, jr_014_5067                           ; $5061: $28 $04
 
     ld   a, $88                                   ; $5063: $3E $88
-    ldh  [hScratchC], a                           ; $5065: $E0 $D9
+    ldh  [hScratch2], a                           ; $5065: $E0 $D9
 
 label_014_5067:
 jr_014_5067:
@@ -1635,7 +1635,7 @@ jr_014_506F:
     ld   a, [$C17D]                               ; $5082: $FA $7D $C1
     adc  $00                                      ; $5085: $CE $00
     ld   [$C17D], a                               ; $5087: $EA $7D $C1
-    ldh  a, [hScratchC]                           ; $508A: $F0 $D9
+    ldh  a, [hScratch2]                           ; $508A: $F0 $D9
     ld   hl, $C17C                                ; $508C: $21 $7C $C1
     cp   [hl]                                     ; $508F: $BE
     ret  z                                        ; $5090: $C8
@@ -1648,10 +1648,10 @@ jr_014_506F:
     inc  c                                        ; $509A: $0C
 
 jr_014_509B:
-    ldh  a, [hScratchA]                           ; $509B: $F0 $D7
+    ldh  a, [hScratch0]                           ; $509B: $F0 $D7
     add  [hl]                                     ; $509D: $86
     and  $1F                                      ; $509E: $E6 $1F
-    ld   hl, hScratchB                            ; $50A0: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $50A0: $21 $D8 $FF
     or   [hl]                                     ; $50A3: $B6
     ld   e, a                                     ; $50A4: $5F
     ld   hl, $4EE8                                ; $50A5: $21 $E8 $4E
@@ -3285,6 +3285,6 @@ jr_014_5920:
     ld   a, $1C                                   ; $592F: $3E $1C
 
 jr_014_5931:
-    ldh  [hBGAttributesBank], a                    ; $5931: $E0 $DF
+    ldh  [hScratch8], a                           ; $5931: $E0 $DF
     ret                                           ; $5933: $C9
 

--- a/src/code/bank1A/map_loading.asm
+++ b/src/code/bank1A/map_loading.asm
@@ -9,8 +9,8 @@
 ;   hl   address of the object in the object map (see wRoomObjects)
 ;   bc   object attribute value * 4
 ; Returns:
-;   hBGAttributesBank      the bank of the BG attributes
-;   hScratchE, hScratchF   the address of the BG attributes
+;   hScratch8      the bank of the BG attributes
+;   hScratch9, hScratchA   the address of the BG attributes
 GetBGAttributesAddressForObject::
     push hl                                       ; $6576: $E5
     push bc                                       ; $6577: $C5
@@ -29,11 +29,11 @@ GetBGAttributesAddressForObject::
     ldh  a, [hMapRoom]                            ; $6581: $F0 $F6
     ld   c, a                                     ; $6583: $4F
 
-    ; hBGAttributesBank = OverworldBGAttributesBanks[hMapRoom]
+    ; hScratch8 = OverworldBGAttributesBanks[hMapRoom]
     ld   hl, OverworldBGAttributesBanks           ; $6584: $21 $76 $64
     add  hl, bc                                   ; $6587: $09
     ld   a, [hl]                                  ; $6588: $7E
-    ldh  [hBGAttributesBank], a                    ; $6589: $E0 $DF
+    ldh  [hScratch8], a                           ; $6589: $E0 $DF
 .overworldPaletteBankEnd
 
     ; bc = [hMapRoom] * 2
@@ -55,7 +55,7 @@ GetBGAttributesAddressForObject::
     jp   z, .indoorPaletteEnd                     ; $659B: $CA $30 $66
 
     ld   a, BANK(IndoorsBGAttributesA)            ; $659E: $3E $23
-    ldh  [hBGAttributesBank], a                    ; $65A0: $E0 $DF
+    ldh  [hScratch8], a                           ; $65A0: $E0 $DF
     inc  h                                        ; $65A2: $24
     inc  h                                        ; $65A3: $24
     ld   b, $00                                   ; $65A4: $06 $00
@@ -163,8 +163,8 @@ GetBGAttributesAddressForObject::
     jr   z, .jr_01A_662E                          ; $6628: $28 $04
 
 .useSecondaryIndoorsPaletteBank
-    ld   a, BANK(IndoorsBGAttributesB)           ; $662A: $3E $24
-    ldh  [hBGAttributesBank], a                    ; $662C: $E0 $DF
+    ld   a, BANK(IndoorsBGAttributesB)            ; $662A: $3E $24
+    ldh  [hScratch8], a                           ; $662C: $E0 $DF
 
 .jr_01A_662E
     inc  h                                        ; $662E: $24
@@ -186,11 +186,11 @@ GetBGAttributesAddressForObject::
 .loadPalettesAdress
     pop  bc                                       ; $6636: $C1
     add  hl, bc                                   ; $6637: $09
-    ; hScratchE, hScratchF = PalettesTable[ObjectAttributeValue * 4]
+    ; hScratch9, hScratchA = PalettesTable[ObjectAttributeValue * 4]
     ld   a, h                                     ; $6638: $7C
-    ldh  [hScratchE], a                           ; $6639: $E0 $E0
+    ldh  [hScratch9], a                           ; $6639: $E0 $E0
     ld   a, l                                     ; $663B: $7D
-    ldh  [hScratchF], a                           ; $663C: $E0 $E1
+    ldh  [hScratchA], a                           ; $663C: $E0 $E1
     pop  hl                                       ; $663E: $E1
     ret                                           ; $663F: $C9
 
@@ -263,13 +263,13 @@ jr_01A_6736:
     ld   b, $00                                   ; $6737: $06 $00
     ld   a, [hl]                                  ; $6739: $7E
     ld   c, a                                     ; $673A: $4F
-    ldh  a, [hScratchE]                           ; $673B: $F0 $E0
+    ldh  a, [hScratch9]                           ; $673B: $F0 $E0
     ld   h, a                                     ; $673D: $67
-    ldh  a, [hScratchF]                           ; $673E: $F0 $E1
+    ldh  a, [hScratchA]                           ; $673E: $F0 $E1
     ld   l, a                                     ; $6740: $6F
     add  hl, bc                                   ; $6741: $09
     ld   a, h                                     ; $6742: $7C
-    ldh  [hScratchE], a                           ; $6743: $E0 $E0
+    ldh  [hScratch9], a                           ; $6743: $E0 $E0
     ld   a, l                                     ; $6745: $7D
-    ldh  [hScratchF], a                           ; $6746: $E0 $E1
+    ldh  [hScratchA], a                           ; $6746: $E0 $E1
     ret                                           ; $6748: $C9

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -2766,7 +2766,7 @@ jr_002_531D:
     ld   a, [hl+]                                 ; $533E: $2A
     ldh  [$FFDB], a                               ; $533F: $E0 $DB
     ld   a, [hl]                                  ; $5341: $7E
-    ldh  [$FFDC], a                               ; $5342: $E0 $DC
+    ldh  [hScratch5], a                               ; $5342: $E0 $DC
     ld   de, $C010                                ; $5344: $11 $10 $C0
     ld   bc, $C014                                ; $5347: $01 $14 $C0
     ld   a, [$C145]                               ; $534A: $FA $45 $C1
@@ -2809,7 +2809,7 @@ jr_002_5366:
     inc  bc                                       ; $537B: $03
     ldh  a, [$FFDB]                               ; $537C: $F0 $DB
     ld   [de], a                                  ; $537E: $12
-    ldh  a, [$FFDC]                               ; $537F: $F0 $DC
+    ldh  a, [hScratch5]                               ; $537F: $F0 $DC
     ld   [bc], a                                  ; $5381: $02
     ret                                           ; $5382: $C9
 
@@ -2881,7 +2881,7 @@ TryOpenLockedDoor::
     ldh  [hSwordIntersectedAreaX], a                               ; $53D5: $E0 $CE
     swap a                                        ; $53D7: $CB $37
     ld   e, a                                     ; $53D9: $5F
-    ldh  a, [$FFDC]                               ; $53DA: $F0 $DC
+    ldh  a, [hScratch5]                               ; $53DA: $F0 $DC
     and  $F0                                      ; $53DC: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a                               ; $53DE: $E0 $CD
     or   e                                        ; $53E0: $B3
@@ -2917,7 +2917,7 @@ TryOpenLockedDoor::
     ld   hl, wEntity0PosX                         ; $540D: $21 $00 $C2
     add  hl, de                                   ; $5410: $19
     ld   [hl], a                                  ; $5411: $77
-    ldh  a, [$FFDC]                               ; $5412: $F0 $DC
+    ldh  a, [hScratch5]                               ; $5412: $F0 $DC
     and  $F0                                      ; $5414: $E6 $F0
     add  $10                                      ; $5416: $C6 $10
     ld   hl, wEntitiesPosYTable                   ; $5418: $21 $10 $C2
@@ -7005,7 +7005,7 @@ jr_002_6F25:
     ldh  a, [hLinkPositionY]                      ; $6F40: $F0 $99
     add  [hl]                                     ; $6F42: $86
     sub  $10                                      ; $6F43: $D6 $10
-    ldh  [$FFDC], a                               ; $6F45: $E0 $DC
+    ldh  [hScratch5], a                               ; $6F45: $E0 $DC
     and  $F0                                      ; $6F47: $E6 $F0
     or   e                                        ; $6F49: $B3
     ld   e, a                                     ; $6F4A: $5F
@@ -7380,7 +7380,7 @@ jr_002_716E:
     rra                                           ; $7185: $1F
     and  $01                                      ; $7186: $E6 $01
     ld   e, a                                     ; $7188: $5F
-    ldh  a, [$FFDC]                               ; $7189: $F0 $DC
+    ldh  a, [hScratch5]                               ; $7189: $F0 $DC
     rra                                           ; $718B: $1F
     rra                                           ; $718C: $1F
     and  $02                                      ; $718D: $E6 $02
@@ -7403,7 +7403,7 @@ label_002_719C::
     cp   $D5                                      ; $71A7: $FE $D5
     jp   z, label_002_7454                        ; $71A9: $CA $54 $74
 
-    ldh  a, [$FFDC]                               ; $71AC: $F0 $DC
+    ldh  a, [hScratch5]                               ; $71AC: $F0 $DC
     and  $0F                                      ; $71AE: $E6 $0F
     cp   $08                                      ; $71B0: $FE $08
     jp   c, label_002_7461                        ; $71B2: $DA $61 $74
@@ -7416,7 +7416,7 @@ label_002_71BB::
     and  a                                        ; $71BE: $A7
     jp   nz, label_002_7454                       ; $71BF: $C2 $54 $74
 
-    ldh  a, [$FFDC]                               ; $71C2: $F0 $DC
+    ldh  a, [hScratch5]                               ; $71C2: $F0 $DC
     and  $0F                                      ; $71C4: $E6 $0F
     cp   $06                                      ; $71C6: $FE $06
     jp   nc, label_002_726A                       ; $71C8: $D2 $6A $72
@@ -7686,7 +7686,7 @@ jr_002_734F:
     ldh  a, [$FFDB]                               ; $7356: $F0 $DB
     and  $F0                                      ; $7358: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a                               ; $735A: $E0 $CE
-    ldh  a, [$FFDC]                               ; $735C: $F0 $DC
+    ldh  a, [hScratch5]                               ; $735C: $F0 $DC
     and  $F0                                      ; $735E: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a                               ; $7360: $E0 $CD
     ldh  a, [hFFE9]                               ; $7362: $F0 $E9
@@ -7875,7 +7875,7 @@ func_002_7468::
     jr   nz, jr_002_7493                          ; $7470: $20 $21
 
 jr_002_7472:
-    ldh  a, [$FFDC]                               ; $7472: $F0 $DC
+    ldh  a, [hScratch5]                               ; $7472: $F0 $DC
     and  $0F                                      ; $7474: $E6 $0F
     cp   $06                                      ; $7476: $FE $06
     jr   nc, jr_002_74AC                          ; $7478: $30 $32
@@ -7905,7 +7905,7 @@ jr_002_7493:
     jr   nz, jr_002_74AC                          ; $74A1: $20 $09
 
 jr_002_74A3:
-    ldh  a, [$FFDC]                               ; $74A3: $F0 $DC
+    ldh  a, [hScratch5]                               ; $74A3: $F0 $DC
     and  $0F                                      ; $74A5: $E6 $0F
     cp   $0C                                      ; $74A7: $FE $0C
     jp   nc, ApplyMapFadeOutTransition                            ; $74A9: $D2 $7D $0C

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -27,7 +27,7 @@ label_002_41D0::
     ld   [hl], a                                  ; $41F2: $77
     ld   hl, $C3B0                                ; $41F3: $21 $B0 $C3
     add  hl, de                                   ; $41F6: $19
-    ldh  a, [hBGAttributesBank]                               ; $41F7: $F0 $DF
+    ldh  a, [hScratch8]                               ; $41F7: $F0 $DF
     ld   [hl], a                                  ; $41F9: $77
 
 jr_002_41FA:
@@ -700,9 +700,9 @@ label_002_45AC::
 
 jr_002_45AD:
     ldh  a, [hLinkPositionY]                      ; $45AD: $F0 $99
-    ldh  [hScratchB], a                               ; $45AF: $E0 $D8
+    ldh  [hScratch1], a                               ; $45AF: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $45B1: $F0 $98
-    ldh  [hScratchA], a                               ; $45B3: $E0 $D7
+    ldh  [hScratch0], a                               ; $45B3: $E0 $D7
     ld   a, JINGLE_WATER_DIVE                     ; $45B5: $3E $0E
     ldh  [hJingle], a                             ; $45B7: $E0 $F2
     ld   a, $0C                                   ; $45B9: $3E $0C
@@ -1582,7 +1582,7 @@ jr_002_4C8B:
     ret                                           ; $4C91: $C9
 
 label_002_4C92::
-    ldh  a, [hScratchB]                               ; $4C92: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4C92: $F0 $D8
     ld   e, a                                     ; $4C94: $5F
     ld   d, $00                                   ; $4C95: $16 $00
     ld   hl, wRoomObjects                       ; $4C97: $21 $11 $D7
@@ -1656,13 +1656,13 @@ jr_002_4CDD:
     ld   b, d                                     ; $4D07: $42
     ld   a, $0C                                   ; $4D08: $3E $0C
     call label_3BAA                               ; $4D0A: $CD $AA $3B
-    ldh  a, [hScratchA]                               ; $4D0D: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4D0D: $F0 $D7
     cpl                                           ; $4D0F: $2F
     inc  a                                        ; $4D10: $3C
     ld   hl, wEntitiesSpeedYTable                                ; $4D11: $21 $50 $C2
     add  hl, bc                                   ; $4D14: $09
     ld   [hl], a                                  ; $4D15: $77
-    ldh  a, [hScratchB]                               ; $4D16: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4D16: $F0 $D8
     cpl                                           ; $4D18: $2F
     inc  a                                        ; $4D19: $3C
     ld   hl, wEntitiesSpeedXTable                                ; $4D1A: $21 $40 $C2
@@ -1703,7 +1703,7 @@ func_002_4D20::
     ldh  [hSwordIntersectedAreaY], a                               ; $4D52: $E0 $CD
     or   c                                        ; $4D54: $B1
     ld   e, a                                     ; $4D55: $5F
-    ldh  [hScratchB], a                               ; $4D56: $E0 $D8
+    ldh  [hScratch1], a                               ; $4D56: $E0 $D8
     ld   hl, wRoomObjects                       ; $4D58: $21 $11 $D7
     add  hl, de                                   ; $4D5B: $19
     ld   a, h                                     ; $4D5C: $7C
@@ -1711,7 +1711,7 @@ func_002_4D20::
     jp   nz, label_002_4D95                       ; $4D5F: $C2 $95 $4D
 
     ld   a, [hl]                                  ; $4D62: $7E
-    ldh  [hScratchA], a                               ; $4D63: $E0 $D7
+    ldh  [hScratch0], a                               ; $4D63: $E0 $D7
     ld   e, a                                     ; $4D65: $5F
     ld   a, [wIsIndoor]                         ; $4D66: $FA $A5 $DB
     ld   d, a                                     ; $4D69: $57
@@ -1723,7 +1723,7 @@ func_002_4D20::
     and  a                                        ; $4D72: $A7
     jr   nz, jr_002_4D8D                          ; $4D73: $20 $18
 
-    ldh  a, [hScratchA]                               ; $4D75: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4D75: $F0 $D7
     cp   $0C                                      ; $4D77: $FE $0C
     jr   z, label_002_4D95                        ; $4D79: $28 $1A
 
@@ -1742,7 +1742,7 @@ func_002_4D20::
     jr   jr_002_4D93                              ; $4D8B: $18 $06
 
 jr_002_4D8D:
-    ldh  a, [hScratchA]                               ; $4D8D: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4D8D: $F0 $D7
     cp   $05                                      ; $4D8F: $FE $05
     jr   nz, label_002_4D95                       ; $4D91: $20 $02
 
@@ -1755,12 +1755,12 @@ label_002_4D95::
     ret                                           ; $4D96: $C9
 
 label_002_4D97::
-    ldh  a, [hScratchA]                               ; $4D97: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4D97: $F0 $D7
     ldh  [hSwordIntersectedAreaX], a                               ; $4D99: $E0 $CE
     swap a                                        ; $4D9B: $CB $37
     and  $0F                                      ; $4D9D: $E6 $0F
     ld   e, a                                     ; $4D9F: $5F
-    ldh  a, [hScratchB]                               ; $4DA0: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4DA0: $F0 $D8
     ldh  [hSwordIntersectedAreaY], a                               ; $4DA2: $E0 $CD
     and  $F0                                      ; $4DA4: $E6 $F0
     or   e                                        ; $4DA6: $B3
@@ -2531,12 +2531,12 @@ jr_002_51ED:
     ld   hl, $C13B                                ; $51FA: $21 $3B $C1
     add  [hl]                                     ; $51FD: $86
     sub  $10                                      ; $51FE: $D6 $10
-    ldh  [hScratchA], a                               ; $5200: $E0 $D7
+    ldh  [hScratch0], a                               ; $5200: $E0 $D7
     ld   a, [wDialogGotItem]                               ; $5202: $FA $A9 $C1
     cp   $01                                      ; $5205: $FE $01
     jr   z, jr_002_524F                           ; $5207: $28 $46
 
-    ldh  a, [hScratchA]                               ; $5209: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5209: $F0 $D7
     add  $02                                      ; $520B: $C6 $02
     ld   [bc], a                                  ; $520D: $02
     inc  bc                                       ; $520E: $03
@@ -2599,17 +2599,17 @@ func_002_524A::
 jr_002_524F:
     ldh  a, [hLinkPositionX]                      ; $524F: $F0 $98
     sub  $08                                      ; $5251: $D6 $08
-    ldh  [hScratchB], a                               ; $5253: $E0 $D8
+    ldh  [hScratch1], a                               ; $5253: $E0 $D8
     ldh  a, [hFrameCounter]                       ; $5255: $F0 $E7
     rla                                           ; $5257: $17
     rla                                           ; $5258: $17
     and  $10                                      ; $5259: $E6 $10
-    ldh  [hScratchD], a                               ; $525B: $E0 $DA
+    ldh  [hScratch3], a                               ; $525B: $E0 $DA
     xor  a                                        ; $525D: $AF
     ld   h, a                                     ; $525E: $67
     ld   l, a                                     ; $525F: $6F
     ld   a, $06                                   ; $5260: $3E $06
-    ldh  [hScratchC], a                               ; $5262: $E0 $D9
+    ldh  [hScratch2], a                               ; $5262: $E0 $D9
     jp   label_1819                               ; $5264: $C3 $19 $18
 
     call ResetSpinAttack                                ; $5267: $CD $AF $0C
@@ -2749,18 +2749,18 @@ jr_002_531D:
     ld   hl, $52E8                                ; $5320: $21 $E8 $52
     add  hl, de                                   ; $5323: $19
     ld   a, [hl]                                  ; $5324: $7E
-    ldh  [hScratchA], a                               ; $5325: $E0 $D7
+    ldh  [hScratch0], a                               ; $5325: $E0 $D7
     ld   hl, $52E0                                ; $5327: $21 $E0 $52
     add  hl, de                                   ; $532A: $19
     ld   a, [hl]                                  ; $532B: $7E
-    ldh  [hScratchB], a                               ; $532C: $E0 $D8
+    ldh  [hScratch1], a                               ; $532C: $E0 $D8
     sla  e                                        ; $532E: $CB $23
     ld   hl, $52F0                                ; $5330: $21 $F0 $52
     add  hl, de                                   ; $5333: $19
     ld   a, [hl+]                                 ; $5334: $2A
-    ldh  [hScratchC], a                               ; $5335: $E0 $D9
+    ldh  [hScratch2], a                               ; $5335: $E0 $D9
     ld   a, [hl]                                  ; $5337: $7E
-    ldh  [hScratchD], a                               ; $5338: $E0 $DA
+    ldh  [hScratch3], a                               ; $5338: $E0 $DA
     ld   hl, $5300                                ; $533A: $21 $00 $53
     add  hl, de                                   ; $533D: $19
     ld   a, [hl+]                                 ; $533E: $2A
@@ -2772,10 +2772,10 @@ jr_002_531D:
     ld   a, [$C145]                               ; $534A: $FA $45 $C1
     ld   hl, $C13B                                ; $534D: $21 $3B $C1
     add  [hl]                                     ; $5350: $86
-    ld   hl, hScratchA                                ; $5351: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $5351: $21 $D7 $FF
     add  [hl]                                     ; $5354: $86
     ld   [hl], a                                  ; $5355: $77
-    ldh  a, [hScratchC]                               ; $5356: $F0 $D9
+    ldh  a, [hScratch2]                               ; $5356: $F0 $D9
     cp   $FF                                      ; $5358: $FE $FF
     jr   z, jr_002_535E                           ; $535A: $28 $02
 
@@ -2783,7 +2783,7 @@ jr_002_531D:
     ld   [de], a                                  ; $535D: $12
 
 jr_002_535E:
-    ldh  a, [hScratchD]                               ; $535E: $F0 $DA
+    ldh  a, [hScratch3]                               ; $535E: $F0 $DA
     cp   $FF                                      ; $5360: $FE $FF
     jr   z, jr_002_5366                           ; $5362: $28 $02
 
@@ -2793,7 +2793,7 @@ jr_002_535E:
 jr_002_5366:
     inc  de                                       ; $5366: $13
     inc  bc                                       ; $5367: $03
-    ldh  a, [hScratchB]                               ; $5368: $F0 $D8
+    ldh  a, [hScratch1]                               ; $5368: $F0 $D8
     ld   hl, hLinkPositionX                       ; $536A: $21 $98 $FF
     add  [hl]                                     ; $536D: $86
     ld   [de], a                                  ; $536E: $12
@@ -2801,9 +2801,9 @@ jr_002_5366:
     ld   [bc], a                                  ; $5371: $02
     inc  de                                       ; $5372: $13
     inc  bc                                       ; $5373: $03
-    ldh  a, [hScratchC]                               ; $5374: $F0 $D9
+    ldh  a, [hScratch2]                               ; $5374: $F0 $D9
     ld   [de], a                                  ; $5376: $12
-    ldh  a, [hScratchD]                               ; $5377: $F0 $DA
+    ldh  a, [hScratch3]                               ; $5377: $F0 $DA
     ld   [bc], a                                  ; $5379: $02
     inc  de                                       ; $537A: $13
     inc  bc                                       ; $537B: $03
@@ -2891,10 +2891,10 @@ TryOpenLockedDoor::
     call label_2178                               ; $53E4: $CD $78 $21
     ldh  a, [hSwordIntersectedAreaX]                               ; $53E7: $F0 $CE
     add  $08                                      ; $53E9: $C6 $08
-    ldh  [hScratchA], a                               ; $53EB: $E0 $D7
+    ldh  [hScratch0], a                               ; $53EB: $E0 $D7
     ldh  a, [hSwordIntersectedAreaY]                               ; $53ED: $F0 $CD
     add  $10                                      ; $53EF: $C6 $10
-    ldh  [hScratchB], a                               ; $53F1: $E0 $D8
+    ldh  [hScratch1], a                               ; $53F1: $E0 $D8
     ld   a, $02                                   ; $53F3: $3E $02
     call label_CC7                                ; $53F5: $CD $C7 $0C
     jp   .return                                  ; $53F8: $C3 $1D $54
@@ -3175,7 +3175,7 @@ func_002_5567::
 
     dec  a                                        ; $5576: $3D
     ld   [hl], a                                  ; $5577: $77
-    ldh  [hScratchA], a                               ; $5578: $E0 $D7
+    ldh  [hScratch0], a                               ; $5578: $E0 $D7
     jr   nz, jr_002_557F                          ; $557A: $20 $03
 
 jr_002_557C:
@@ -3308,10 +3308,10 @@ jr_002_55FD:
     ld   c, $04                                   ; $561C: $0E $04
 
 jr_002_561E:
-    ldh  a, [hScratchB]                               ; $561E: $F0 $D8
+    ldh  a, [hScratch1]                               ; $561E: $F0 $D8
     ld   [de], a                                  ; $5620: $12
     inc  de                                       ; $5621: $13
-    ldh  a, [hScratchC]                               ; $5622: $F0 $D9
+    ldh  a, [hScratch2]                               ; $5622: $F0 $D9
     ld   hl, $55FF                                ; $5624: $21 $FF $55
     add  hl, bc                                   ; $5627: $09
     add  [hl]                                     ; $5628: $86
@@ -3343,7 +3343,7 @@ jr_002_561E:
     ld   [wC167], a                               ; $564A: $EA $67 $C1
     xor  a                                        ; $564D: $AF
     ld   [wScreenShakeHorizontal], a              ; $564E: $EA $55 $C1
-    ldh  a, [hScratchA]                               ; $5651: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5651: $F0 $D7
     cp   $02                                      ; $5653: $FE $02
     jr   nc, jr_002_565B                          ; $5655: $30 $04
 
@@ -3395,7 +3395,7 @@ jr_002_568C:
     cp   $08                                      ; $568E: $FE $08
     jp   nz, label_002_5707                       ; $5690: $C2 $07 $57
 
-    ldh  a, [hScratchA]                               ; $5693: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5693: $F0 $D7
     rra                                           ; $5695: $1F
     rra                                           ; $5696: $1F
     rra                                           ; $5697: $1F
@@ -3405,9 +3405,9 @@ jr_002_568C:
     ld   hl, $5642                                ; $569C: $21 $42 $56
     add  hl, de                                   ; $569F: $19
     ld   a, [hl+]                                 ; $56A0: $2A
-    ldh  [hScratchA], a                               ; $56A1: $E0 $D7
+    ldh  [hScratch0], a                               ; $56A1: $E0 $D7
     ld   a, [hl]                                  ; $56A3: $7E
-    ldh  [hScratchB], a                               ; $56A4: $E0 $D8
+    ldh  [hScratch1], a                               ; $56A4: $E0 $D8
     ld   a, $60                                   ; $56A6: $3E $60
     ldh  [hSwordIntersectedAreaX], a                               ; $56A8: $E0 $CE
     ldh  a, [hMapRoom]                           ; $56AA: $F0 $F6
@@ -3433,7 +3433,7 @@ jr_002_56B8:
     ld   [hl+], a                                 ; $56CB: $22
     ld   a, $41                                   ; $56CC: $3E $41
     ld   [hl+], a                                 ; $56CE: $22
-    ldh  a, [hScratchA]                               ; $56CF: $F0 $D7
+    ldh  a, [hScratch0]                               ; $56CF: $F0 $D7
     ld   [hl+], a                                 ; $56D1: $22
     ldh  a, [$FFCF]                               ; $56D2: $F0 $CF
     ld   [hl+], a                                 ; $56D4: $22
@@ -3442,7 +3442,7 @@ jr_002_56B8:
     ld   [hl+], a                                 ; $56D9: $22
     ld   a, $41                                   ; $56DA: $3E $41
     ld   [hl+], a                                 ; $56DC: $22
-    ldh  a, [hScratchB]                               ; $56DD: $F0 $D8
+    ldh  a, [hScratch1]                               ; $56DD: $F0 $D8
     ld   [hl+], a                                 ; $56DF: $22
     ld   [hl], b                                  ; $56E0: $70
     ld   a, e                                     ; $56E1: $7B
@@ -3481,7 +3481,7 @@ label_002_5707::
     nop                                           ; $5714: $00
     ld   [$611E], sp                              ; $5715: $08 $1E $61
     call func_002_58D0                            ; $5718: $CD $D0 $58
-    ldh  a, [hScratchA]                               ; $571B: $F0 $D7
+    ldh  a, [hScratch0]                               ; $571B: $F0 $D7
     and  $08                                      ; $571D: $E6 $08
     ld   d, $00                                   ; $571F: $16 $00
     ld   e, a                                     ; $5721: $5F
@@ -3509,7 +3509,7 @@ label_002_5707::
 jr_002_5743:
     ld   [$6130], sp                              ; $5743: $08 $30 $61
     call func_002_58D0                            ; $5746: $CD $D0 $58
-    ldh  a, [hScratchA]                               ; $5749: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5749: $F0 $D7
     and  $08                                      ; $574B: $E6 $08
     ld   d, $00                                   ; $574D: $16 $00
     ld   e, a                                     ; $574F: $5F
@@ -3520,7 +3520,7 @@ jr_002_5743:
     rst  $38                                      ; $5759: $FF
     ld   bc, $FF01                                ; $575A: $01 $01 $FF
     rst  $38                                      ; $575D: $FF
-    ldh  a, [hScratchA]                               ; $575E: $F0 $D7
+    ldh  a, [hScratch0]                               ; $575E: $F0 $D7
     cp   $0A                                      ; $5760: $FE $0A
     jr   c, jr_002_5780                           ; $5762: $38 $1C
 
@@ -3547,7 +3547,7 @@ jr_002_5780:
     call func_002_58D0                            ; $5780: $CD $D0 $58
     push bc                                       ; $5783: $C5
     ld   c, $3A                                   ; $5784: $0E $3A
-    ldh  a, [hScratchA]                               ; $5786: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5786: $F0 $D7
     cp   $07                                      ; $5788: $FE $07
     jr   nc, jr_002_578E                          ; $578A: $30 $02
 
@@ -3559,17 +3559,17 @@ jr_002_578E:
     ld   d, $00                                   ; $5792: $16 $00
     ld   hl, $C030                                ; $5794: $21 $30 $C0
     add  hl, de                                   ; $5797: $19
-    ldh  a, [hScratchB]                               ; $5798: $F0 $D8
+    ldh  a, [hScratch1]                               ; $5798: $F0 $D8
     ld   [hl+], a                                 ; $579A: $22
-    ldh  a, [hScratchC]                               ; $579B: $F0 $D9
+    ldh  a, [hScratch2]                               ; $579B: $F0 $D9
     ld   [hl+], a                                 ; $579D: $22
     ld   a, c                                     ; $579E: $79
     ld   [hl+], a                                 ; $579F: $22
     xor  a                                        ; $57A0: $AF
     ld   [hl+], a                                 ; $57A1: $22
-    ldh  a, [hScratchB]                               ; $57A2: $F0 $D8
+    ldh  a, [hScratch1]                               ; $57A2: $F0 $D8
     ld   [hl+], a                                 ; $57A4: $22
-    ldh  a, [hScratchC]                               ; $57A5: $F0 $D9
+    ldh  a, [hScratch2]                               ; $57A5: $F0 $D9
     add  $08                                      ; $57A7: $C6 $08
     ld   [hl+], a                                 ; $57A9: $22
     ld   a, c                                     ; $57AA: $79
@@ -3587,9 +3587,9 @@ jr_002_57BB:
     ld   d, $00                                   ; $57BB: $16 $00
     ld   hl, $C030                                ; $57BD: $21 $30 $C0
     add  hl, de                                   ; $57C0: $19
-    ldh  a, [hScratchB]                               ; $57C1: $F0 $D8
+    ldh  a, [hScratch1]                               ; $57C1: $F0 $D8
     ld   [hl+], a                                 ; $57C3: $22
-    ldh  a, [hScratchC]                               ; $57C4: $F0 $D9
+    ldh  a, [hScratch2]                               ; $57C4: $F0 $D9
     ld   [hl+], a                                 ; $57C6: $22
     ld   a, $24                                   ; $57C7: $3E $24
     ld   [hl+], a                                 ; $57C9: $22
@@ -3625,7 +3625,7 @@ jr_002_57E6:
     ret  nc                                       ; $57EE: $D0
 
     ld   e, b                                     ; $57EF: $58
-    ldh  a, [hScratchA]                               ; $57F0: $F0 $D7
+    ldh  a, [hScratch0]                               ; $57F0: $F0 $D7
     and  $08                                      ; $57F2: $E6 $08
     ld   d, $00                                   ; $57F4: $16 $00
     ld   e, a                                     ; $57F6: $5F
@@ -3676,7 +3676,7 @@ jr_002_582D:
     ld   hl, $57FD                                ; $5830: $21 $FD $57
 
 jr_002_5833:
-    ldh  a, [hScratchA]                               ; $5833: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5833: $F0 $D7
     and  $08                                      ; $5835: $E6 $08
     ld   e, a                                     ; $5837: $5F
     ld   d, $00                                   ; $5838: $16 $00
@@ -3698,12 +3698,12 @@ label_002_583A::
     jp   label_002_58F5                           ; $5851: $C3 $F5 $58
 
 label_002_5854::
-    ldh  a, [hScratchB]                               ; $5854: $F0 $D8
+    ldh  a, [hScratch1]                               ; $5854: $F0 $D8
     add  [hl]                                     ; $5856: $86
     ld   [de], a                                  ; $5857: $12
     inc  hl                                       ; $5858: $23
     inc  de                                       ; $5859: $13
-    ldh  a, [hScratchC]                               ; $585A: $F0 $D9
+    ldh  a, [hScratch2]                               ; $585A: $F0 $D9
     add  [hl]                                     ; $585C: $86
     ld   [de], a                                  ; $585D: $12
     inc  hl                                       ; $585E: $23
@@ -3730,7 +3730,7 @@ label_002_5854::
     ld   [$2078], sp                              ; $5874: $08 $78 $20
 
 label_002_5877::
-    ldh  a, [hScratchA]                               ; $5877: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5877: $F0 $D7
     and  $08                                      ; $5879: $E6 $08
     ld   d, $00                                   ; $587B: $16 $00
     ld   e, a                                     ; $587D: $5F
@@ -3762,7 +3762,7 @@ jr_002_5899:
 jr_002_58A1:
     ld   [$2130], sp                              ; $58A1: $08 $30 $21
     call func_002_58D0                            ; $58A4: $CD $D0 $58
-    ldh  a, [hScratchA]                               ; $58A7: $F0 $D7
+    ldh  a, [hScratch0]                               ; $58A7: $F0 $D7
     cp   $04                                      ; $58A9: $FE $04
     jr   nz, jr_002_58BB                          ; $58AB: $20 $0E
 
@@ -3782,7 +3782,7 @@ jr_002_58BB:
     call func_002_5F5C                            ; $58BF: $CD $5C $5F
 
 jr_002_58C2:
-    ldh  a, [hScratchA]                               ; $58C2: $F0 $D7
+    ldh  a, [hScratch0]                               ; $58C2: $F0 $D7
     rla                                           ; $58C4: $17
     and  $18                                      ; $58C5: $E6 $18
     ld   d, $00                                   ; $58C7: $16 $00
@@ -3794,14 +3794,14 @@ func_002_58D0::
     ld   hl, $C540                                ; $58D0: $21 $40 $C5
     add  hl, bc                                   ; $58D3: $09
     ld   a, [hl]                                  ; $58D4: $7E
-    ldh  [hScratchB], a                               ; $58D5: $E0 $D8
+    ldh  [hScratch1], a                               ; $58D5: $E0 $D8
     cp   $88                                      ; $58D7: $FE $88
     jr   nc, func_002_58E6                        ; $58D9: $30 $0B
 
     ld   hl, $C530                                ; $58DB: $21 $30 $C5
     add  hl, bc                                   ; $58DE: $09
     ld   a, [hl]                                  ; $58DF: $7E
-    ldh  [hScratchC], a                               ; $58E0: $E0 $D9
+    ldh  [hScratch2], a                               ; $58E0: $E0 $D9
     cp   $A8                                      ; $58E2: $FE $A8
     jr   c, jr_002_58EC                           ; $58E4: $38 $06
 
@@ -3859,9 +3859,9 @@ func_002_5926::
     ldh  a, [hLinkPositionY]                      ; $5926: $F0 $99
 
 func_002_5928::
-    ldh  [hScratchB], a                               ; $5928: $E0 $D8
+    ldh  [hScratch1], a                               ; $5928: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $592A: $F0 $98
-    ldh  [hScratchA], a                               ; $592C: $E0 $D7
+    ldh  [hScratch0], a                               ; $592C: $E0 $D7
     ld   a, JINGLE_WATER_DIVE                     ; $592E: $3E $0E
     ldh  [hJingle], a                             ; $5930: $E0 $F2
     ld   a, $01                                   ; $5932: $3E $01
@@ -4137,7 +4137,7 @@ jr_002_5B31:
     ld   hl, $C1F0                                ; $5B41: $21 $F0 $C1
     add  hl, bc                                   ; $5B44: $09
     ld   a, [hl]                                  ; $5B45: $7E
-    ldh  [hScratchA], a                               ; $5B46: $E0 $D7
+    ldh  [hScratch0], a                               ; $5B46: $E0 $D7
     ld   a, c                                     ; $5B48: $79
     and  $07                                      ; $5B49: $E6 $07
     ld   c, a                                     ; $5B4B: $4F
@@ -4146,7 +4146,7 @@ jr_002_5B4C:
     ld   hl, $5A40                                ; $5B4C: $21 $40 $5A
     add  hl, bc                                   ; $5B4F: $09
     ld   a, [hl]                                  ; $5B50: $7E
-    ld   hl, hScratchA                                ; $5B51: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $5B51: $21 $D7 $FF
     add  [hl]                                     ; $5B54: $86
     ld   e, a                                     ; $5B55: $5F
     ld   d, $00                                   ; $5B56: $16 $00
@@ -4449,13 +4449,13 @@ jr_002_5CE5:
     ld   hl, $C1F4                                ; $5CF7: $21 $F4 $C1
     add  hl, bc                                   ; $5CFA: $09
     ld   a, [hl]                                  ; $5CFB: $7E
-    ldh  [hScratchA], a                               ; $5CFC: $E0 $D7
+    ldh  [hScratch0], a                               ; $5CFC: $E0 $D7
 
 jr_002_5CFE:
     ld   hl, $5BF4                                ; $5CFE: $21 $F4 $5B
     add  hl, bc                                   ; $5D01: $09
     ld   a, [hl]                                  ; $5D02: $7E
-    ld   hl, hScratchA                                ; $5D03: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $5D03: $21 $D7 $FF
     add  [hl]                                     ; $5D06: $86
     ld   e, a                                     ; $5D07: $5F
     ld   d, $00                                   ; $5D08: $16 $00
@@ -4607,17 +4607,17 @@ jr_002_5DC0:
     add  hl, de                                   ; $5DD9: $19
     ld   [hl], $80                                ; $5DDA: $36 $80
     ld   a, $88                                   ; $5DDC: $3E $88
-    ldh  [hScratchA], a                               ; $5DDE: $E0 $D7
+    ldh  [hScratch0], a                               ; $5DDE: $E0 $D7
     ld   a, $30                                   ; $5DE0: $3E $30
-    ldh  [hScratchB], a                               ; $5DE2: $E0 $D8
+    ldh  [hScratch1], a                               ; $5DE2: $E0 $D8
     ld   a, $02                                   ; $5DE4: $3E $02
     jp   label_002_5DF6                           ; $5DE6: $C3 $F6 $5D
 
     call func_002_5DAF                            ; $5DE9: $CD $AF $5D
     ld   a, $88                                   ; $5DEC: $3E $88
-    ldh  [hScratchA], a                               ; $5DEE: $E0 $D7
+    ldh  [hScratch0], a                               ; $5DEE: $E0 $D7
     ld   a, $20                                   ; $5DF0: $3E $20
-    ldh  [hScratchB], a                               ; $5DF2: $E0 $D8
+    ldh  [hScratch1], a                               ; $5DF2: $E0 $D8
     ld   a, $04                                   ; $5DF4: $3E $04
 
 label_002_5DF6::
@@ -4753,7 +4753,7 @@ jr_002_5EA2:
 label_002_5EAB::
     call func_002_5DAF                            ; $5EAB: $CD $AF $5D
     ld   a, $88                                   ; $5EAE: $3E $88
-    ldh  [hScratchA], a                               ; $5EB0: $E0 $D7
+    ldh  [hScratch0], a                               ; $5EB0: $E0 $D7
     ldh  a, [hLinkPositionY]                      ; $5EB2: $F0 $99
     sub  $30                                      ; $5EB4: $D6 $30
     add  $08                                      ; $5EB6: $C6 $08
@@ -4773,7 +4773,7 @@ jr_002_5ECA:
     ld   a, $30                                   ; $5ECA: $3E $30
 
 jr_002_5ECC:
-    ldh  [hScratchB], a                               ; $5ECC: $E0 $D8
+    ldh  [hScratch1], a                               ; $5ECC: $E0 $D8
     ld   a, $03                                   ; $5ECE: $3E $03
     jp   label_CC7                                ; $5ED0: $C3 $C7 $0C
 
@@ -4913,7 +4913,7 @@ func_002_5F5C::
 
 func_002_5F9F::
     and  $1F                                      ; $5F9F: $E6 $1F
-    ldh  [hScratchA], a                               ; $5FA1: $E0 $D7
+    ldh  [hScratch0], a                               ; $5FA1: $E0 $D7
     dec  a                                        ; $5FA3: $3D
     JP_TABLE                                      ; $5FA4: $C7
     db   $fc                                      ; $5FA5: $FC
@@ -5013,7 +5013,7 @@ jr_002_6011:
     cp   $FF                                      ; $6013: $FE $FF
     jr   nz, jr_002_6000                          ; $6015: $20 $E9
 
-    ldh  a, [hScratchA]                               ; $6017: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6017: $F0 $D7
     cp   $08                                      ; $6019: $FE $08
     jr   nz, jr_002_6029                          ; $601B: $20 $0C
 
@@ -5036,7 +5036,7 @@ jr_002_602C:
     ret  nz                                       ; $6031: $C0
 
     xor  a                                        ; $6032: $AF
-    ldh  [hScratchA], a                               ; $6033: $E0 $D7
+    ldh  [hScratch0], a                               ; $6033: $E0 $D7
     ld   de, $0000                                ; $6035: $11 $00 $00
     ldh  a, [hMapRoom]                           ; $6038: $F0 $F6
     cp   $12                                      ; $603A: $FE $12
@@ -5068,7 +5068,7 @@ jr_002_604F:
     cp   $08                                      ; $605C: $FE $08
     jr   nz, jr_002_6064                          ; $605E: $20 $04
 
-    ld   hl, hScratchA                                ; $6060: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $6060: $21 $D7 $FF
     inc  [hl]                                     ; $6063: $34
 
 jr_002_6064:
@@ -5085,7 +5085,7 @@ jr_002_6064:
     ld   e, $04                                   ; $6072: $1E $04
 
 jr_002_6074:
-    ldh  a, [hScratchA]                               ; $6074: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6074: $F0 $D7
     cp   e                                        ; $6076: $BB
     ret  nz                                       ; $6077: $C0
 
@@ -5135,7 +5135,7 @@ jr_002_60A8:
     cp   $04                                      ; $60B5: $FE $04
     jr   nz, jr_002_60BD                          ; $60B7: $20 $04
 
-    ld   hl, hScratchA                                ; $60B9: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $60B9: $21 $D7 $FF
     inc  [hl]                                     ; $60BC: $34
 
 jr_002_60BD:
@@ -5144,7 +5144,7 @@ jr_002_60BD:
     and  $0F                                      ; $60BF: $E6 $0F
     jr   nz, jr_002_609B                          ; $60C1: $20 $D8
 
-    ldh  a, [hScratchA]                               ; $60C3: $F0 $D7
+    ldh  a, [hScratch0]                               ; $60C3: $F0 $D7
     cp   $02                                      ; $60C5: $FE $02
     ret  nz                                       ; $60C7: $C0
 
@@ -5745,12 +5745,12 @@ LoadHeartsCount::
     and  a                                        ; $643D: $A7
     jr   z, jr_002_6462                           ; $643E: $28 $22
 
-    ldh  [hScratchA], a                               ; $6440: $E0 $D7
+    ldh  [hScratch0], a                               ; $6440: $E0 $D7
 
 jr_002_6442:
-    ldh  a, [hScratchA]                               ; $6442: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6442: $F0 $D7
     sub  $08                                      ; $6444: $D6 $08
-    ldh  [hScratchA], a                               ; $6446: $E0 $D7
+    ldh  [hScratch0], a                               ; $6446: $E0 $D7
     jr   c, jr_002_6459                           ; $6448: $38 $0F
 
     ld   a, $A9                                   ; $644A: $3E $A9
@@ -5958,7 +5958,7 @@ jr_002_6982:
     and  a                                        ; $698B: $A7
     ret  nz                                       ; $698C: $C0
 
-    ldh  a, [hScratchA]                               ; $698D: $F0 $D7
+    ldh  a, [hScratch0]                               ; $698D: $F0 $D7
     cp   $B0                                      ; $698F: $FE $B0
     jr   z, jr_002_699E                           ; $6991: $28 $0B
 
@@ -6014,7 +6014,7 @@ jr_002_69D7:
     and  a                                        ; $69E0: $A7
     ret  nz                                       ; $69E1: $C0
 
-    ldh  a, [hScratchA]                               ; $69E2: $F0 $D7
+    ldh  a, [hScratch0]                               ; $69E2: $F0 $D7
     cp   $B1                                      ; $69E4: $FE $B1
     jr   z, jr_002_69F3                           ; $69E6: $28 $0B
 
@@ -6219,7 +6219,7 @@ jr_002_6AFC:
     and  a                                        ; $6B02: $A7
     ret  nz                                       ; $6B03: $C0
 
-    ldh  a, [hScratchA]                               ; $6B04: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6B04: $F0 $D7
     cp   $B1                                      ; $6B06: $FE $B1
     jr   z, jr_002_6B2A                           ; $6B08: $28 $20
 
@@ -6299,8 +6299,8 @@ label_002_6B66::
     ld   c, $04                                   ; $6B66: $0E $04
     ld   b, $00                                   ; $6B68: $06 $00
     call func_002_6C2F                            ; $6B6A: $CD $2F $6C
-    ldh  a, [hScratchB]                               ; $6B6D: $F0 $D8
-    ldh  [hScratchA], a                               ; $6B6F: $E0 $D7
+    ldh  a, [hScratch1]                               ; $6B6D: $F0 $D8
+    ldh  [hScratch0], a                               ; $6B6F: $E0 $D7
     xor  a                                        ; $6B71: $AF
     ld   [wCollisionType], a                               ; $6B72: $EA $33 $C1
     ld   c, $00                                   ; $6B75: $0E $00
@@ -6454,7 +6454,7 @@ func_002_6C2F::
     ld   a, [wIsIndoor]                         ; $6C58: $FA $A5 $DB
     ld   d, a                                     ; $6C5B: $57
     call label_2A26                               ; $6C5C: $CD $26 $2A
-    ldh  [hScratchB], a                               ; $6C5F: $E0 $D8
+    ldh  [hScratch1], a                               ; $6C5F: $E0 $D8
     cp   $60                                      ; $6C61: $FE $60
     jr   z, func_002_6C69                         ; $6C63: $28 $04
 
@@ -7142,9 +7142,9 @@ jr_002_700D:
 
 jr_002_7015:
     ldh  a, [hLinkPositionY]                      ; $7015: $F0 $99
-    ldh  [hScratchB], a                               ; $7017: $E0 $D8
+    ldh  [hScratch1], a                               ; $7017: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $7019: $F0 $98
-    ldh  [hScratchA], a                               ; $701B: $E0 $D7
+    ldh  [hScratch0], a                               ; $701B: $E0 $D7
     ld   a, $09                                   ; $701D: $3E $09
     call label_CC7                                ; $701F: $CD $C7 $0C
     ld   [hl], $DF                                ; $7022: $36 $DF
@@ -7753,14 +7753,14 @@ label_002_73AD::
     ldh  a, [hLinkPositionY]                      ; $73CA: $F0 $99
     and  $F0                                      ; $73CC: $E6 $F0
     or   e                                        ; $73CE: $B3
-    ldh  [hScratchA], a                               ; $73CF: $E0 $D7
+    ldh  [hScratch0], a                               ; $73CF: $E0 $D7
     ld   e, $00                                   ; $73D1: $1E $00
     ld   d, e                                     ; $73D3: $53
 
 jr_002_73D4:
     ld   hl, $73A3                                ; $73D4: $21 $A3 $73
     add  hl, de                                   ; $73D7: $19
-    ldh  a, [hScratchA]                               ; $73D8: $F0 $D7
+    ldh  a, [hScratch0]                               ; $73D8: $F0 $D7
     cp   [hl]                                     ; $73DA: $BE
     jr   nz, jr_002_73E6                          ; $73DB: $20 $09
 
@@ -7977,13 +7977,13 @@ func_002_7504::
 func_002_7512::
     ldh  a, [hLinkPositionX]                      ; $7512: $F0 $98
     and  $F0                                      ; $7514: $E6 $F0
-    ldh  [hScratchA], a                               ; $7516: $E0 $D7
+    ldh  [hScratch0], a                               ; $7516: $E0 $D7
     swap a                                        ; $7518: $CB $37
     ld   e, a                                     ; $751A: $5F
     ldh  a, [hLinkPositionY]                      ; $751B: $F0 $99
     sub  $04                                      ; $751D: $D6 $04
     and  $F0                                      ; $751F: $E6 $F0
-    ldh  [hScratchB], a                               ; $7521: $E0 $D8
+    ldh  [hScratch1], a                               ; $7521: $E0 $D8
     or   e                                        ; $7523: $B3
     ld   e, a                                     ; $7524: $5F
     ldh  [hLinkRoomPosition], a                               ; $7525: $E0 $FA
@@ -8202,7 +8202,7 @@ jr_002_764C:
 
     ldh  a, [hLinkPositionX]                      ; $7662: $F0 $98
     sub  $08                                      ; $7664: $D6 $08
-    ld   hl, hScratchA                                ; $7666: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $7666: $21 $D7 $FF
     sub  [hl]                                     ; $7669: $96
     bit  7, a                                     ; $766A: $CB $7F
     ld   a, $FF                                   ; $766C: $3E $FF
@@ -8214,7 +8214,7 @@ jr_002_7672:
     ld   hl, hLinkPositionX                       ; $7672: $21 $98 $FF
     add  [hl]                                     ; $7675: $86
     ld   [hl], a                                  ; $7676: $77
-    ldh  a, [hScratchB]                               ; $7677: $F0 $D8
+    ldh  a, [hScratch1]                               ; $7677: $F0 $D8
     add  $10                                      ; $7679: $C6 $10
     ld   hl, hLinkPositionY                       ; $767B: $21 $99 $FF
     sub  [hl]                                     ; $767E: $96

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -1604,22 +1604,22 @@ func_020_486C::
 func_020_4874::
     ld   hl, $486C                                ; $4874: $21 $6C $48
     add  hl, de                                   ; $4877: $19
-    ldh  a, [hScratchA]                           ; $4878: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4878: $F0 $D7
     add  [hl]                                     ; $487A: $86
     sub  $08                                      ; $487B: $D6 $08
     and  $F0                                      ; $487D: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $487F: $E0 $CE
     swap a                                        ; $4881: $CB $37
-    ldh  [hScratchA], a                           ; $4883: $E0 $D7
+    ldh  [hScratch0], a                           ; $4883: $E0 $D7
     ld   hl, $4870                                ; $4885: $21 $70 $48
     add  hl, de                                   ; $4888: $19
-    ldh  a, [hScratchB]                           ; $4889: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4889: $F0 $D8
     add  [hl]                                     ; $488B: $86
     sub  $10                                      ; $488C: $D6 $10
     and  $F0                                      ; $488E: $E6 $F0
     ld   e, a                                     ; $4890: $5F
     ldh  [hSwordIntersectedAreaY], a              ; $4891: $E0 $CD
-    ldh  a, [hScratchA]                           ; $4893: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4893: $F0 $D7
     or   e                                        ; $4895: $B3
     ld   e, a                                     ; $4896: $5F
     ret                                           ; $4897: $C9
@@ -1682,9 +1682,9 @@ func_020_48CA::
     ldh  a, [hLinkDirection]                      ; $48DD: $F0 $9E
     ld   e, a                                     ; $48DF: $5F
     ldh  a, [hLinkPositionX]                      ; $48E0: $F0 $98
-    ldh  [hScratchA], a                           ; $48E2: $E0 $D7
+    ldh  [hScratch0], a                           ; $48E2: $E0 $D7
     ldh  a, [hLinkPositionY]                      ; $48E4: $F0 $99
-    ldh  [hScratchB], a                           ; $48E6: $E0 $D8
+    ldh  [hScratch1], a                           ; $48E6: $E0 $D8
     call func_020_4874                            ; $48E8: $CD $74 $48
     ld   hl, wRoomObjects                         ; $48EB: $21 $11 $D7
     add  hl, de                                   ; $48EE: $19
@@ -1761,25 +1761,25 @@ jr_020_4917:
 func_020_4954::
     ld   a, [hl]                                  ; $4954: $7E
     inc  a                                        ; $4955: $3C
-    ldh  [hScratchA], a                           ; $4956: $E0 $D7
+    ldh  [hScratch0], a                           ; $4956: $E0 $D7
     dec  a                                        ; $4958: $3D
     cp   $55                                      ; $4959: $FE $55
     jr   nz, jr_020_4961                          ; $495B: $20 $04
 
     ld   a, $AE                                   ; $495D: $3E $AE
-    ldh  [hScratchA], a                           ; $495F: $E0 $D7
+    ldh  [hScratch0], a                           ; $495F: $E0 $D7
 
 jr_020_4961:
-    ldh  a, [hScratchA]                           ; $4961: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4961: $F0 $D7
     ld   [hl], a                                  ; $4963: $77
     call label_2887                               ; $4964: $CD $87 $28
     push bc                                       ; $4967: $C5
-    ldh  a, [hScratchA]                           ; $4968: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4968: $F0 $D7
     ld   [$DDD8], a                               ; $496A: $EA $D8 $DD
     ld   a, $20                                   ; $496D: $3E $20
     call label_91D                                ; $496F: $CD $1D $09
     pop  bc                                       ; $4972: $C1
-    ldh  a, [hScratchA]                           ; $4973: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4973: $F0 $D7
     cp   $AE                                      ; $4975: $FE $AE
     jr   nz, jr_020_497F                          ; $4977: $20 $06
 
@@ -1930,7 +1930,7 @@ func_020_4A22:
     ld   c, a                                     ; $4A79: $4F
     ld   b, $00                                   ; $4A7A: $06 $00
     ld   a, [$C12A]                               ; $4A7C: $FA $2A $C1
-    ldh  [hScratchC], a                           ; $4A7F: $E0 $D9
+    ldh  [hScratch2], a                           ; $4A7F: $E0 $D9
     ld   hl, $49EC                                ; $4A81: $21 $EC $49
     add  hl, bc                                   ; $4A84: $09
     ldh  a, [hIsGBC]                              ; $4A85: $F0 $FE
@@ -1976,16 +1976,16 @@ jr_020_4A92:
     inc  hl                                       ; $4AB1: $23
     inc  hl                                       ; $4AB2: $23
     push hl                                       ; $4AB3: $E5
-    ldh  a, [hScratchA]                           ; $4AB4: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4AB4: $F0 $D7
     add  h                                        ; $4AB6: $84
     ld   [bc], a                                  ; $4AB7: $02
     inc  bc                                       ; $4AB8: $03
-    ldh  a, [hScratchB]                           ; $4AB9: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4AB9: $F0 $D8
     add  l                                        ; $4ABB: $85
     ld   [bc], a                                  ; $4ABC: $02
     inc  bc                                       ; $4ABD: $03
     ld   hl, $4A93                                ; $4ABE: $21 $93 $4A
-    ldh  a, [hScratchC]                           ; $4AC1: $F0 $D9
+    ldh  a, [hScratch2]                           ; $4AC1: $F0 $D9
     sla  a                                        ; $4AC3: $CB $27
     ld   e, a                                     ; $4AC5: $5F
     ld   d, $00                                   ; $4AC6: $16 $00
@@ -2005,14 +2005,14 @@ jr_020_4AD4:
     ld   hl, $4AA3                                ; $4AD5: $21 $A3 $4A
     add  hl, de                                   ; $4AD8: $19
     ld   a, [hl]                                  ; $4AD9: $7E
-    ld   hl, hScratchD                            ; $4ADA: $21 $DA $FF
+    ld   hl, hScratch3                            ; $4ADA: $21 $DA $FF
     or   [hl]                                     ; $4ADD: $B6
     ld   [bc], a                                  ; $4ADE: $02
     ldh  a, [hIsGBC]                              ; $4ADF: $F0 $FE
     and  a                                        ; $4AE1: $A7
     jr   z, jr_020_4AEF                           ; $4AE2: $28 $0B
 
-    ldh  a, [hScratchD]                           ; $4AE4: $F0 $DA
+    ldh  a, [hScratch3]                           ; $4AE4: $F0 $DA
     and  a                                        ; $4AE6: $A7
     jr   z, jr_020_4AEF                           ; $4AE7: $28 $06
 
@@ -2024,11 +2024,11 @@ jr_020_4AD4:
 jr_020_4AEF:
     inc  bc                                       ; $4AEF: $03
     pop  hl                                       ; $4AF0: $E1
-    ldh  a, [hScratchA]                           ; $4AF1: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4AF1: $F0 $D7
     add  h                                        ; $4AF3: $84
     ld   [bc], a                                  ; $4AF4: $02
     inc  bc                                       ; $4AF5: $03
-    ldh  a, [hScratchB]                           ; $4AF6: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4AF6: $F0 $D8
     add  l                                        ; $4AF8: $85
     add  $08                                      ; $4AF9: $C6 $08
     ld   [bc], a                                  ; $4AFB: $02
@@ -2041,14 +2041,14 @@ jr_020_4AEF:
     ld   hl, $4AA4                                ; $4B04: $21 $A4 $4A
     add  hl, de                                   ; $4B07: $19
     ld   a, [hl]                                  ; $4B08: $7E
-    ld   hl, hScratchD                            ; $4B09: $21 $DA $FF
+    ld   hl, hScratch3                            ; $4B09: $21 $DA $FF
     or   [hl]                                     ; $4B0C: $B6
     ld   [bc], a                                  ; $4B0D: $02
     ldh  a, [hIsGBC]                              ; $4B0E: $F0 $FE
     and  a                                        ; $4B10: $A7
     jr   z, jr_020_4B1E                           ; $4B11: $28 $0B
 
-    ldh  a, [hScratchD]                           ; $4B13: $F0 $DA
+    ldh  a, [hScratch3]                           ; $4B13: $F0 $DA
     and  a                                        ; $4B15: $A7
     jr   z, jr_020_4B1E                           ; $4B16: $28 $06
 
@@ -3453,7 +3453,7 @@ jr_020_527C:
     ld   hl, data_020_5246                        ; $5280: $21 $46 $52
     add  hl, de                                   ; $5283: $19
     ld   a, [hl]                                  ; $5284: $7E
-    ldh  [hScratchA], a                           ; $5285: $E0 $D7
+    ldh  [hScratch0], a                           ; $5285: $E0 $D7
     sla  e                                        ; $5287: $CB $23
     ld   hl, data_020_5224                        ; $5289: $21 $24 $52
     add  hl, de                                   ; $528C: $19
@@ -3471,7 +3471,7 @@ jr_020_5296:
     and  $03                                      ; $5298: $E6 $03
     jr   nz, jr_020_5296                          ; $529A: $20 $FA
 
-    ld   hl, hScratchB                            ; $529C: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $529C: $21 $D8 $FF
     ld   [hl], $01                                ; $529F: $36 $01
     ldh  a, [hIsGBC]                              ; $52A1: $F0 $FE
     and  a                                        ; $52A3: $A7
@@ -3486,7 +3486,7 @@ jr_020_52A8:
     and  [hl]                                     ; $52AF: $A6
     jr   nz, jr_020_52A8                          ; $52B0: $20 $F6
 
-    ldh  a, [hScratchA]                           ; $52B2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $52B2: $F0 $D7
     ld   l, a                                     ; $52B4: $6F
     ld   a, [$C17C]                               ; $52B5: $FA $7C $C1
     ld   e, a                                     ; $52B8: $5F
@@ -4239,10 +4239,10 @@ jr_020_55F0:
 
     inc  [hl]                                     ; $5601: $34
     xor  a                                        ; $5602: $AF
-    ldh  [hScratchA], a                           ; $5603: $E0 $D7
+    ldh  [hScratch0], a                           ; $5603: $E0 $D7
 
 jr_020_5605:
-    ldh  a, [hScratchA]                           ; $5605: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5605: $F0 $D7
     cp   $03                                      ; $5607: $FE $03
     jr   z, jr_020_562E                           ; $5609: $28 $23
 
@@ -4271,7 +4271,7 @@ jr_020_561C:
 
     ld   a, c                                     ; $5626: $79
     ld   [hl], a                                  ; $5627: $77
-    ld   hl, hScratchA                            ; $5628: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $5628: $21 $D7 $FF
     inc  [hl]                                     ; $562B: $34
     jr   jr_020_5605                              ; $562C: $18 $D7
 
@@ -4301,10 +4301,10 @@ func_020_564B:
     jr   z, jr_020_568A                           ; $564D: $28 $3B
 
     xor  a                                        ; $564F: $AF
-    ldh  [hScratchA], a                           ; $5650: $E0 $D7
+    ldh  [hScratch0], a                           ; $5650: $E0 $D7
 
 jr_020_5652:
-    ldh  a, [hScratchA]                           ; $5652: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5652: $F0 $D7
     cp   $03                                      ; $5654: $FE $03
     jr   z, jr_020_568A                           ; $5656: $28 $32
 
@@ -4318,7 +4318,7 @@ jr_020_5652:
     ld   b, $00                                   ; $5662: $06 $00
 
 jr_020_5664:
-    ldh  a, [hScratchA]                           ; $5664: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5664: $F0 $D7
     sla  a                                        ; $5666: $CB $27
     sla  a                                        ; $5668: $CB $27
     or   b                                        ; $566A: $B0
@@ -4343,7 +4343,7 @@ jr_020_5677:
     ld   a, c                                     ; $5681: $79
     pop  hl                                       ; $5682: $E1
     ld   [hl], a                                  ; $5683: $77
-    ld   hl, hScratchA                            ; $5684: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $5684: $21 $D7 $FF
     inc  [hl]                                     ; $5687: $34
     jr   jr_020_5652                              ; $5688: $18 $C8
 
@@ -5256,7 +5256,7 @@ jr_020_5ADE:
     ld   hl, $5AEE                                ; $5B08: $21 $EE $5A
     add  hl, bc                                   ; $5B0B: $09
     ld   a, [hl]                                  ; $5B0C: $7E
-    ldh  [hScratchA], a                           ; $5B0D: $E0 $D7
+    ldh  [hScratch0], a                           ; $5B0D: $E0 $D7
     ld   a, $9C                                   ; $5B0F: $3E $9C
     ld   [$DC91], a                               ; $5B11: $EA $91 $DC
     ld   [$DC95], a                               ; $5B14: $EA $95 $DC
@@ -5267,7 +5267,7 @@ jr_020_5ADE:
     ld   a, $41                                   ; $5B21: $3E $41
     ld   [$DC93], a                               ; $5B23: $EA $93 $DC
     ld   [$DC97], a                               ; $5B26: $EA $97 $DC
-    ldh  a, [hScratchA]                           ; $5B29: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5B29: $F0 $D7
     ld   [$DC94], a                               ; $5B2B: $EA $94 $DC
     ld   [$DC98], a                               ; $5B2E: $EA $98 $DC
     xor  a                                        ; $5B31: $AF
@@ -5285,7 +5285,7 @@ jr_020_5B3D:
     ret                                           ; $5B48: $C9
 
 func_020_5B49:
-    ldh  a, [hScratchB]                           ; $5B49: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5B49: $F0 $D8
     cp   $09                                      ; $5B4B: $FE $09
     jr   z, jr_020_5B8B                           ; $5B4D: $28 $3C
 
@@ -5407,7 +5407,7 @@ func_020_5BB9:
     ld   a, $81                                   ; $5BD8: $3E $81
     ld   [hl+], a                                 ; $5BDA: $22
     push hl                                       ; $5BDB: $E5
-    ldh  a, [hScratchB]                           ; $5BDC: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5BDC: $F0 $D8
     sla  a                                        ; $5BDE: $CB $27
     ld   c, a                                     ; $5BE0: $4F
     ld   hl, $5C14                                ; $5BE1: $21 $14 $5C
@@ -5579,12 +5579,12 @@ func_020_5C9C:
     ld   hl, wAButtonSlot                         ; $5C9E: $21 $00 $DB
     add  hl, bc                                   ; $5CA1: $09
     ld   a, [hl]                                  ; $5CA2: $7E
-    ldh  [hScratchB], a                           ; $5CA3: $E0 $D8
+    ldh  [hScratch1], a                           ; $5CA3: $E0 $D8
     sla  a                                        ; $5CA5: $CB $27
     ld   e, a                                     ; $5CA7: $5F
     sla  a                                        ; $5CA8: $CB $27
     add  e                                        ; $5CAA: $83
-    ldh  [hScratchA], a                           ; $5CAB: $E0 $D7
+    ldh  [hScratch0], a                           ; $5CAB: $E0 $D7
     ldh  a, [hIsGBC]                              ; $5CAD: $F0 $FE
     and  a                                        ; $5CAF: $A7
     jr   z, jr_020_5CB5                           ; $5CB0: $28 $03
@@ -5615,7 +5615,7 @@ jr_020_5CB5:
     ld   a, $02                                   ; $5CD4: $3E $02
     ld   [hl+], a                                 ; $5CD6: $22
     push hl                                       ; $5CD7: $E5
-    ldh  a, [hScratchA]                           ; $5CD8: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5CD8: $F0 $D7
     ld   c, a                                     ; $5CDA: $4F
     ld   hl, $5C30                                ; $5CDB: $21 $30 $5C
     add  hl, bc                                   ; $5CDE: $09
@@ -5656,7 +5656,7 @@ jr_020_5CB5:
     ld   a, $02                                   ; $5D06: $3E $02
     ld   [hl+], a                                 ; $5D08: $22
     push hl                                       ; $5D09: $E5
-    ldh  a, [hScratchA]                           ; $5D0A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5D0A: $F0 $D7
     ld   c, a                                     ; $5D0C: $4F
     ld   hl, $5C33                                ; $5D0D: $21 $33 $5C
     add  hl, bc                                   ; $5D10: $09
@@ -6926,11 +6926,11 @@ jr_020_636E:
     ld   hl, $633A                                ; $6370: $21 $3A $63
     add  hl, de                                   ; $6373: $19
     ld   a, [hl]                                  ; $6374: $7E
-    ldh  [hScratchA], a                           ; $6375: $E0 $D7
+    ldh  [hScratch0], a                           ; $6375: $E0 $D7
     ld   hl, $6346                                ; $6377: $21 $46 $63
     add  hl, de                                   ; $637A: $19
     ld   a, [hl]                                  ; $637B: $7E
-    ldh  [hScratchB], a                           ; $637C: $E0 $D8
+    ldh  [hScratch1], a                           ; $637C: $E0 $D8
     ld   a, [wActivePowerUp]                      ; $637E: $FA $7C $D4
     dec  a                                        ; $6381: $3D
     jr   nz, jr_020_63BE                          ; $6382: $20 $3A
@@ -6964,11 +6964,11 @@ jr_020_63A2:
 jr_020_63AB:
     ld   a, [wWindowY]                            ; $63AB: $FA $9A $DB
     push hl                                       ; $63AE: $E5
-    ld   hl, hScratchB                            ; $63AF: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $63AF: $21 $D8 $FF
     add  [hl]                                     ; $63B2: $86
     pop  hl                                       ; $63B3: $E1
     ld   [hl+], a                                 ; $63B4: $22
-    ldh  a, [hScratchA]                           ; $63B5: $F0 $D7
+    ldh  a, [hScratch0]                           ; $63B5: $F0 $D7
     ld   [hl+], a                                 ; $63B7: $22
     ld   a, $04                                   ; $63B8: $3E $04
     ld   [hl+], a                                 ; $63BA: $22
@@ -8320,7 +8320,7 @@ jr_020_6A68:
     ld   a, $1F                                   ; $6A74: $3E $1F
 
 jr_020_6A76:
-    ldh  [hScratchA], a                           ; $6A76: $E0 $D7
+    ldh  [hScratch0], a                           ; $6A76: $E0 $D7
     ldh  a, [$FFE5]                               ; $6A78: $F0 $E5
     ld   c, a                                     ; $6A7A: $4F
     ld   a, [hl+]                                 ; $6A7B: $2A
@@ -8339,7 +8339,7 @@ jr_020_6A76:
     ld   a, $3E                                   ; $6A8E: $3E $3E
 
 jr_020_6A90:
-    ldh  [hScratchB], a                           ; $6A90: $E0 $D8
+    ldh  [hScratch1], a                           ; $6A90: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $6A92: $F0 $E6
     ld   c, a                                     ; $6A94: $4F
     ld   a, [hl]                                  ; $6A95: $7E
@@ -8351,17 +8351,17 @@ jr_020_6A90:
     ld   a, $7C                                   ; $6A9D: $3E $7C
 
 jr_020_6A9F:
-    ldh  [hScratchC], a                           ; $6A9F: $E0 $D9
+    ldh  [hScratch2], a                           ; $6A9F: $E0 $D9
     pop  hl                                       ; $6AA1: $E1
-    ldh  a, [hScratchA]                           ; $6AA2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6AA2: $F0 $D7
     ld   b, a                                     ; $6AA4: $47
-    ldh  a, [hScratchB]                           ; $6AA5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6AA5: $F0 $D8
     swap a                                        ; $6AA7: $CB $37
     ld   c, a                                     ; $6AA9: $4F
     and  $E0                                      ; $6AAA: $E6 $E0
     or   b                                        ; $6AAC: $B0
     ld   [hl+], a                                 ; $6AAD: $22
-    ldh  a, [hScratchC]                           ; $6AAE: $F0 $D9
+    ldh  a, [hScratch2]                           ; $6AAE: $F0 $D9
     ld   b, a                                     ; $6AB0: $47
     ld   a, c                                     ; $6AB1: $79
     and  $03                                      ; $6AB2: $E6 $03
@@ -8393,7 +8393,7 @@ func_020_6AC1::
     ldh  [hFreeWarpDataAddress], a                ; $6AD5: $E0 $E6
     ld   hl, $DC10                                ; $6AD7: $21 $10 $DC
     ld   a, $40                                   ; $6ADA: $3E $40
-    ldh  [hScratchD], a                           ; $6ADC: $E0 $DA
+    ldh  [hScratch3], a                           ; $6ADC: $E0 $DA
     ld   a, e                                     ; $6ADE: $7B
     and  $10                                      ; $6ADF: $E6 $10
     jr   z, jr_020_6AF5                           ; $6AE1: $28 $12
@@ -8443,7 +8443,7 @@ jr_020_6B17:
     ld   a, b                                     ; $6B17: $78
 
 jr_020_6B18:
-    ldh  [hScratchA], a                           ; $6B18: $E0 $D7
+    ldh  [hScratch0], a                           ; $6B18: $E0 $D7
     ld   a, e                                     ; $6B1A: $7B
     and  $E0                                      ; $6B1B: $E6 $E0
     swap a                                        ; $6B1D: $CB $37
@@ -8480,7 +8480,7 @@ jr_020_6B43:
     ld   a, b                                     ; $6B43: $78
 
 jr_020_6B44:
-    ldh  [hScratchB], a                           ; $6B44: $E0 $D8
+    ldh  [hScratch1], a                           ; $6B44: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $6B46: $F0 $E6
     ld   c, a                                     ; $6B48: $4F
     ld   a, d                                     ; $6B49: $7A
@@ -8503,25 +8503,25 @@ jr_020_6B5B:
     ld   a, b                                     ; $6B5B: $78
 
 jr_020_6B5C:
-    ldh  [hScratchC], a                           ; $6B5C: $E0 $D9
+    ldh  [hScratch2], a                           ; $6B5C: $E0 $D9
     pop  hl                                       ; $6B5E: $E1
-    ldh  a, [hScratchA]                           ; $6B5F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6B5F: $F0 $D7
     ld   b, a                                     ; $6B61: $47
-    ldh  a, [hScratchB]                           ; $6B62: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6B62: $F0 $D8
     swap a                                        ; $6B64: $CB $37
     ld   c, a                                     ; $6B66: $4F
     and  $E0                                      ; $6B67: $E6 $E0
     or   b                                        ; $6B69: $B0
     ld   [hl+], a                                 ; $6B6A: $22
-    ldh  a, [hScratchC]                           ; $6B6B: $F0 $D9
+    ldh  a, [hScratch2]                           ; $6B6B: $F0 $D9
     ld   b, a                                     ; $6B6D: $47
     ld   a, c                                     ; $6B6E: $79
     and  $03                                      ; $6B6F: $E6 $03
     or   b                                        ; $6B71: $B0
     ld   [hl+], a                                 ; $6B72: $22
-    ldh  a, [hScratchD]                           ; $6B73: $F0 $DA
+    ldh  a, [hScratch3]                           ; $6B73: $F0 $DA
     dec  a                                        ; $6B75: $3D
-    ldh  [hScratchD], a                           ; $6B76: $E0 $DA
+    ldh  [hScratch3], a                           ; $6B76: $E0 $DA
     and  a                                        ; $6B78: $A7
     jp   nz, label_020_6AF5                       ; $6B79: $C2 $F5 $6A
 
@@ -8581,7 +8581,7 @@ jr_020_6BB4:
     pop  bc                                       ; $6BBB: $C1
     ld   hl, $DC10                                ; $6BBC: $21 $10 $DC
     ld   a, $08                                   ; $6BBF: $3E $08
-    ldh  [hScratchA], a                           ; $6BC1: $E0 $D7
+    ldh  [hScratch0], a                           ; $6BC1: $E0 $D7
 
 jr_020_6BC3:
     call func_020_6B86                            ; $6BC3: $CD $86 $6B
@@ -8589,10 +8589,10 @@ jr_020_6BC3:
     call func_020_6B86                            ; $6BC9: $CD $86 $6B
     inc  hl                                       ; $6BCC: $23
     inc  hl                                       ; $6BCD: $23
-    ldh  a, [hScratchA]                           ; $6BCE: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6BCE: $F0 $D7
     dec  a                                        ; $6BD0: $3D
     and  a                                        ; $6BD1: $A7
-    ldh  [hScratchA], a                           ; $6BD2: $E0 $D7
+    ldh  [hScratch0], a                           ; $6BD2: $E0 $D7
     jr   nz, jr_020_6BC3                          ; $6BD4: $20 $ED
 
     ld   a, $01                                   ; $6BD6: $3E $01
@@ -8740,7 +8740,7 @@ jr_020_6C8B:
     ldh  [hFreeWarpDataAddress], a                ; $6C95: $E0 $E6
     ld   hl, $DC10                                ; $6C97: $21 $10 $DC
     ld   a, $40                                   ; $6C9A: $3E $40
-    ldh  [hScratchD], a                           ; $6C9C: $E0 $DA
+    ldh  [hScratch3], a                           ; $6C9C: $E0 $DA
     call func_020_6AF5                            ; $6C9E: $CD $F5 $6A
     ld   a, $01                                   ; $6CA1: $3E $01
 
@@ -8778,7 +8778,7 @@ jr_020_6CB5:
     ldh  [hFreeWarpDataAddress], a                ; $6CD8: $E0 $E6
     ld   hl, $DC10                                ; $6CDA: $21 $10 $DC
     ld   a, $40                                   ; $6CDD: $3E $40
-    ldh  [hScratchD], a                           ; $6CDF: $E0 $DA
+    ldh  [hScratch3], a                           ; $6CDF: $E0 $DA
     ld   a, [wTransitionGfx]                      ; $6CE1: $FA $7F $C1
     cp   $03                                      ; $6CE4: $FE $03
     jr   z, jr_020_6CFA                           ; $6CE6: $28 $12
@@ -8880,7 +8880,7 @@ jr_020_6D68:
     ld   a, $1F                                   ; $6D6F: $3E $1F
 
 jr_020_6D71:
-    ldh  [hScratchA], a                           ; $6D71: $E0 $D7
+    ldh  [hScratch0], a                           ; $6D71: $E0 $D7
     ld   a, [hl+]                                 ; $6D73: $2A
     and  $E0                                      ; $6D74: $E6 $E0
     swap a                                        ; $6D76: $CB $37
@@ -8896,7 +8896,7 @@ jr_020_6D71:
     ld   a, $3E                                   ; $6D85: $3E $3E
 
 jr_020_6D87:
-    ldh  [hScratchB], a                           ; $6D87: $E0 $D8
+    ldh  [hScratch1], a                           ; $6D87: $E0 $D8
     ld   a, [hl]                                  ; $6D89: $7E
     add  $04                                      ; $6D8A: $C6 $04
     and  $7C                                      ; $6D8C: $E6 $7C
@@ -8905,18 +8905,18 @@ jr_020_6D87:
     ld   a, $7C                                   ; $6D90: $3E $7C
 
 jr_020_6D92:
-    ldh  [hScratchC], a                           ; $6D92: $E0 $D9
+    ldh  [hScratch2], a                           ; $6D92: $E0 $D9
     pop  hl                                       ; $6D94: $E1
-    ldh  a, [hScratchA]                           ; $6D95: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6D95: $F0 $D7
     ld   d, a                                     ; $6D97: $57
-    ldh  a, [hScratchB]                           ; $6D98: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6D98: $F0 $D8
     swap a                                        ; $6D9A: $CB $37
     and  $E0                                      ; $6D9C: $E6 $E0
     or   d                                        ; $6D9E: $B2
     ld   [hl+], a                                 ; $6D9F: $22
-    ldh  a, [hScratchC]                           ; $6DA0: $F0 $D9
+    ldh  a, [hScratch2]                           ; $6DA0: $F0 $D9
     ld   d, a                                     ; $6DA2: $57
-    ldh  a, [hScratchB]                           ; $6DA3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6DA3: $F0 $D8
     swap a                                        ; $6DA5: $CB $37
     and  $03                                      ; $6DA7: $E6 $03
     or   d                                        ; $6DA9: $B2
@@ -8998,18 +8998,18 @@ LoadRoomObjectsAttributes::
 
 .jr_020_6E14
     ld   a, $27                                   ; $6E14: $3E $27
-    ldh  [hScratchA], a                           ; $6E16: $E0 $D7
+    ldh  [hScratch0], a                           ; $6E16: $E0 $D7
     jr   .copyAttributes                          ; $6E18: $18 $22
 
 .jr_020_6E1A
     ; Set attributes bank for rooms < $CC
     ld   a, BANK(OverworldObjectsAttributesTableA) ; $6E1A: $3E $26
-    ldh  [hScratchA], a                           ; $6E1C: $E0 $D7
+    ldh  [hScratch0], a                           ; $6E1C: $E0 $D7
     ; If the room id >= $CC…
     ldh  a, [hMapRoom]                            ; $6E1E: $F0 $F6
     cp   $CC                                      ; $6E20: $FE $CC
     jr   c, .bankEnd                              ; $6E22: $38 $06
-    ld   hl, hScratchA                            ; $6E24: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $6E24: $21 $D7 $FF
     ; … use BANK(OverworldObjectsAttributesTableA) + 1 for the attributes bank
     inc  [hl]                                     ; $6E27: $34
     sub  $CC                                      ; $6E28: $D6 $CC
@@ -12757,7 +12757,7 @@ jr_020_7D97:
     xor  a                                        ; $7DA3: $AF
 
 jr_020_7DA4:
-    ldh  [hScratchA], a                           ; $7DA4: $E0 $D7
+    ldh  [hScratch0], a                           ; $7DA4: $E0 $D7
     ldh  a, [$FFE5]                               ; $7DA6: $F0 $E5
     ld   c, a                                     ; $7DA8: $4F
     ld   a, [hl+]                                 ; $7DA9: $2A
@@ -12777,7 +12777,7 @@ jr_020_7DA4:
     xor  a                                        ; $7DBC: $AF
 
 jr_020_7DBD:
-    ldh  [hScratchB], a                           ; $7DBD: $E0 $D8
+    ldh  [hScratch1], a                           ; $7DBD: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $7DBF: $F0 $E6
     ld   c, a                                     ; $7DC1: $4F
     ld   a, [hl]                                  ; $7DC2: $7E
@@ -12790,17 +12790,17 @@ jr_020_7DBD:
     xor  a                                        ; $7DCA: $AF
 
 jr_020_7DCB:
-    ldh  [hScratchC], a                           ; $7DCB: $E0 $D9
+    ldh  [hScratch2], a                           ; $7DCB: $E0 $D9
     pop  hl                                       ; $7DCD: $E1
-    ldh  a, [hScratchA]                           ; $7DCE: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7DCE: $F0 $D7
     ld   b, a                                     ; $7DD0: $47
-    ldh  a, [hScratchB]                           ; $7DD1: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7DD1: $F0 $D8
     swap a                                        ; $7DD3: $CB $37
     ld   c, a                                     ; $7DD5: $4F
     and  $E0                                      ; $7DD6: $E6 $E0
     or   b                                        ; $7DD8: $B0
     ld   [hl+], a                                 ; $7DD9: $22
-    ldh  a, [hScratchC]                           ; $7DDA: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7DDA: $F0 $D9
     ld   b, a                                     ; $7DDC: $47
     ld   a, c                                     ; $7DDD: $79
     and  $03                                      ; $7DDE: $E6 $03

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -55,7 +55,7 @@ jr_017_407D:
     ld   a, [hl]                                  ; $408D: $7E
     and  c                                        ; $408E: $A1
     ld   [hl], a                                  ; $408F: $77
-    ldh  a, [hScratchC]                           ; $4090: $F0 $D9
+    ldh  a, [hScratch2]                           ; $4090: $F0 $D9
     inc  a                                        ; $4092: $3C
     cp   $0D                                      ; $4093: $FE $0D
     jr   nz, jr_017_407D                          ; $4095: $20 $E6
@@ -2896,7 +2896,7 @@ CreditsLoadBGMap:
     ld   b, a                                     ; $5B25: $47
     ; Return bank to restore
     ld   a, BANK(CreditsLoadBGMap)                   ; $5B26: $3E $17
-    ldh  [hScratchK], a                           ; $5B28: $E0 $E6
+    ldh  [hScratchF], a                           ; $5B28: $E0 $E6
     ld   h, [hl]                                  ; $5B2A: $66
     ld   l, b                                     ; $5B2B: $68
     ; Source bank

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -40,7 +40,7 @@ Func_017_4062::
     ld   d, a                                     ; $407C: $57
 
 jr_017_407D:
-    ldh  [$FFD9], a                               ; $407D: $E0 $D9
+    ldh  [hScratch2], a                               ; $407D: $E0 $D9
     sla  a                                        ; $407F: $CB $27
     ld   e, a                                     ; $4081: $5F
     ld   hl, Data_017_4048                        ; $4082: $21 $48 $40
@@ -377,18 +377,18 @@ jr_017_46C9:
     ld   a, $18                                   ; $46D2: $3E $18
 
 jr_017_46D4:
-    ldh  [$FFD7], a                               ; $46D4: $E0 $D7
+    ldh  [hScratch0], a                               ; $46D4: $E0 $D7
     ld   c, $09                                   ; $46D6: $0E $09
 
 jr_017_46D8:
     ld   a, $40                                   ; $46D8: $3E $40
     ld   [de], a                                  ; $46DA: $12
     inc  de                                       ; $46DB: $13
-    ldh  a, [$FFD7]                               ; $46DC: $F0 $D7
+    ldh  a, [hScratch0]                               ; $46DC: $F0 $D7
     ld   [de], a                                  ; $46DE: $12
     inc  de                                       ; $46DF: $13
     add  $10                                      ; $46E0: $C6 $10
-    ldh  [$FFD7], a                               ; $46E2: $E0 $D7
+    ldh  [hScratch0], a                               ; $46E2: $E0 $D7
     ld   a, [hl+]                                 ; $46E4: $2A
     inc  hl                                       ; $46E5: $23
     push hl                                       ; $46E6: $E5
@@ -471,7 +471,7 @@ func_017_4784:
     add  hl, de                                   ; $47A1: $19
     push hl                                       ; $47A2: $E5
     xor  a                                        ; $47A3: $AF
-    ldh  [$FFD8], a                               ; $47A4: $E0 $D8
+    ldh  [hScratch1], a                               ; $47A4: $E0 $D8
     ld   de, $C054                                ; $47A6: $11 $54 $C0
     ldh  a, [$FFFE]                               ; $47A9: $F0 $FE
     and  a                                        ; $47AB: $A7
@@ -482,7 +482,7 @@ func_017_4784:
 jr_017_47B1:
     ld   a, $55                                   ; $47B1: $3E $55
     call func_017_47C8                            ; $47B3: $CD $C8 $47
-    ld   hl, $FFD8                                ; $47B6: $21 $D8 $FF
+    ld   hl, hScratch1                                ; $47B6: $21 $D8 $FF
     inc  [hl]                                     ; $47B9: $34
     pop  hl                                       ; $47BA: $E1
     ld   de, $C078                                ; $47BB: $11 $78 $C0
@@ -515,17 +515,17 @@ func_017_47C8:
     ld   a, $18                                   ; $47E4: $3E $18
 
 jr_017_47E6:
-    ldh  [$FFD7], a                               ; $47E6: $E0 $D7
+    ldh  [hScratch0], a                               ; $47E6: $E0 $D7
 
 jr_017_47E8:
     ldh  a, [$FFE9]                               ; $47E8: $F0 $E9
     ld   [de], a                                  ; $47EA: $12
     inc  de                                       ; $47EB: $13
-    ldh  a, [$FFD7]                               ; $47EC: $F0 $D7
+    ldh  a, [hScratch0]                               ; $47EC: $F0 $D7
     ld   [de], a                                  ; $47EE: $12
     inc  de                                       ; $47EF: $13
     add  b                                        ; $47F0: $80
-    ldh  [$FFD7], a                               ; $47F1: $E0 $D7
+    ldh  [hScratch0], a                               ; $47F1: $E0 $D7
     ld   a, [$D011]                               ; $47F3: $FA $11 $D0
     cp   $25                                      ; $47F6: $FE $25
     ld   a, [hl+]                                 ; $47F8: $2A
@@ -561,7 +561,7 @@ jr_017_4816:
 
 jr_017_4818:
     sla  a                                        ; $4818: $CB $27
-    ld   hl, $FFD8                                ; $481A: $21 $D8 $FF
+    ld   hl, hScratch1                                ; $481A: $21 $D8 $FF
     add  [hl]                                     ; $481D: $86
     ld   e, a                                     ; $481E: $5F
     ld   d, $00                                   ; $481F: $16 $00
@@ -710,7 +710,7 @@ ApplyWindFishVfx::
     inc  a                                        ; $48FC: $3C
     ld   [$C180], a                               ; $48FD: $EA $80 $C1
     ld   a, [$D005]                               ; $4900: $FA $05 $D0
-    ldh  [$FFD8], a                               ; $4903: $E0 $D8
+    ldh  [hScratch1], a                               ; $4903: $E0 $D8
     ld   hl, $C17C                                ; $4905: $21 $7C $C1
     xor  a                                        ; $4908: $AF
     ld   [hl+], a                                 ; $4909: $22
@@ -748,7 +748,7 @@ jr_017_4919:
     ld   a, [$C17C]                               ; $493E: $FA $7C $C1
     add  [hl]                                     ; $4941: $86
     and  $1F                                      ; $4942: $E6 $1F
-    ld   hl, $FFD8                                ; $4944: $21 $D8 $FF
+    ld   hl, hScratch1                                ; $4944: $21 $D8 $FF
     or   [hl]                                     ; $4947: $B6
     ld   e, a                                     ; $4948: $5F
     ld   hl, Data_017_49B7                        ; $4949: $21 $B7 $49
@@ -798,7 +798,7 @@ jr_017_496C:
     ld   a, [$C17C]                               ; $4991: $FA $7C $C1
     add  [hl]                                     ; $4994: $86
     and  $1F                                      ; $4995: $E6 $1F
-    ld   hl, $FFD8                                ; $4997: $21 $D8 $FF
+    ld   hl, hScratch1                                ; $4997: $21 $D8 $FF
     or   [hl]                                     ; $499A: $B6
     ld   e, a                                     ; $499B: $5F
     ld   hl, Data_017_49B7                        ; $499C: $21 $B7 $49
@@ -6113,7 +6113,7 @@ jr_017_76BF:
     ld   d, a                                     ; $76E5: $57
     sra  a                                        ; $76E6: $CB $2F
     add  d                                        ; $76E8: $82
-    ldh  [$FFD7], a                               ; $76E9: $E0 $D7
+    ldh  [hScratch0], a                               ; $76E9: $E0 $D7
     ldh  a, [hFrameCounter]                               ; $76EB: $F0 $E7
     and  $03                                      ; $76ED: $E6 $03
     jr   nz, jr_017_76FD                          ; $76EF: $20 $0C
@@ -6136,7 +6136,7 @@ jr_017_76FD:
     add  hl, de                                   ; $7705: $19
     ldh  a, [$FFEC]                               ; $7706: $F0 $EC
     add  [hl]                                     ; $7708: $86
-    ld   hl, $FFD7                                ; $7709: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $7709: $21 $D7 $FF
     sub  [hl]                                     ; $770C: $96
     ldh  [$FFEC], a                               ; $770D: $E0 $EC
     cp   $A8                                      ; $770F: $FE $A8
@@ -6623,7 +6623,7 @@ Func_017_79A4::
     add  hl, bc                                   ; $79AA: $09
     ld   a, [hl]                                  ; $79AB: $7E
     add  $50                                      ; $79AC: $C6 $50
-    ldh  [$FFD7], a                               ; $79AE: $E0 $D7
+    ldh  [hScratch0], a                               ; $79AE: $E0 $D7
     call func_017_7A01                            ; $79B0: $CD $01 $7A
     ld   de, Data_017_7987                        ; $79B3: $11 $87 $79
     call func_017_7A29                            ; $79B6: $CD $29 $7A
@@ -6727,7 +6727,7 @@ jr_017_7A1B:
 func_017_7A29:
     push bc                                       ; $7A29: $C5
     push de                                       ; $7A2A: $D5
-    ldh  a, [$FFD7]                               ; $7A2B: $F0 $D7
+    ldh  a, [hScratch0]                               ; $7A2B: $F0 $D7
     ld   e, a                                     ; $7A2D: $5F
     ld   d, b                                     ; $7A2E: $50
     ld   hl, $C000                                ; $7A2F: $21 $00 $C0
@@ -7317,7 +7317,7 @@ jr_017_7D4D:
     inc  de                                       ; $7D52: $13
     ld   [hl+], a                                 ; $7D53: $22
     push hl                                       ; $7D54: $E5
-    ld   hl, $FFD7                                ; $7D55: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $7D55: $21 $D7 $FF
     ld   a, [$DC0F]                               ; $7D58: $FA $0F $DC
     and  a                                        ; $7D5B: $A7
     jr   z, jr_017_7D5F                           ; $7D5C: $28 $01
@@ -7341,7 +7341,7 @@ jr_017_7D5F:
     inc  de                                       ; $7D6F: $13
     ld   [hl+], a                                 ; $7D70: $22
     push hl                                       ; $7D71: $E5
-    ld   hl, $FFD7                                ; $7D72: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $7D72: $21 $D7 $FF
     ld   a, [de]                                  ; $7D75: $1A
     or   [hl]                                     ; $7D76: $B6
     pop  hl                                       ; $7D77: $E1
@@ -7544,7 +7544,7 @@ jr_017_7E88:
     ldh  [$FFE6], a                               ; $7E92: $E0 $E6
     ld   hl, $DC10                                ; $7E94: $21 $10 $DC
     ld   a, $40                                   ; $7E97: $3E $40
-    ldh  [$FFDA], a                               ; $7E99: $E0 $DA
+    ldh  [hScratch3], a                               ; $7E99: $E0 $DA
     call func_017_7EA4                            ; $7E9B: $CD $A4 $7E
     ld   a, $01                                   ; $7E9E: $3E $01
 
@@ -7586,7 +7586,7 @@ jr_017_7EC6:
     ld   a, b                                     ; $7EC6: $78
 
 jr_017_7EC7:
-    ldh  [$FFD7], a                               ; $7EC7: $E0 $D7
+    ldh  [hScratch0], a                               ; $7EC7: $E0 $D7
     ld   a, e                                     ; $7EC9: $7B
     and  $E0                                      ; $7ECA: $E6 $E0
     swap a                                        ; $7ECC: $CB $37
@@ -7623,7 +7623,7 @@ jr_017_7EF2:
     ld   a, b                                     ; $7EF2: $78
 
 jr_017_7EF3:
-    ldh  [$FFD8], a                               ; $7EF3: $E0 $D8
+    ldh  [hScratch1], a                               ; $7EF3: $E0 $D8
     ldh  a, [$FFE6]                               ; $7EF5: $F0 $E6
     ld   c, a                                     ; $7EF7: $4F
     ld   a, d                                     ; $7EF8: $7A
@@ -7646,25 +7646,25 @@ jr_017_7F0A:
     ld   a, b                                     ; $7F0A: $78
 
 jr_017_7F0B:
-    ldh  [$FFD9], a                               ; $7F0B: $E0 $D9
+    ldh  [hScratch2], a                               ; $7F0B: $E0 $D9
     pop  hl                                       ; $7F0D: $E1
-    ldh  a, [$FFD7]                               ; $7F0E: $F0 $D7
+    ldh  a, [hScratch0]                               ; $7F0E: $F0 $D7
     ld   b, a                                     ; $7F10: $47
-    ldh  a, [$FFD8]                               ; $7F11: $F0 $D8
+    ldh  a, [hScratch1]                               ; $7F11: $F0 $D8
     swap a                                        ; $7F13: $CB $37
     ld   c, a                                     ; $7F15: $4F
     and  $E0                                      ; $7F16: $E6 $E0
     or   b                                        ; $7F18: $B0
     ld   [hl+], a                                 ; $7F19: $22
-    ldh  a, [$FFD9]                               ; $7F1A: $F0 $D9
+    ldh  a, [hScratch2]                               ; $7F1A: $F0 $D9
     ld   b, a                                     ; $7F1C: $47
     ld   a, c                                     ; $7F1D: $79
     and  $03                                      ; $7F1E: $E6 $03
     or   b                                        ; $7F20: $B0
     ld   [hl+], a                                 ; $7F21: $22
-    ldh  a, [$FFDA]                               ; $7F22: $F0 $DA
+    ldh  a, [hScratch3]                               ; $7F22: $F0 $DA
     dec  a                                        ; $7F24: $3D
-    ldh  [$FFDA], a                               ; $7F25: $E0 $DA
+    ldh  [hScratch3], a                               ; $7F25: $E0 $DA
     and  a                                        ; $7F27: $A7
     jp   nz, label_017_7EA4                       ; $7F28: $C2 $A4 $7E
 
@@ -7713,7 +7713,7 @@ jr_017_7F57:
     ld   a, $1F                                   ; $7F63: $3E $1F
 
 jr_017_7F65:
-    ldh  [$FFD7], a                               ; $7F65: $E0 $D7
+    ldh  [hScratch0], a                               ; $7F65: $E0 $D7
     ldh  a, [$FFE5]                               ; $7F67: $F0 $E5
     ld   c, a                                     ; $7F69: $4F
     ld   a, [hl+]                                 ; $7F6A: $2A
@@ -7732,7 +7732,7 @@ jr_017_7F65:
     ld   a, $3E                                   ; $7F7D: $3E $3E
 
 jr_017_7F7F:
-    ldh  [$FFD8], a                               ; $7F7F: $E0 $D8
+    ldh  [hScratch1], a                               ; $7F7F: $E0 $D8
     ldh  a, [$FFE6]                               ; $7F81: $F0 $E6
     ld   c, a                                     ; $7F83: $4F
     ld   a, [hl]                                  ; $7F84: $7E
@@ -7744,17 +7744,17 @@ jr_017_7F7F:
     ld   a, $7C                                   ; $7F8C: $3E $7C
 
 jr_017_7F8E:
-    ldh  [$FFD9], a                               ; $7F8E: $E0 $D9
+    ldh  [hScratch2], a                               ; $7F8E: $E0 $D9
     pop  hl                                       ; $7F90: $E1
-    ldh  a, [$FFD7]                               ; $7F91: $F0 $D7
+    ldh  a, [hScratch0]                               ; $7F91: $F0 $D7
     ld   b, a                                     ; $7F93: $47
-    ldh  a, [$FFD8]                               ; $7F94: $F0 $D8
+    ldh  a, [hScratch1]                               ; $7F94: $F0 $D8
     swap a                                        ; $7F96: $CB $37
     ld   c, a                                     ; $7F98: $4F
     and  $E0                                      ; $7F99: $E6 $E0
     or   b                                        ; $7F9B: $B0
     ld   [hl+], a                                 ; $7F9C: $22
-    ldh  a, [$FFD9]                               ; $7F9D: $F0 $D9
+    ldh  a, [hScratch2]                               ; $7F9D: $F0 $D9
     ld   b, a                                     ; $7F9F: $47
     ld   a, c                                     ; $7FA0: $79
     and  $03                                      ; $7FA1: $E6 $03

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -897,10 +897,10 @@ func_015_451D:
     ld   a, $0E                                   ; $451D: $3E $0E
     ldh  [hJingle], a                             ; $451F: $E0 $F2
     ldh  a, [wActiveEntityPosX]                   ; $4521: $F0 $EE
-    ldh  [hScratchA], a                           ; $4523: $E0 $D7
+    ldh  [hScratch0], a                           ; $4523: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4525: $F0 $EC
     add  $00                                      ; $4527: $C6 $00
-    ldh  [hScratchB], a                           ; $4529: $E0 $D8
+    ldh  [hScratch1], a                           ; $4529: $E0 $D8
     ld   a, $01                                   ; $452B: $3E $01
     jp   label_CC7                                ; $452D: $C3 $C7 $0C
 
@@ -1064,9 +1064,9 @@ jr_015_460B:
 
     ld   a, $50                                   ; $460D: $3E $50
     dec  a                                        ; $460F: $3D
-    ldh  [hScratchA], a                           ; $4610: $E0 $D7
+    ldh  [hScratch0], a                           ; $4610: $E0 $D7
     ld   a, $30                                   ; $4612: $3E $30
-    ldh  [hScratchB], a                           ; $4614: $E0 $D8
+    ldh  [hScratch1], a                           ; $4614: $E0 $D8
     ld   a, $02                                   ; $4616: $3E $02
     call label_CC7                                ; $4618: $CD $C7 $0C
     ld   a, $2F                                   ; $461B: $3E $2F
@@ -1314,18 +1314,18 @@ jr_015_475C:
     ld   a, $0A                                   ; $4790: $3E $0A
     ldh  [hNoiseSfx], a                           ; $4792: $E0 $F4
     push bc                                       ; $4794: $C5
-    ldh  a, [hScratchC]                           ; $4795: $F0 $D9
+    ldh  a, [hScratch2]                           ; $4795: $F0 $D9
     ld   c, a                                     ; $4797: $4F
     ld   hl, $4776                                ; $4798: $21 $76 $47
     add  hl, bc                                   ; $479B: $09
-    ldh  a, [hScratchA]                           ; $479C: $F0 $D7
+    ldh  a, [hScratch0]                           ; $479C: $F0 $D7
     add  [hl]                                     ; $479E: $86
     ld   hl, wEntity0PosX                         ; $479F: $21 $00 $C2
     add  hl, de                                   ; $47A2: $19
     ld   [hl], a                                  ; $47A3: $77
     ld   hl, $4778                                ; $47A4: $21 $78 $47
     add  hl, bc                                   ; $47A7: $09
-    ldh  a, [hScratchB]                           ; $47A8: $F0 $D8
+    ldh  a, [hScratch1]                           ; $47A8: $F0 $D8
     add  [hl]                                     ; $47AA: $86
     ld   hl, wEntity0PosY                         ; $47AB: $21 $10 $C2
     add  hl, de                                   ; $47AE: $19
@@ -1342,7 +1342,7 @@ jr_015_475C:
     ld   hl, wEntity0SpeedY                       ; $47BF: $21 $50 $C2
     add  hl, de                                   ; $47C2: $19
     ld   [hl], a                                  ; $47C3: $77
-    ldh  a, [hScratchC]                           ; $47C4: $F0 $D9
+    ldh  a, [hScratch2]                           ; $47C4: $F0 $D9
     ld   hl, wEntitiesUnknownTableG               ; $47C6: $21 $B0 $C3
     add  hl, de                                   ; $47C9: $19
     ld   [hl], a                                  ; $47CA: $77
@@ -2150,11 +2150,11 @@ jr_015_4BD0:
     call label_3B86                               ; $4C10: $CD $86 $3B
     jr   c, jr_015_4C49                           ; $4C13: $38 $34
 
-    ldh  a, [hScratchA]                           ; $4C15: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4C15: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4C17: $21 $00 $C2
     add  hl, de                                   ; $4C1A: $19
     ld   [hl], a                                  ; $4C1B: $77
-    ldh  a, [hScratchB]                           ; $4C1C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4C1C: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4C1E: $21 $10 $C2
     add  hl, de                                   ; $4C21: $19
     ld   [hl], a                                  ; $4C22: $77
@@ -2166,13 +2166,13 @@ jr_015_4BD0:
     ld   b, d                                     ; $4C2A: $42
     ld   a, $20                                   ; $4C2B: $3E $20
     call label_3BB5                               ; $4C2D: $CD $B5 $3B
-    ldh  a, [hScratchB]                           ; $4C30: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4C30: $F0 $D8
     cpl                                           ; $4C32: $2F
     inc  a                                        ; $4C33: $3C
     ld   hl, wEntity0SpeedX                       ; $4C34: $21 $40 $C2
     add  hl, bc                                   ; $4C37: $09
     ld   [hl], a                                  ; $4C38: $77
-    ldh  a, [hScratchA]                           ; $4C39: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4C39: $F0 $D7
     cpl                                           ; $4C3B: $2F
     inc  a                                        ; $4C3C: $3C
     ld   hl, wEntity0SpeedY                       ; $4C3D: $21 $50 $C2
@@ -2328,9 +2328,9 @@ func_015_4D0F:
     jr   c, jr_015_4D39                           ; $4D21: $38 $16
 
     ldh  a, [wActiveEntityPosX]                   ; $4D23: $F0 $EE
-    ldh  [hScratchA], a                           ; $4D25: $E0 $D7
+    ldh  [hScratch0], a                           ; $4D25: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4D27: $F0 $EC
-    ldh  [hScratchB], a                           ; $4D29: $E0 $D8
+    ldh  [hScratch1], a                           ; $4D29: $E0 $D8
     ld   a, $02                                   ; $4D2B: $3E $02
     call label_CC7                                ; $4D2D: $CD $C7 $0C
     ld   a, $2F                                   ; $4D30: $3E $2F
@@ -2385,11 +2385,11 @@ jr_015_4D5B:
 
     ld   a, $12                                   ; $4D77: $3E $12
     ldh  [hNoiseSfx], a                           ; $4D79: $E0 $F4
-    ldh  a, [hScratchA]                           ; $4D7B: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4D7B: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4D7D: $21 $00 $C2
     add  hl, de                                   ; $4D80: $19
     ld   [hl], a                                  ; $4D81: $77
-    ldh  a, [hScratchB]                           ; $4D82: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4D82: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4D84: $21 $10 $C2
     add  hl, de                                   ; $4D87: $19
     add  $04                                      ; $4D88: $C6 $04
@@ -2462,7 +2462,7 @@ label_015_4DB5:
     ld   [$DBC7], a                               ; $4DE6: $EA $C7 $DB
     ld   a, $30                                   ; $4DE9: $3E $30
     call label_3BB5                               ; $4DEB: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $4DEE: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4DEE: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $4DF0: $E0 $9B
 
 jr_015_4DF2:
@@ -2490,7 +2490,7 @@ jr_015_4DFB:
     ld   [hl], a                                  ; $4E12: $77
     ld   hl, $4DB1                                ; $4E13: $21 $B1 $4D
     add  hl, bc                                   ; $4E16: $09
-    ldh  a, [hScratchA]                           ; $4E17: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4E17: $F0 $D7
     add  [hl]                                     ; $4E19: $86
     ld   hl, wEntity0PosX                         ; $4E1A: $21 $00 $C2
     add  hl, de                                   ; $4E1D: $19
@@ -2501,7 +2501,7 @@ jr_015_4DFB:
     ld   hl, wEntity0SpeedX                       ; $4E24: $21 $40 $C2
     add  hl, de                                   ; $4E27: $19
     ld   [hl], a                                  ; $4E28: $77
-    ldh  a, [hScratchB]                           ; $4E29: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4E29: $F0 $D8
     add  $00                                      ; $4E2B: $C6 $00
     ld   hl, wEntity0PosY                         ; $4E2D: $21 $10 $C2
     add  hl, de                                   ; $4E30: $19
@@ -2603,9 +2603,9 @@ label_015_4E62:
 
 label_015_4ECB:
     ldh  a, [wActiveEntityPosX]                   ; $4ECB: $F0 $EE
-    ldh  [hScratchA], a                           ; $4ECD: $E0 $D7
+    ldh  [hScratch0], a                           ; $4ECD: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4ECF: $F0 $EC
-    ldh  [hScratchB], a                           ; $4ED1: $E0 $D8
+    ldh  [hScratch1], a                           ; $4ED1: $E0 $D8
     ld   a, $07                                   ; $4ED3: $3E $07
     ldh  [hJingle], a                             ; $4ED5: $E0 $F2
     ld   a, $05                                   ; $4ED7: $3E $05
@@ -2659,15 +2659,15 @@ jr_015_4F02:
     add  hl, de                                   ; $4F28: $19
     set  1, [hl]                                  ; $4F29: $CB $CE
     set  4, [hl]                                  ; $4F2B: $CB $E6
-    ldh  a, [hScratchA]                           ; $4F2D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4F2D: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4F2F: $21 $00 $C2
     add  hl, de                                   ; $4F32: $19
     ld   [hl], a                                  ; $4F33: $77
-    ldh  a, [hScratchB]                           ; $4F34: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4F34: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4F36: $21 $10 $C2
     add  hl, de                                   ; $4F39: $19
     ld   [hl], a                                  ; $4F3A: $77
-    ldh  a, [hScratchD]                           ; $4F3B: $F0 $DA
+    ldh  a, [hScratch3]                           ; $4F3B: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $4F3D: $21 $10 $C3
     add  hl, de                                   ; $4F40: $19
     ld   [hl], a                                  ; $4F41: $77
@@ -2720,13 +2720,13 @@ jr_015_4F50:
     ldh  [hJingle], a                             ; $4F8E: $E0 $F2
     ld   a, $12                                   ; $4F90: $3E $12
     call label_3BB5                               ; $4F92: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $4F95: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4F95: $F0 $D7
     cpl                                           ; $4F97: $2F
     inc  a                                        ; $4F98: $3C
     ld   hl, wEntity0SpeedY                       ; $4F99: $21 $50 $C2
     add  hl, bc                                   ; $4F9C: $09
     ld   [hl], a                                  ; $4F9D: $77
-    ldh  a, [hScratchB]                           ; $4F9E: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4F9E: $F0 $D8
     cpl                                           ; $4FA0: $2F
     inc  a                                        ; $4FA1: $3C
     ld   hl, wEntity0SpeedX                       ; $4FA2: $21 $40 $C2
@@ -3403,21 +3403,21 @@ jr_015_5384:
     push bc                                       ; $538C: $C5
     ldh  a, [hFFE8]                               ; $538D: $F0 $E8
     ld   c, a                                     ; $538F: $4F
-    ldh  a, [hScratchA]                           ; $5390: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5390: $F0 $D7
     ld   hl, $5356                                ; $5392: $21 $56 $53
     add  hl, bc                                   ; $5395: $09
     add  [hl]                                     ; $5396: $86
     ld   hl, wEntity0PosX                         ; $5397: $21 $00 $C2
     add  hl, de                                   ; $539A: $19
     ld   [hl], a                                  ; $539B: $77
-    ldh  a, [hScratchB]                           ; $539C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $539C: $F0 $D8
     ld   hl, $535E                                ; $539E: $21 $5E $53
     add  hl, bc                                   ; $53A1: $09
     add  [hl]                                     ; $53A2: $86
     ld   hl, wEntity0PosY                         ; $53A3: $21 $10 $C2
     add  hl, de                                   ; $53A6: $19
     ld   [hl], a                                  ; $53A7: $77
-    ldh  a, [hScratchD]                           ; $53A8: $F0 $DA
+    ldh  a, [hScratch3]                           ; $53A8: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $53AA: $21 $10 $C3
     add  hl, de                                   ; $53AD: $19
     ld   [hl], a                                  ; $53AE: $77
@@ -4305,14 +4305,14 @@ label_015_582B:
     ld   c, a                                     ; $586C: $4F
     ld   hl, $584C                                ; $586D: $21 $4C $58
     add  hl, bc                                   ; $5870: $09
-    ldh  a, [hScratchA]                           ; $5871: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5871: $F0 $D7
     add  [hl]                                     ; $5873: $86
     ld   hl, wEntity0PosX                         ; $5874: $21 $00 $C2
     add  hl, de                                   ; $5877: $19
     ld   [hl], a                                  ; $5878: $77
     ld   hl, $5850                                ; $5879: $21 $50 $58
     add  hl, bc                                   ; $587C: $09
-    ldh  a, [hScratchB]                           ; $587D: $F0 $D8
+    ldh  a, [hScratch1]                           ; $587D: $F0 $D8
     add  [hl]                                     ; $587F: $86
     ld   hl, wEntity0PosY                         ; $5880: $21 $10 $C2
     add  hl, de                                   ; $5883: $19
@@ -5426,11 +5426,11 @@ func_015_5E38:
     ld   hl, $C440                                ; $5E54: $21 $40 $C4
     add  hl, de                                   ; $5E57: $19
     inc  [hl]                                     ; $5E58: $34
-    ldh  a, [hScratchA]                           ; $5E59: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5E59: $F0 $D7
     ld   hl, wEntity0PosX                         ; $5E5B: $21 $00 $C2
     add  hl, de                                   ; $5E5E: $19
     ld   [hl], a                                  ; $5E5F: $77
-    ldh  a, [hScratchB]                           ; $5E60: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5E60: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5E62: $21 $10 $C2
     add  hl, de                                   ; $5E65: $19
     ld   [hl], a                                  ; $5E66: $77
@@ -5460,14 +5460,14 @@ jr_015_5E84:
     ldh  [hNoiseSfx], a                           ; $5E87: $E0 $F4
     ld   a, $18                                   ; $5E89: $3E $18
     call label_3BB5                               ; $5E8B: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $5E8E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5E8E: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $5E90: $E0 $9B
     cpl                                           ; $5E92: $2F
     inc  a                                        ; $5E93: $3C
     ld   hl, wEntity0SpeedY                       ; $5E94: $21 $50 $C2
     add  hl, bc                                   ; $5E97: $09
     ld   [hl], a                                  ; $5E98: $77
-    ldh  a, [hScratchB]                           ; $5E99: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5E99: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $5E9B: $E0 $9A
     cpl                                           ; $5E9D: $2F
     inc  a                                        ; $5E9E: $3C
@@ -5590,11 +5590,11 @@ jr_015_5F4C:
     call label_3B86                               ; $5F50: $CD $86 $3B
     jr   c, jr_015_5F96                           ; $5F53: $38 $41
 
-    ldh  a, [hScratchA]                           ; $5F55: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5F55: $F0 $D7
     ld   hl, wEntity0PosX                         ; $5F57: $21 $00 $C2
     add  hl, de                                   ; $5F5A: $19
     ld   [hl], a                                  ; $5F5B: $77
-    ldh  a, [hScratchB]                           ; $5F5C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5F5C: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5F5E: $21 $10 $C2
     add  hl, de                                   ; $5F61: $19
     ld   [hl], a                                  ; $5F62: $77
@@ -5602,11 +5602,11 @@ jr_015_5F4C:
     add  hl, de                                   ; $5F66: $19
     inc  [hl]                                     ; $5F67: $34
     push bc                                       ; $5F68: $C5
-    ldh  a, [hScratchA]                           ; $5F69: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5F69: $F0 $D7
     ld   hl, wEntity0PosX                         ; $5F6B: $21 $00 $C2
     add  hl, de                                   ; $5F6E: $19
     ld   [hl], a                                  ; $5F6F: $77
-    ldh  a, [hScratchB]                           ; $5F70: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5F70: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5F72: $21 $10 $C2
     add  hl, de                                   ; $5F75: $19
     ld   [hl], a                                  ; $5F76: $77
@@ -6154,8 +6154,8 @@ jr_015_623A:
     ld   hl, $C3D0                                ; $6268: $21 $D0 $C3
     add  hl, bc                                   ; $626B: $09
     ld   a, [hl]                                  ; $626C: $7E
-    ldh  [hScratchA], a                           ; $626D: $E0 $D7
-    ldh  a, [hScratchA]                           ; $626F: $F0 $D7
+    ldh  [hScratch0], a                           ; $626D: $E0 $D7
+    ldh  a, [hScratch0]                           ; $626F: $F0 $D7
     sub  $0C                                      ; $6271: $D6 $0C
     and  $7F                                      ; $6273: $E6 $7F
     ld   e, a                                     ; $6275: $5F
@@ -6172,7 +6172,7 @@ jr_015_623A:
     ldh  [hActiveEntityUnknownG], a               ; $6287: $E0 $F1
     ld   de, $6235                                ; $6289: $11 $35 $62
     call RenderAnimatedActiveEntity                               ; $628C: $CD $C0 $3B
-    ldh  a, [hScratchA]                           ; $628F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $628F: $F0 $D7
     sub  $18                                      ; $6291: $D6 $18
     and  $7F                                      ; $6293: $E6 $7F
     ld   e, a                                     ; $6295: $5F
@@ -6191,7 +6191,7 @@ jr_015_623A:
 
 jr_015_62AC:
     call RenderAnimatedActiveEntity                               ; $62AC: $CD $C0 $3B
-    ldh  a, [hScratchA]                           ; $62AF: $F0 $D7
+    ldh  a, [hScratch0]                           ; $62AF: $F0 $D7
     sub  $24                                      ; $62B1: $D6 $24
     and  $7F                                      ; $62B3: $E6 $7F
     ld   e, a                                     ; $62B5: $5F
@@ -6208,7 +6208,7 @@ jr_015_62AC:
     ldh  [hActiveEntityUnknownG], a               ; $62C7: $E0 $F1
     ld   de, $6235                                ; $62C9: $11 $35 $62
     call RenderAnimatedActiveEntity                               ; $62CC: $CD $C0 $3B
-    ldh  a, [hScratchA]                           ; $62CF: $F0 $D7
+    ldh  a, [hScratch0]                           ; $62CF: $F0 $D7
     sub  $2E                                      ; $62D1: $D6 $2E
     and  $7F                                      ; $62D3: $E6 $7F
     ld   e, a                                     ; $62D5: $5F
@@ -6910,7 +6910,7 @@ jr_015_66A0:
     add  hl, bc                                   ; $66A4: $09
     ld   a, [$D225]                               ; $66A5: $FA $25 $D2
     add  [hl]                                     ; $66A8: $86
-    ld   hl, hScratchA                            ; $66A9: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $66A9: $21 $D7 $FF
     add  [hl]                                     ; $66AC: $86
     ld   hl, wEntity0PosX                         ; $66AD: $21 $00 $C2
     add  hl, de                                   ; $66B0: $19
@@ -6919,7 +6919,7 @@ jr_015_66A0:
     add  hl, bc                                   ; $66B5: $09
     ld   a, [hl]                                  ; $66B6: $7E
     sub  $0C                                      ; $66B7: $D6 $0C
-    ld   hl, hScratchB                            ; $66B9: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $66B9: $21 $D8 $FF
     add  [hl]                                     ; $66BC: $86
     ld   hl, wEntity0PosY                         ; $66BD: $21 $10 $C2
     add  hl, de                                   ; $66C0: $19
@@ -6974,7 +6974,7 @@ jr_015_66D6:
     ld   hl, wEntitiesUnknownTableB               ; $6707: $21 $B0 $C2
     add  hl, de                                   ; $670A: $19
     inc  [hl]                                     ; $670B: $34
-    ldh  a, [hScratchB]                           ; $670C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $670C: $F0 $D8
     sub  $10                                      ; $670E: $D6 $10
     ld   hl, wEntity0PosY                         ; $6710: $21 $10 $C2
     add  hl, de                                   ; $6713: $19
@@ -6990,7 +6990,7 @@ jr_015_66D6:
     ld   a, $F8                                   ; $6722: $3E $F8
 
 jr_015_6724:
-    ld   hl, hScratchA                            ; $6724: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $6724: $21 $D7 $FF
     add  [hl]                                     ; $6727: $86
     ld   hl, wEntity0PosX                         ; $6728: $21 $00 $C2
     add  hl, de                                   ; $672B: $19
@@ -7159,7 +7159,7 @@ jr_015_67F9:
 
     ld   a, $18                                   ; $6820: $3E $18
     call label_3BB5                               ; $6822: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $6825: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6825: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $6827: $21 $50 $C2
     sub  [hl]                                     ; $682A: $96
     bit  7, a                                     ; $682B: $CB $7F
@@ -7170,7 +7170,7 @@ jr_015_67F9:
 
 jr_015_6831:
     inc  [hl]                                     ; $6831: $34
-    ldh  a, [hScratchB]                           ; $6832: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6832: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $6834: $21 $40 $C2
     sub  [hl]                                     ; $6837: $96
     bit  7, a                                     ; $6838: $CB $7F
@@ -7213,11 +7213,11 @@ jr_015_685F:
     call label_3B86                               ; $686B: $CD $86 $3B
     ret  c                                        ; $686E: $D8
 
-    ldh  a, [hScratchA]                           ; $686F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $686F: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6871: $21 $00 $C2
     add  hl, de                                   ; $6874: $19
     ld   [hl], a                                  ; $6875: $77
-    ldh  a, [hScratchB]                           ; $6876: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6876: $F0 $D8
     ld   hl, wEntity0PosY                         ; $6878: $21 $10 $C2
     add  hl, de                                   ; $687B: $19
     ld   [hl], a                                  ; $687C: $77
@@ -8123,7 +8123,7 @@ jr_015_6CBC:
     call label_3BB5                               ; $6CD9: $CD $B5 $3B
     ld   hl, wEntity0SpeedY                       ; $6CDC: $21 $50 $C2
     add  hl, bc                                   ; $6CDF: $09
-    ldh  a, [hScratchA]                           ; $6CE0: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6CE0: $F0 $D7
     sub  [hl]                                     ; $6CE2: $96
     and  $80                                      ; $6CE3: $E6 $80
     jr   nz, jr_015_6CE9                          ; $6CE5: $20 $02
@@ -8135,7 +8135,7 @@ jr_015_6CE9:
     dec  [hl]                                     ; $6CE9: $35
     ld   hl, wEntity0SpeedX                       ; $6CEA: $21 $40 $C2
     add  hl, bc                                   ; $6CED: $09
-    ldh  a, [hScratchB]                           ; $6CEE: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6CEE: $F0 $D8
     sub  [hl]                                     ; $6CF0: $96
     and  $80                                      ; $6CF1: $E6 $80
     jr   nz, jr_015_6CF7                          ; $6CF3: $20 $02
@@ -8586,7 +8586,7 @@ jr_015_6F40:
     ldh  [hLinkPositionY], a                      ; $6F4A: $E0 $99
     ld   a, $08                                   ; $6F4C: $3E $08
     call label_3BB5                               ; $6F4E: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $6F51: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6F51: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $6F53: $21 $50 $C2
     add  hl, bc                                   ; $6F56: $09
     sub  [hl]                                     ; $6F57: $96
@@ -8598,7 +8598,7 @@ jr_015_6F40:
 
 jr_015_6F5E:
     dec  [hl]                                     ; $6F5E: $35
-    ldh  a, [hScratchB]                           ; $6F5F: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6F5F: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $6F61: $21 $40 $C2
     add  hl, bc                                   ; $6F64: $09
     sub  [hl]                                     ; $6F65: $96
@@ -9254,9 +9254,9 @@ label_015_72CF:
     ld   [wDB94], a                               ; $72FF: $EA $94 $DB
     ld   a, $20                                   ; $7302: $3E $20
     call label_3BB5                               ; $7304: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $7307: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7307: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $7309: $E0 $9B
-    ldh  a, [hScratchB]                           ; $730B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $730B: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $730D: $E0 $9A
     ld   a, $10                                   ; $730F: $3E $10
     ld   [$C13E], a                               ; $7311: $EA $3E $C1
@@ -9633,11 +9633,11 @@ jr_015_7506:
     call label_3B98                               ; $753A: $CD $98 $3B
     jr   c, jr_015_756E                           ; $753D: $38 $2F
 
-    ldh  a, [hScratchA]                           ; $753F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $753F: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7541: $21 $00 $C2
     add  hl, de                                   ; $7544: $19
     ld   [hl], a                                  ; $7545: $77
-    ldh  a, [hScratchB]                           ; $7546: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7546: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7548: $21 $10 $C2
     add  hl, de                                   ; $754B: $19
     ld   [hl], a                                  ; $754C: $77
@@ -9749,9 +9749,9 @@ jr_015_75E1:
 
     push hl                                       ; $75EF: $E5
     ldh  a, [wActiveEntityPosX]                   ; $75F0: $F0 $EE
-    ldh  [hScratchA], a                           ; $75F2: $E0 $D7
+    ldh  [hScratch0], a                           ; $75F2: $E0 $D7
     ldh  a, [$FFEF]                               ; $75F4: $F0 $EF
-    ldh  [hScratchB], a                           ; $75F6: $E0 $D8
+    ldh  [hScratch1], a                           ; $75F6: $E0 $D8
     ld   a, $05                                   ; $75F8: $3E $05
     call label_CC7                                ; $75FA: $CD $C7 $0C
     pop  hl                                       ; $75FD: $E1
@@ -9798,9 +9798,9 @@ jr_015_7619:
 jr_015_7639:
     ldh  a, [wActiveEntityPosX]                   ; $7639: $F0 $EE
     add  $04                                      ; $763B: $C6 $04
-    ldh  [hScratchA], a                           ; $763D: $E0 $D7
+    ldh  [hScratch0], a                           ; $763D: $E0 $D7
     ldh  a, [$FFEF]                               ; $763F: $F0 $EF
-    ldh  [hScratchB], a                           ; $7641: $E0 $D8
+    ldh  [hScratch1], a                           ; $7641: $E0 $D8
     ld   a, $06                                   ; $7643: $3E $06
     call label_CC7                                ; $7645: $CD $C7 $0C
     ld   [hl], $10                                ; $7648: $36 $10
@@ -9970,11 +9970,11 @@ jr_015_773A:
     call label_3B86                               ; $773A: $CD $86 $3B
     ret  c                                        ; $773D: $D8
 
-    ldh  a, [hScratchA]                           ; $773E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $773E: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7740: $21 $00 $C2
     add  hl, de                                   ; $7743: $19
     ld   [hl], a                                  ; $7744: $77
-    ldh  a, [hScratchB]                           ; $7745: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7745: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7747: $21 $10 $C2
     add  hl, de                                   ; $774A: $19
     sub  $0C                                      ; $774B: $D6 $0C
@@ -10072,13 +10072,13 @@ jr_015_77BE:
     ld   [hl], a                                  ; $77E6: $77
     ld   a, $10                                   ; $77E7: $3E $10
     call label_3BB5                               ; $77E9: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $77EC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $77EC: $F0 $D7
     cpl                                           ; $77EE: $2F
     inc  a                                        ; $77EF: $3C
     ld   hl, wEntity0SpeedY                       ; $77F0: $21 $50 $C2
     add  hl, bc                                   ; $77F3: $09
     ld   [hl], a                                  ; $77F4: $77
-    ldh  a, [hScratchB]                           ; $77F5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $77F5: $F0 $D8
     cpl                                           ; $77F7: $2F
     inc  a                                        ; $77F8: $3C
     ld   hl, wEntity0SpeedX                       ; $77F9: $21 $40 $C2
@@ -10827,7 +10827,7 @@ jr_015_7C08:
 func_015_7C0A:
     call func_015_7BDB                            ; $7C0A: $CD $DB $7B
     ld   a, e                                     ; $7C0D: $7B
-    ldh  [hScratchA], a                           ; $7C0E: $E0 $D7
+    ldh  [hScratch0], a                           ; $7C0E: $E0 $D7
     ld   a, d                                     ; $7C10: $7A
     bit  7, a                                     ; $7C11: $CB $7F
     jr   z, jr_015_7C17                           ; $7C13: $28 $02
@@ -10839,7 +10839,7 @@ jr_015_7C17:
     push af                                       ; $7C17: $F5
     call func_015_7BEB                            ; $7C18: $CD $EB $7B
     ld   a, e                                     ; $7C1B: $7B
-    ldh  [hScratchB], a                           ; $7C1C: $E0 $D8
+    ldh  [hScratch1], a                           ; $7C1C: $E0 $D8
     ld   a, d                                     ; $7C1E: $7A
     bit  7, a                                     ; $7C1F: $CB $7F
     jr   z, jr_015_7C25                           ; $7C21: $28 $02
@@ -10852,11 +10852,11 @@ jr_015_7C25:
     cp   d                                        ; $7C26: $BA
     jr   nc, jr_015_7C2D                          ; $7C27: $30 $04
 
-    ldh  a, [hScratchA]                           ; $7C29: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7C29: $F0 $D7
     jr   jr_015_7C2F                              ; $7C2B: $18 $02
 
 jr_015_7C2D:
-    ldh  a, [hScratchB]                           ; $7C2D: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7C2D: $F0 $D8
 
 jr_015_7C2F:
     ld   e, a                                     ; $7C2F: $5F
@@ -10933,9 +10933,9 @@ label_015_7C71:
 label_015_7C91:
     call func_015_7B13                            ; $7C91: $CD $13 $7B
     ldh  a, [wActiveEntityPosX]                   ; $7C94: $F0 $EE
-    ldh  [hScratchA], a                           ; $7C96: $E0 $D7
+    ldh  [hScratch0], a                           ; $7C96: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7C98: $F0 $EC
-    ldh  [hScratchB], a                           ; $7C9A: $E0 $D8
+    ldh  [hScratch1], a                           ; $7C9A: $E0 $D8
     ld   a, $02                                   ; $7C9C: $3E $02
     call label_CC7                                ; $7C9E: $CD $C7 $0C
     ld   a, $13                                   ; $7CA1: $3E $13
@@ -10944,11 +10944,11 @@ label_015_7C91:
 
     ld   a, $36                                   ; $7CA6: $3E $36
     call label_3B86                               ; $7CA8: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $7CAB: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7CAB: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7CAD: $21 $00 $C2
     add  hl, de                                   ; $7CB0: $19
     ld   [hl], a                                  ; $7CB1: $77
-    ldh  a, [hScratchB]                           ; $7CB2: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7CB2: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7CB4: $21 $10 $C2
     add  hl, de                                   ; $7CB7: $19
     ld   [hl], a                                  ; $7CB8: $77

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -1675,7 +1675,7 @@ jr_018_4A2A:
     add  hl, bc                                   ; $4A5A: $09
     ld   [hl], a                                  ; $4A5B: $77
     call func_018_6493                            ; $4A5C: $CD $93 $64
-    ldh  a, [hScratchD]                           ; $4A5F: $F0 $DA
+    ldh  a, [hScratch3]                           ; $4A5F: $F0 $DA
     cp   $07                                      ; $4A61: $FE $07
     ret  nz                                       ; $4A63: $C0
 
@@ -1747,10 +1747,10 @@ jr_018_4A97:
     ld   a, $0E                                   ; $4AC9: $3E $0E
     ldh  [hJingle], a                             ; $4ACB: $E0 $F2
     ldh  a, [wActiveEntityPosX]                   ; $4ACD: $F0 $EE
-    ldh  [hScratchA], a                           ; $4ACF: $E0 $D7
+    ldh  [hScratch0], a                           ; $4ACF: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4AD1: $F0 $EC
     add  $00                                      ; $4AD3: $C6 $00
-    ldh  [hScratchB], a                           ; $4AD5: $E0 $D8
+    ldh  [hScratch1], a                           ; $4AD5: $E0 $D8
     ld   a, $01                                   ; $4AD7: $3E $01
     jp   label_CC7                                ; $4AD9: $C3 $C7 $0C
 
@@ -1762,11 +1762,11 @@ jr_018_4ADC:
     call label_3B86                               ; $4AE2: $CD $86 $3B
     jr   c, jr_018_4B03                           ; $4AE5: $38 $1C
 
-    ldh  a, [hScratchA]                           ; $4AE7: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4AE7: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4AE9: $21 $00 $C2
     add  hl, de                                   ; $4AEC: $19
     ld   [hl], a                                  ; $4AED: $77
-    ldh  a, [hScratchB]                           ; $4AEE: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4AEE: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4AF0: $21 $10 $C2
     add  hl, de                                   ; $4AF3: $19
     ld   [hl], a                                  ; $4AF4: $77
@@ -2462,9 +2462,9 @@ jr_018_4F1D:
     call GetEntityTransitionCountdown             ; $4F1E: $CD $05 $0C
     ld   [hl], $90                                ; $4F21: $36 $90
     ldh  a, [wActiveEntityPosX]                   ; $4F23: $F0 $EE
-    ldh  [hScratchA], a                           ; $4F25: $E0 $D7
+    ldh  [hScratch0], a                           ; $4F25: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4F27: $F0 $EC
-    ldh  [hScratchB], a                           ; $4F29: $E0 $D8
+    ldh  [hScratch1], a                           ; $4F29: $E0 $D8
     ld   a, $02                                   ; $4F2B: $3E $02
     call label_CC7                                ; $4F2D: $CD $C7 $0C
     ld   a, $06                                   ; $4F30: $3E $06
@@ -2502,11 +2502,11 @@ jr_018_4F4E:
     ld   [hl], $48                                ; $4F63: $36 $48
     ld   a, $02                                   ; $4F65: $3E $02
     call label_3B86                               ; $4F67: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $4F6A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4F6A: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4F6C: $21 $00 $C2
     add  hl, de                                   ; $4F6F: $19
     ld   [hl], a                                  ; $4F70: $77
-    ldh  a, [hScratchB]                           ; $4F71: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4F71: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4F73: $21 $10 $C2
     add  hl, de                                   ; $4F76: $19
     ld   [hl], a                                  ; $4F77: $77
@@ -2577,11 +2577,11 @@ jr_018_4FAF:
     call label_3B86                               ; $4FDA: $CD $86 $3B
     ld   a, $26                                   ; $4FDD: $3E $26
     ldh  [hNoiseSfx], a                           ; $4FDF: $E0 $F4
-    ldh  a, [hScratchA]                           ; $4FE1: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4FE1: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4FE3: $21 $00 $C2
     add  hl, de                                   ; $4FE6: $19
     ld   [hl], a                                  ; $4FE7: $77
-    ldh  a, [hScratchB]                           ; $4FE8: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4FE8: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4FEA: $21 $10 $C2
     add  hl, de                                   ; $4FED: $19
     ld   [hl], a                                  ; $4FEE: $77
@@ -3537,12 +3537,12 @@ jr_018_552F:
     call label_3B86                               ; $5553: $CD $86 $3B
     jr   c, jr_018_557B                           ; $5556: $38 $23
 
-    ldh  a, [hScratchA]                           ; $5558: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5558: $F0 $D7
     sub  $08                                      ; $555A: $D6 $08
     ld   hl, wEntity0PosX                         ; $555C: $21 $00 $C2
     add  hl, de                                   ; $555F: $19
     ld   [hl], a                                  ; $5560: $77
-    ldh  a, [hScratchB]                           ; $5561: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5561: $F0 $D8
     add  $02                                      ; $5563: $C6 $02
     ld   hl, wEntity0PosY                         ; $5565: $21 $10 $C2
     add  hl, de                                   ; $5568: $19
@@ -3833,18 +3833,18 @@ label_018_572E:
     ld   a, $24                                   ; $572E: $3E $24
     ldh  [hNoiseSfx], a                           ; $5730: $E0 $F4
     ldh  a, [wActiveEntityPosX]                   ; $5732: $F0 $EE
-    ldh  [hScratchA], a                           ; $5734: $E0 $D7
+    ldh  [hScratch0], a                           ; $5734: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $5736: $F0 $EC
     add  $10                                      ; $5738: $C6 $10
-    ldh  [hScratchB], a                           ; $573A: $E0 $D8
+    ldh  [hScratch1], a                           ; $573A: $E0 $D8
     ld   a, $01                                   ; $573C: $3E $01
     call label_CC7                                ; $573E: $CD $C7 $0C
     ldh  a, [wActiveEntityPosX]                   ; $5741: $F0 $EE
     add  $10                                      ; $5743: $C6 $10
-    ldh  [hScratchA], a                           ; $5745: $E0 $D7
+    ldh  [hScratch0], a                           ; $5745: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $5747: $F0 $EC
     add  $10                                      ; $5749: $C6 $10
-    ldh  [hScratchB], a                           ; $574B: $E0 $D8
+    ldh  [hScratch1], a                           ; $574B: $E0 $D8
     ld   a, $01                                   ; $574D: $3E $01
     jp   label_CC7                                ; $574F: $C3 $C7 $0C
 
@@ -4415,7 +4415,7 @@ jr_018_5A7F:
     call label_3B86                               ; $5AAB: $CD $86 $3B
     jr   c, jr_018_5AE7                           ; $5AAE: $38 $37
 
-    ldh  a, [hScratchB]                           ; $5AB0: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5AB0: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5AB2: $21 $10 $C2
     add  hl, de                                   ; $5AB5: $19
     sub  $08                                      ; $5AB6: $D6 $08
@@ -4431,7 +4431,7 @@ jr_018_5A7F:
     ld   c, a                                     ; $5AC3: $4F
     ld   hl, $5A88                                ; $5AC4: $21 $88 $5A
     add  hl, bc                                   ; $5AC7: $09
-    ldh  a, [hScratchA]                           ; $5AC8: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5AC8: $F0 $D7
     add  [hl]                                     ; $5ACA: $86
     ld   hl, wEntity0PosX                         ; $5ACB: $21 $00 $C2
     add  hl, de                                   ; $5ACE: $19
@@ -4869,9 +4869,9 @@ jr_018_5CEF:
 
 jr_018_5D5E:
     ldh  a, [wActiveEntityPosY]                   ; $5D5E: $F0 $EC
-    ldh  [hScratchB], a                           ; $5D60: $E0 $D8
+    ldh  [hScratch1], a                           ; $5D60: $E0 $D8
     ldh  a, [wActiveEntityPosX]                   ; $5D62: $F0 $EE
-    ldh  [hScratchA], a                           ; $5D64: $E0 $D7
+    ldh  [hScratch0], a                           ; $5D64: $E0 $D7
     ld   a, $0E                                   ; $5D66: $3E $0E
     ldh  [hJingle], a                             ; $5D68: $E0 $F2
     ld   a, $0C                                   ; $5D6A: $3E $0C
@@ -5090,7 +5090,7 @@ jr_018_5EA2:
 jr_018_5EAD:
     ld   a, $18                                   ; $5EAD: $3E $18
     call label_AEA                                ; $5EAF: $CD $EA $0A
-    ldh  a, [hScratchA]                           ; $5EB2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5EB2: $F0 $D7
     jp   OpenDialogInTable2                       ; $5EB4: $C3 $7C $23
 
     ld   h, b                                     ; $5EB7: $60
@@ -5782,11 +5782,11 @@ func_018_62F5:
     ld   a, $20                                   ; $6304: $3E $20
     ldh  [hSwordIntersectedAreaY], a              ; $6306: $E0 $CD
     add  $10                                      ; $6308: $C6 $10
-    ldh  [hScratchB], a                           ; $630A: $E0 $D8
+    ldh  [hScratch1], a                           ; $630A: $E0 $D8
     ld   a, $80                                   ; $630C: $3E $80
     ldh  [hSwordIntersectedAreaX], a              ; $630E: $E0 $CE
     add  $08                                      ; $6310: $C6 $08
-    ldh  [hScratchA], a                           ; $6312: $E0 $D7
+    ldh  [hScratch0], a                           ; $6312: $E0 $D7
     ld   a, $02                                   ; $6314: $3E $02
     call label_CC7                                ; $6316: $CD $C7 $0C
     call label_2887                               ; $6319: $CD $87 $28
@@ -5894,7 +5894,7 @@ jr_018_63AF:
     add  hl, bc                                   ; $63B7: $09
     ld   [hl], a                                  ; $63B8: $77
     call func_018_6493                            ; $63B9: $CD $93 $64
-    ldh  a, [hScratchD]                           ; $63BC: $F0 $DA
+    ldh  a, [hScratch3]                           ; $63BC: $F0 $DA
     cp   $00                                      ; $63BE: $FE $00
     jr   z, jr_018_63C9                           ; $63C0: $28 $07
 
@@ -5917,11 +5917,11 @@ jr_018_63D1:
     call label_3B98                               ; $63D8: $CD $98 $3B
     jr   c, jr_018_63F7                           ; $63DB: $38 $1A
 
-    ldh  a, [hScratchA]                           ; $63DD: $F0 $D7
+    ldh  a, [hScratch0]                           ; $63DD: $F0 $D7
     ld   hl, wEntity0PosX                         ; $63DF: $21 $00 $C2
     add  hl, de                                   ; $63E2: $19
     ld   [hl], a                                  ; $63E3: $77
-    ldh  a, [hScratchB]                           ; $63E4: $F0 $D8
+    ldh  a, [hScratch1]                           ; $63E4: $F0 $D8
     ld   hl, wEntity0PosY                         ; $63E6: $21 $10 $C2
     add  hl, de                                   ; $63E9: $19
     ld   [hl], a                                  ; $63EA: $77
@@ -6074,7 +6074,7 @@ func_018_6493:
     ld   a, [wIsIndoor]                           ; $64C0: $FA $A5 $DB
     ld   d, a                                     ; $64C3: $57
     call label_2A26                               ; $64C4: $CD $26 $2A
-    ldh  [hScratchD], a                           ; $64C7: $E0 $DA
+    ldh  [hScratch3], a                           ; $64C7: $E0 $DA
     ret                                           ; $64C9: $C9
 
     db   $EC                                      ; $64CA: $EC
@@ -6189,7 +6189,7 @@ jr_018_655B:
 
     ld   a, $08                                   ; $657B: $3E $08
     call label_3BB5                               ; $657D: $CD $B5 $3B
-    ldh  a, [hScratchB]                           ; $6580: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6580: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $6582: $21 $40 $C2
     add  hl, bc                                   ; $6585: $09
     add  [hl]                                     ; $6586: $86
@@ -6900,11 +6900,11 @@ jr_018_691B:
     ld   d, h                                     ; $692D: $54
     pop  hl                                       ; $692E: $E1
     ld   a, c                                     ; $692F: $79
-    ldh  [hScratchA], a                           ; $6930: $E0 $D7
+    ldh  [hScratch0], a                           ; $6930: $E0 $D7
     ld   a, [wLinkWalkingFrameCount]              ; $6932: $FA $23 $C1
     ld   c, a                                     ; $6935: $4F
     call SkipDisabledEntityDuringRoomTransition ; $6936: $CD $57 $3D
-    ldh  a, [hScratchA]                           ; $6939: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6939: $F0 $D7
     ld   c, a                                     ; $693B: $4F
 
 jr_018_693C:
@@ -7069,9 +7069,9 @@ func_018_69D8:
     jr   nz, jr_018_6A71                          ; $6A0E: $20 $61
 
     ldh  a, [wActiveEntityPosX]                   ; $6A10: $F0 $EE
-    ldh  [hScratchA], a                           ; $6A12: $E0 $D7
+    ldh  [hScratch0], a                           ; $6A12: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $6A14: $F0 $EC
-    ldh  [hScratchB], a                           ; $6A16: $E0 $D8
+    ldh  [hScratch1], a                           ; $6A16: $E0 $D8
     ld   a, $02                                   ; $6A18: $3E $02
     call label_CC7                                ; $6A1A: $CD $C7 $0C
     ld   a, $0C                                   ; $6A1D: $3E $0C
@@ -7094,15 +7094,15 @@ func_018_6A31:
     ld   hl, $C460                                ; $6A3D: $21 $60 $C4
     add  hl, de                                   ; $6A40: $19
     ld   [hl], a                                  ; $6A41: $77
-    ldh  a, [hScratchA]                           ; $6A42: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A42: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6A44: $21 $00 $C2
     add  hl, de                                   ; $6A47: $19
     ld   [hl], a                                  ; $6A48: $77
-    ldh  a, [hScratchB]                           ; $6A49: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6A49: $F0 $D8
     ld   hl, wEntity0PosY                         ; $6A4B: $21 $10 $C2
     add  hl, de                                   ; $6A4E: $19
     ld   [hl], a                                  ; $6A4F: $77
-    ldh  a, [hScratchD]                           ; $6A50: $F0 $DA
+    ldh  a, [hScratch3]                           ; $6A50: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $6A52: $21 $10 $C3
     add  hl, de                                   ; $6A55: $19
     ld   [hl], a                                  ; $6A56: $77
@@ -7189,13 +7189,13 @@ jr_018_6A8B:
 
     ld   a, $10                                   ; $6AE0: $3E $10
     call label_3BB5                               ; $6AE2: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $6AE5: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6AE5: $F0 $D7
     cpl                                           ; $6AE7: $2F
     inc  a                                        ; $6AE8: $3C
     ld   hl, wEntity0SpeedY                       ; $6AE9: $21 $50 $C2
     add  hl, bc                                   ; $6AEC: $09
     ld   [hl], a                                  ; $6AED: $77
-    ldh  a, [hScratchB]                           ; $6AEE: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6AEE: $F0 $D8
     cpl                                           ; $6AF0: $2F
     inc  a                                        ; $6AF1: $3C
     ld   hl, wEntity0SpeedX                       ; $6AF2: $21 $40 $C2
@@ -7386,13 +7386,13 @@ jr_018_6BD4:
 
     ld   a, $20                                   ; $6C05: $3E $20
     call label_3BB5                               ; $6C07: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $6C0A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6C0A: $F0 $D7
     cpl                                           ; $6C0C: $2F
     inc  a                                        ; $6C0D: $3C
     ld   hl, wEntity0SpeedY                       ; $6C0E: $21 $50 $C2
     add  hl, bc                                   ; $6C11: $09
     ld   [hl], a                                  ; $6C12: $77
-    ldh  a, [hScratchB]                           ; $6C13: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6C13: $F0 $D8
     cpl                                           ; $6C15: $2F
     inc  a                                        ; $6C16: $3C
     ld   hl, wEntity0SpeedX                       ; $6C17: $21 $40 $C2
@@ -7420,7 +7420,7 @@ jr_018_6C27:
 jr_018_6C38:
     ld   a, $20                                   ; $6C38: $3E $20
     call label_3BB5                               ; $6C3A: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $6C3D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6C3D: $F0 $D7
     cpl                                           ; $6C3F: $2F
     inc  a                                        ; $6C40: $3C
     ld   hl, wEntity0SpeedY                       ; $6C41: $21 $50 $C2
@@ -7437,7 +7437,7 @@ jr_018_6C38:
 jr_018_6C4E:
     dec  [hl]                                     ; $6C4E: $35
     dec  [hl]                                     ; $6C4F: $35
-    ldh  a, [hScratchB]                           ; $6C50: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6C50: $F0 $D8
     cpl                                           ; $6C52: $2F
     inc  a                                        ; $6C53: $3C
     ld   hl, wEntity0SpeedX                       ; $6C54: $21 $40 $C2
@@ -7736,12 +7736,12 @@ jr_018_6DDE:
     call label_3B86                               ; $6DED: $CD $86 $3B
     jr   c, jr_018_6E35                           ; $6DF0: $38 $43
 
-    ldh  a, [hScratchA]                           ; $6DF2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6DF2: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6DF4: $21 $00 $C2
     add  hl, de                                   ; $6DF7: $19
     ld   [hl], a                                  ; $6DF8: $77
-    ldh  a, [hScratchB]                           ; $6DF9: $F0 $D8
-    ld   hl, hScratchD                            ; $6DFB: $21 $DA $FF
+    ldh  a, [hScratch1]                           ; $6DF9: $F0 $D8
+    ld   hl, hScratch3                            ; $6DFB: $21 $DA $FF
     sub  [hl]                                     ; $6DFE: $96
     ld   hl, wEntity0PosY                         ; $6DFF: $21 $10 $C2
     add  hl, de                                   ; $6E02: $19
@@ -7852,7 +7852,7 @@ jr_018_6E74:
     ld   a, $20                                   ; $6E9F: $3E $20
     call label_3BB5                               ; $6EA1: $CD $B5 $3B
     pop  de                                       ; $6EA4: $D1
-    ldh  a, [hScratchB]                           ; $6EA5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6EA5: $F0 $D8
     cpl                                           ; $6EA7: $2F
     inc  a                                        ; $6EA8: $3C
     jr   nz, jr_018_6EAD                          ; $6EA9: $20 $02
@@ -7863,7 +7863,7 @@ jr_018_6EAD:
     ld   hl, wEntity0SpeedX                       ; $6EAD: $21 $40 $C2
     add  hl, bc                                   ; $6EB0: $09
     ld   [hl], a                                  ; $6EB1: $77
-    ldh  a, [hScratchA]                           ; $6EB2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6EB2: $F0 $D7
     cpl                                           ; $6EB4: $2F
     inc  a                                        ; $6EB5: $3C
     jr   nz, jr_018_6EBA                          ; $6EB6: $20 $02
@@ -7975,9 +7975,9 @@ label_018_6F1F:
     jr   z, jr_018_6F54                           ; $6F42: $28 $10
 
     ldh  a, [wActiveEntityPosX]                   ; $6F44: $F0 $EE
-    ldh  [hScratchA], a                           ; $6F46: $E0 $D7
+    ldh  [hScratch0], a                           ; $6F46: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $6F48: $F0 $EC
-    ldh  [hScratchB], a                           ; $6F4A: $E0 $D8
+    ldh  [hScratch1], a                           ; $6F4A: $E0 $D8
     ld   a, $02                                   ; $6F4C: $3E $02
     call label_CC7                                ; $6F4E: $CD $C7 $0C
 
@@ -8887,14 +8887,14 @@ jr_018_7416:
     ld   [hl], a                                  ; $7431: $77
     ld   hl, $73EE                                ; $7432: $21 $EE $73
     add  hl, bc                                   ; $7435: $09
-    ldh  a, [hScratchA]                           ; $7436: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7436: $F0 $D7
     add  [hl]                                     ; $7438: $86
     ld   hl, wEntity0PosX                         ; $7439: $21 $00 $C2
     add  hl, de                                   ; $743C: $19
     ld   [hl], a                                  ; $743D: $77
     ld   hl, $73F4                                ; $743E: $21 $F4 $73
     add  hl, bc                                   ; $7441: $09
-    ldh  a, [hScratchB]                           ; $7442: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7442: $F0 $D8
     add  [hl]                                     ; $7444: $86
     ld   hl, wEntity0PosY                         ; $7445: $21 $10 $C2
     add  hl, de                                   ; $7448: $19
@@ -9677,15 +9677,15 @@ jr_018_78A6:
     ld   hl, $C430                                ; $78B7: $21 $30 $C4
     add  hl, de                                   ; $78BA: $19
     res  0, [hl]                                  ; $78BB: $CB $86
-    ldh  a, [hScratchA]                           ; $78BD: $F0 $D7
+    ldh  a, [hScratch0]                           ; $78BD: $F0 $D7
     ld   hl, wEntity0PosX                         ; $78BF: $21 $00 $C2
     add  hl, de                                   ; $78C2: $19
     ld   [hl], a                                  ; $78C3: $77
-    ldh  a, [hScratchB]                           ; $78C4: $F0 $D8
+    ldh  a, [hScratch1]                           ; $78C4: $F0 $D8
     ld   hl, wEntity0PosY                         ; $78C6: $21 $10 $C2
     add  hl, de                                   ; $78C9: $19
     ld   [hl], a                                  ; $78CA: $77
-    ldh  a, [hScratchD]                           ; $78CB: $F0 $DA
+    ldh  a, [hScratch3]                           ; $78CB: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $78CD: $21 $10 $C3
     add  hl, de                                   ; $78D0: $19
     ld   [hl], a                                  ; $78D1: $77
@@ -9734,13 +9734,13 @@ jr_018_78F1:
     ld   [hl], $12                                ; $791B: $36 $12
     ld   a, $20                                   ; $791D: $3E $20
     call label_3BB5                               ; $791F: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $7922: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7922: $F0 $D7
     cpl                                           ; $7924: $2F
     inc  a                                        ; $7925: $3C
     ld   hl, wEntity0SpeedY                       ; $7926: $21 $50 $C2
     add  hl, bc                                   ; $7929: $09
     ld   [hl], a                                  ; $792A: $77
-    ldh  a, [hScratchB]                           ; $792B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $792B: $F0 $D8
     cpl                                           ; $792D: $2F
     inc  a                                        ; $792E: $3C
     ld   hl, wEntity0SpeedX                       ; $792F: $21 $40 $C2
@@ -9840,9 +9840,9 @@ jr_018_79B3:
 
     call label_2178                               ; $79B9: $CD $78 $21
     ldh  a, [wActiveEntityPosX]                   ; $79BC: $F0 $EE
-    ldh  [hScratchA], a                           ; $79BE: $E0 $D7
+    ldh  [hScratch0], a                           ; $79BE: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $79C0: $F0 $EC
-    ldh  [hScratchB], a                           ; $79C2: $E0 $D8
+    ldh  [hScratch1], a                           ; $79C2: $E0 $D8
     ld   a, $02                                   ; $79C4: $3E $02
     call label_CC7                                ; $79C6: $CD $C7 $0C
     ld   a, $2F                                   ; $79C9: $3E $2F
@@ -10181,11 +10181,11 @@ jr_018_7B2C:
     ld   a, [bc]                                  ; $7B9C: $0A
 
 func_018_7B9D:
-    ldh  a, [hScratchA]                           ; $7B9D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7B9D: $F0 $D7
     rlca                                          ; $7B9F: $07
     and  $01                                      ; $7BA0: $E6 $01
     ld   e, a                                     ; $7BA2: $5F
-    ldh  a, [hScratchB]                           ; $7BA3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7BA3: $F0 $D8
     rlca                                          ; $7BA5: $07
     rla                                           ; $7BA6: $17
     and  $02                                      ; $7BA7: $E6 $02
@@ -10195,7 +10195,7 @@ func_018_7B9D:
     rla                                           ; $7BAC: $17
     and  $18                                      ; $7BAD: $E6 $18
     ld   h, a                                     ; $7BAF: $67
-    ldh  a, [hScratchB]                           ; $7BB0: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7BB0: $F0 $D8
     bit  7, a                                     ; $7BB2: $CB $7F
     jr   z, jr_018_7BB8                           ; $7BB4: $28 $02
 
@@ -10204,7 +10204,7 @@ func_018_7B9D:
 
 jr_018_7BB8:
     ld   d, a                                     ; $7BB8: $57
-    ldh  a, [hScratchA]                           ; $7BB9: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7BB9: $F0 $D7
     bit  7, a                                     ; $7BBB: $CB $7F
     jr   z, jr_018_7BC1                           ; $7BBD: $28 $02
 
@@ -10277,11 +10277,11 @@ jr_018_7C1C:
 
     ld   a, $30                                   ; $7C21: $3E $30
     call label_3BB5                               ; $7C23: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $7C26: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7C26: $F0 $D7
     cpl                                           ; $7C28: $2F
     inc  a                                        ; $7C29: $3C
     ldh  [hLinkPositionYIncrement], a             ; $7C2A: $E0 $9B
-    ldh  a, [hScratchB]                           ; $7C2C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7C2C: $F0 $D8
     cpl                                           ; $7C2E: $2F
     inc  a                                        ; $7C2F: $3C
     ldh  [hLinkPositionXIncrement], a             ; $7C30: $E0 $9A
@@ -10375,9 +10375,9 @@ jr_018_7CAF:
     ld   a, $07                                   ; $7CB3: $3E $07
     ldh  [hJingle], a                             ; $7CB5: $E0 $F2
     ldh  a, [wActiveEntityPosX]                   ; $7CB7: $F0 $EE
-    ldh  [hScratchA], a                           ; $7CB9: $E0 $D7
+    ldh  [hScratch0], a                           ; $7CB9: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7CBB: $F0 $EC
-    ldh  [hScratchB], a                           ; $7CBD: $E0 $D8
+    ldh  [hScratch1], a                           ; $7CBD: $E0 $D8
     ld   a, $05                                   ; $7CBF: $3E $05
     jp   label_CC7                                ; $7CC1: $C3 $C7 $0C
 
@@ -10392,15 +10392,15 @@ func_018_7CC8:
     sub  [hl]                                     ; $7CD3: $96
     sra  a                                        ; $7CD4: $CB $2F
     sra  a                                        ; $7CD6: $CB $2F
-    ldh  [hScratchA], a                           ; $7CD8: $E0 $D7
-    ldh  [hScratchC], a                           ; $7CDA: $E0 $D9
+    ldh  [hScratch0], a                           ; $7CD8: $E0 $D7
+    ldh  [hScratch2], a                           ; $7CDA: $E0 $D9
     ldh  a, [$FFEF]                               ; $7CDC: $F0 $EF
     ld   hl, hLinkPositionY                       ; $7CDE: $21 $99 $FF
     sub  [hl]                                     ; $7CE1: $96
     sra  a                                        ; $7CE2: $CB $2F
     sra  a                                        ; $7CE4: $CB $2F
-    ldh  [hScratchB], a                           ; $7CE6: $E0 $D8
-    ldh  [hScratchD], a                           ; $7CE8: $E0 $DA
+    ldh  [hScratch1], a                           ; $7CE6: $E0 $D8
+    ldh  [hScratch3], a                           ; $7CE8: $E0 $DA
     ld   a, [$C3C0]                               ; $7CEA: $FA $C0 $C3
     ld   e, a                                     ; $7CED: $5F
     ld   d, $00                                   ; $7CEE: $16 $00
@@ -10418,14 +10418,14 @@ jr_018_7CF8:
     jr   nz, jr_018_7D09                          ; $7D00: $20 $07
 
     ldh  a, [hLinkPositionY]                      ; $7D02: $F0 $99
-    ld   hl, hScratchB                            ; $7D04: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $7D04: $21 $D8 $FF
     add  [hl]                                     ; $7D07: $86
     ld   [de], a                                  ; $7D08: $12
 
 jr_018_7D09:
     inc  de                                       ; $7D09: $13
     ldh  a, [hLinkPositionX]                      ; $7D0A: $F0 $98
-    ld   hl, hScratchA                            ; $7D0C: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $7D0C: $21 $D7 $FF
     add  [hl]                                     ; $7D0F: $86
     add  $04                                      ; $7D10: $C6 $04
     ld   [de], a                                  ; $7D12: $12
@@ -10436,14 +10436,14 @@ jr_018_7D09:
     ld   a, $00                                   ; $7D18: $3E $00
     ld   [de], a                                  ; $7D1A: $12
     inc  de                                       ; $7D1B: $13
-    ldh  a, [hScratchA]                           ; $7D1C: $F0 $D7
-    ld   hl, hScratchC                            ; $7D1E: $21 $D9 $FF
+    ldh  a, [hScratch0]                           ; $7D1C: $F0 $D7
+    ld   hl, hScratch2                            ; $7D1E: $21 $D9 $FF
     add  [hl]                                     ; $7D21: $86
-    ldh  [hScratchA], a                           ; $7D22: $E0 $D7
-    ldh  a, [hScratchB]                           ; $7D24: $F0 $D8
-    ld   hl, hScratchD                            ; $7D26: $21 $DA $FF
+    ldh  [hScratch0], a                           ; $7D22: $E0 $D7
+    ldh  a, [hScratch1]                           ; $7D24: $F0 $D8
+    ld   hl, hScratch3                            ; $7D26: $21 $DA $FF
     add  [hl]                                     ; $7D29: $86
-    ldh  [hScratchB], a                           ; $7D2A: $E0 $D8
+    ldh  [hScratch1], a                           ; $7D2A: $E0 $D8
     ldh  a, [$FFDB]                               ; $7D2C: $F0 $DB
     dec  a                                        ; $7D2E: $3D
     jr   nz, jr_018_7CF8                          ; $7D2F: $20 $C7
@@ -10787,7 +10787,7 @@ jr_018_7EDF:
 func_018_7EE1:
     call func_018_7EB2                            ; $7EE1: $CD $B2 $7E
     ld   a, e                                     ; $7EE4: $7B
-    ldh  [hScratchA], a                           ; $7EE5: $E0 $D7
+    ldh  [hScratch0], a                           ; $7EE5: $E0 $D7
     ld   a, d                                     ; $7EE7: $7A
     bit  7, a                                     ; $7EE8: $CB $7F
     jr   z, jr_018_7EEE                           ; $7EEA: $28 $02
@@ -10799,7 +10799,7 @@ jr_018_7EEE:
     push af                                       ; $7EEE: $F5
     call func_018_7EC2                            ; $7EEF: $CD $C2 $7E
     ld   a, e                                     ; $7EF2: $7B
-    ldh  [hScratchB], a                           ; $7EF3: $E0 $D8
+    ldh  [hScratch1], a                           ; $7EF3: $E0 $D8
     ld   a, d                                     ; $7EF5: $7A
     bit  7, a                                     ; $7EF6: $CB $7F
     jr   z, jr_018_7EFC                           ; $7EF8: $28 $02
@@ -10812,11 +10812,11 @@ jr_018_7EFC:
     cp   d                                        ; $7EFD: $BA
     jr   nc, jr_018_7F04                          ; $7EFE: $30 $04
 
-    ldh  a, [hScratchA]                           ; $7F00: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7F00: $F0 $D7
     jr   jr_018_7F06                              ; $7F02: $18 $02
 
 jr_018_7F04:
-    ldh  a, [hScratchB]                           ; $7F04: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7F04: $F0 $D8
 
 jr_018_7F06:
     ld   e, a                                     ; $7F06: $5F
@@ -10896,9 +10896,9 @@ label_018_7F4F:
 label_018_7F6F:
     call func_018_7DEE                            ; $7F6F: $CD $EE $7D
     ldh  a, [wActiveEntityPosX]                   ; $7F72: $F0 $EE
-    ldh  [hScratchA], a                           ; $7F74: $E0 $D7
+    ldh  [hScratch0], a                           ; $7F74: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7F76: $F0 $EC
-    ldh  [hScratchB], a                           ; $7F78: $E0 $D8
+    ldh  [hScratch1], a                           ; $7F78: $E0 $D8
     ld   a, $02                                   ; $7F7A: $3E $02
     call label_CC7                                ; $7F7C: $CD $C7 $0C
     ld   a, $13                                   ; $7F7F: $3E $13
@@ -10907,11 +10907,11 @@ label_018_7F6F:
 
     ld   a, $36                                   ; $7F84: $3E $36
     call label_3B86                               ; $7F86: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $7F89: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7F89: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7F8B: $21 $00 $C2
     add  hl, de                                   ; $7F8E: $19
     ld   [hl], a                                  ; $7F8F: $77
-    ldh  a, [hScratchB]                           ; $7F90: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7F90: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7F92: $21 $10 $C2
     add  hl, de                                   ; $7F95: $19
     ld   [hl], a                                  ; $7F96: $77

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -6057,7 +6057,7 @@ func_018_6493:
     ld   c, a                                     ; $64A7: $4F
     ld   a, [hl]                                  ; $64A8: $7E
     sub  $07                                      ; $64A9: $D6 $07
-    ldh  [$FFDC], a                               ; $64AB: $E0 $DC
+    ldh  [hScratch5], a                               ; $64AB: $E0 $DC
     and  $F0                                      ; $64AD: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $64AF: $E0 $CD
     or   c                                        ; $64B1: $B1

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -253,19 +253,19 @@ jr_019_4193:
     ld   c, a                                     ; $419C: $4F
     ld   hl, $4165                                ; $419D: $21 $65 $41
     add  hl, bc                                   ; $41A0: $09
-    ldh  a, [hScratchA]                           ; $41A1: $F0 $D7
+    ldh  a, [hScratch0]                           ; $41A1: $F0 $D7
     add  [hl]                                     ; $41A3: $86
     ld   hl, wEntity0PosX                         ; $41A4: $21 $00 $C2
     add  hl, de                                   ; $41A7: $19
     ld   [hl], a                                  ; $41A8: $77
     ld   hl, $416B                                ; $41A9: $21 $6B $41
     add  hl, bc                                   ; $41AC: $09
-    ldh  a, [hScratchB]                           ; $41AD: $F0 $D8
+    ldh  a, [hScratch1]                           ; $41AD: $F0 $D8
     add  [hl]                                     ; $41AF: $86
     ld   hl, wEntity0PosY                         ; $41B0: $21 $10 $C2
     add  hl, de                                   ; $41B3: $19
     ld   [hl], a                                  ; $41B4: $77
-    ldh  a, [hScratchD]                           ; $41B5: $F0 $DA
+    ldh  a, [hScratch3]                           ; $41B5: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $41B7: $21 $10 $C3
     add  hl, de                                   ; $41BA: $19
     ld   [hl], a                                  ; $41BB: $77
@@ -297,14 +297,14 @@ jr_019_41E2:
     ld   a, $29                                   ; $41E2: $3E $29
     ldh  [hNoiseSfx], a                           ; $41E4: $E0 $F4
     ldh  a, [wActiveEntityPosX]                   ; $41E6: $F0 $EE
-    ldh  [hScratchA], a                           ; $41E8: $E0 $D7
+    ldh  [hScratch0], a                           ; $41E8: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $41EA: $F0 $EC
-    ldh  [hScratchB], a                           ; $41EC: $E0 $D8
+    ldh  [hScratch1], a                           ; $41EC: $E0 $D8
     ld   a, $02                                   ; $41EE: $3E $02
     call label_CC7                                ; $41F0: $CD $C7 $0C
     ldh  a, [wActiveEntityPosY]                   ; $41F3: $F0 $EC
     sub  $10                                      ; $41F5: $D6 $10
-    ldh  [hScratchB], a                           ; $41F7: $E0 $D8
+    ldh  [hScratch1], a                           ; $41F7: $E0 $D8
     ld   a, $02                                   ; $41F9: $3E $02
     call label_CC7                                ; $41FB: $CD $C7 $0C
     jp   label_019_7E61                           ; $41FE: $C3 $61 $7E
@@ -796,10 +796,10 @@ jr_019_44DA:
     call label_2178                               ; $44E3: $CD $78 $21
     ldh  a, [hSwordIntersectedAreaX]              ; $44E6: $F0 $CE
     add  $08                                      ; $44E8: $C6 $08
-    ldh  [hScratchA], a                           ; $44EA: $E0 $D7
+    ldh  [hScratch0], a                           ; $44EA: $E0 $D7
     ldh  a, [hSwordIntersectedAreaY]              ; $44EC: $F0 $CD
     add  $10                                      ; $44EE: $C6 $10
-    ldh  [hScratchB], a                           ; $44F0: $E0 $D8
+    ldh  [hScratch1], a                           ; $44F0: $E0 $D8
     ld   a, $08                                   ; $44F2: $3E $08
     call label_CC7                                ; $44F4: $CD $C7 $0C
     ld   a, $13                                   ; $44F7: $3E $13
@@ -893,9 +893,9 @@ jr_019_4562:
     jr   nz, jr_019_459F                          ; $4583: $20 $1A
 
     ldh  a, [wActiveEntityPosX]                   ; $4585: $F0 $EE
-    ldh  [hScratchA], a                           ; $4587: $E0 $D7
+    ldh  [hScratch0], a                           ; $4587: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4589: $F0 $EC
-    ldh  [hScratchB], a                           ; $458B: $E0 $D8
+    ldh  [hScratch1], a                           ; $458B: $E0 $D8
     ld   a, $0D                                   ; $458D: $3E $0D
     call label_CC7                                ; $458F: $CD $C7 $0C
     ld   hl, $C520                                ; $4592: $21 $20 $C5
@@ -914,10 +914,10 @@ jr_019_45A0:
 
 func_019_45A3:
     ldh  a, [wActiveEntityPosX]                   ; $45A3: $F0 $EE
-    ldh  [hScratchA], a                           ; $45A5: $E0 $D7
+    ldh  [hScratch0], a                           ; $45A5: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $45A7: $F0 $EC
     add  $03                                      ; $45A9: $C6 $03
-    ldh  [hScratchB], a                           ; $45AB: $E0 $D8
+    ldh  [hScratch1], a                           ; $45AB: $E0 $D8
     ld   a, $05                                   ; $45AD: $3E $05
     jp   label_CC7                                ; $45AF: $C3 $C7 $0C
 
@@ -2341,11 +2341,11 @@ func_019_4E00:
     call label_3B86                               ; $4E1F: $CD $86 $3B
     ld   hl, wEntity0PosX                         ; $4E22: $21 $00 $C2
     add  hl, de                                   ; $4E25: $19
-    ldh  a, [hScratchA]                           ; $4E26: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4E26: $F0 $D7
     ld   [hl], a                                  ; $4E28: $77
     ld   hl, wEntity0PosY                         ; $4E29: $21 $10 $C2
     add  hl, de                                   ; $4E2C: $19
-    ldh  a, [hScratchB]                           ; $4E2D: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4E2D: $F0 $D8
     ld   [hl], a                                  ; $4E2F: $77
     ld   hl, wEntitiesTransitionCountdownTable    ; $4E30: $21 $E0 $C2
     add  hl, de                                   ; $4E33: $19
@@ -2404,11 +2404,11 @@ label_019_4E62:
 
     ld   a, $D5                                   ; $4E88: $3E $D5
     call label_3B86                               ; $4E8A: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $4E8D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4E8D: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4E8F: $21 $00 $C2
     add  hl, de                                   ; $4E92: $19
     ld   [hl], a                                  ; $4E93: $77
-    ldh  a, [hScratchB]                           ; $4E94: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4E94: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4E96: $21 $10 $C2
     add  hl, de                                   ; $4E99: $19
     ld   [hl], a                                  ; $4E9A: $77
@@ -2614,11 +2614,11 @@ jr_019_4F8F:
     call label_3B86                               ; $4FBC: $CD $86 $3B
     ret  c                                        ; $4FBF: $D8
 
-    ldh  a, [hScratchA]                           ; $4FC0: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4FC0: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4FC2: $21 $00 $C2
     add  hl, de                                   ; $4FC5: $19
     ld   [hl], a                                  ; $4FC6: $77
-    ldh  a, [hScratchB]                           ; $4FC7: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4FC7: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4FC9: $21 $10 $C2
     add  hl, de                                   ; $4FCC: $19
     ld   [hl], a                                  ; $4FCD: $77
@@ -2759,12 +2759,12 @@ jr_019_506C:
     srl  c                                        ; $5071: $CB $39
     ld   hl, $500B                                ; $5073: $21 $0B $50
     add  hl, bc                                   ; $5076: $09
-    ldh  a, [hScratchA]                           ; $5077: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5077: $F0 $D7
     add  [hl]                                     ; $5079: $86
     ld   hl, wEntity0PosX                         ; $507A: $21 $00 $C2
     add  hl, de                                   ; $507D: $19
     ld   [hl], a                                  ; $507E: $77
-    ldh  a, [hScratchB]                           ; $507F: $F0 $D8
+    ldh  a, [hScratch1]                           ; $507F: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5081: $21 $10 $C2
     add  hl, de                                   ; $5084: $19
     ld   [hl], a                                  ; $5085: $77
@@ -3372,7 +3372,7 @@ jr_019_542C:
     call label_3B86                               ; $5430: $CD $86 $3B
     ret  c                                        ; $5433: $D8
 
-    ldh  a, [hScratchB]                           ; $5434: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5434: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5436: $21 $10 $C2
     add  hl, de                                   ; $5439: $19
     ld   [hl], a                                  ; $543A: $77
@@ -3384,7 +3384,7 @@ jr_019_542C:
     ld   c, a                                     ; $5444: $4F
     ld   hl, $5410                                ; $5445: $21 $10 $54
     add  hl, bc                                   ; $5448: $09
-    ldh  a, [hScratchA]                           ; $5449: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5449: $F0 $D7
     add  [hl]                                     ; $544B: $86
     ld   hl, wEntity0PosX                         ; $544C: $21 $00 $C2
     add  hl, de                                   ; $544F: $19
@@ -3457,11 +3457,11 @@ jr_019_54AC:
     call label_3B86                               ; $54B4: $CD $86 $3B
     ret  c                                        ; $54B7: $D8
 
-    ldh  a, [hScratchA]                           ; $54B8: $F0 $D7
+    ldh  a, [hScratch0]                           ; $54B8: $F0 $D7
     ld   hl, wEntity0PosX                         ; $54BA: $21 $00 $C2
     add  hl, de                                   ; $54BD: $19
     ld   [hl], a                                  ; $54BE: $77
-    ldh  a, [hScratchB]                           ; $54BF: $F0 $D8
+    ldh  a, [hScratch1]                           ; $54BF: $F0 $D8
     ld   hl, wEntity0PosY                         ; $54C1: $21 $10 $C2
     add  hl, de                                   ; $54C4: $19
     ld   [hl], a                                  ; $54C5: $77
@@ -3787,11 +3787,11 @@ jr_019_560B:
     ld   a, [bc]                                  ; $567A: $0A
 
 func_019_567B:
-    ldh  a, [hScratchA]                           ; $567B: $F0 $D7
+    ldh  a, [hScratch0]                           ; $567B: $F0 $D7
     rlca                                          ; $567D: $07
     and  $01                                      ; $567E: $E6 $01
     ld   e, a                                     ; $5680: $5F
-    ldh  a, [hScratchB]                           ; $5681: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5681: $F0 $D8
     rlca                                          ; $5683: $07
     rla                                           ; $5684: $17
     and  $02                                      ; $5685: $E6 $02
@@ -3801,7 +3801,7 @@ func_019_567B:
     rla                                           ; $568A: $17
     and  $18                                      ; $568B: $E6 $18
     ld   h, a                                     ; $568D: $67
-    ldh  a, [hScratchB]                           ; $568E: $F0 $D8
+    ldh  a, [hScratch1]                           ; $568E: $F0 $D8
     bit  7, a                                     ; $5690: $CB $7F
     jr   z, jr_019_5696                           ; $5692: $28 $02
 
@@ -3810,7 +3810,7 @@ func_019_567B:
 
 jr_019_5696:
     ld   d, a                                     ; $5696: $57
-    ldh  a, [hScratchA]                           ; $5697: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5697: $F0 $D7
     bit  7, a                                     ; $5699: $CB $7F
     jr   z, jr_019_569F                           ; $569B: $28 $02
 
@@ -4172,9 +4172,9 @@ label_019_58A2:
     call label_3B18                               ; $58AF: $CD $18 $3B
     ld   a, $10                                   ; $58B2: $3E $10
     call label_3BB5                               ; $58B4: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $58B7: $F0 $D7
+    ldh  a, [hScratch0]                           ; $58B7: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $58B9: $E0 $9B
-    ldh  a, [hScratchB]                           ; $58BB: $F0 $D8
+    ldh  a, [hScratch1]                           ; $58BB: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $58BD: $E0 $9A
     ret                                           ; $58BF: $C9
 
@@ -7892,9 +7892,9 @@ jr_019_6CC2:
     ldh  a, [wActiveEntityPosY]                   ; $6CD1: $F0 $EC
 
 func_019_6CD3:
-    ldh  [hScratchB], a                           ; $6CD3: $E0 $D8
+    ldh  [hScratch1], a                           ; $6CD3: $E0 $D8
     ldh  a, [wActiveEntityPosX]                   ; $6CD5: $F0 $EE
-    ldh  [hScratchA], a                           ; $6CD7: $E0 $D7
+    ldh  [hScratch0], a                           ; $6CD7: $E0 $D7
     ld   a, $01                                   ; $6CD9: $3E $01
     call label_CC7                                ; $6CDB: $CD $C7 $0C
     ld   a, $0E                                   ; $6CDE: $3E $0E
@@ -8019,12 +8019,12 @@ jr_019_6D86:
 
     ld   a, $CD                                   ; $6D90: $3E $CD
     call label_3B86                               ; $6D92: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $6D95: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6D95: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6D97: $21 $00 $C2
     add  hl, de                                   ; $6D9A: $19
     sub  $02                                      ; $6D9B: $D6 $02
     ld   [hl], a                                  ; $6D9D: $77
-    ldh  a, [hScratchB]                           ; $6D9E: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6D9E: $F0 $D8
     ld   hl, wEntity0PosY                         ; $6DA0: $21 $10 $C2
     add  hl, de                                   ; $6DA3: $19
     ld   [hl], a                                  ; $6DA4: $77
@@ -9868,7 +9868,7 @@ jr_019_77BC:
     ld   hl, sp+$28                               ; $77CB: $F8 $28
     ld   a, b                                     ; $77CD: $78
     nop                                           ; $77CE: $00
-    ldh  [hScratchB], a                           ; $77CF: $E0 $D8
+    ldh  [hScratch1], a                           ; $77CF: $E0 $D8
     db   $76                                      ; $77D1: $76
     jr   nz, jr_019_77B4                          ; $77D2: $20 $E0
 
@@ -9957,7 +9957,7 @@ jr_019_7822:
     db   $10                                      ; $7828: $10
     ld   [hl], h                                  ; $7829: $74
     nop                                           ; $782A: $00
-    ldh  a, [hScratchB]                           ; $782B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $782B: $F0 $D8
     ld   a, b                                     ; $782D: $78
     jr   nz, jr_019_7820                          ; $782E: $20 $F0
 
@@ -10214,42 +10214,42 @@ jr_019_796C:
     ld   hl, $794E                                ; $7972: $21 $4E $79
     add  hl, de                                   ; $7975: $19
     ld   a, [hl]                                  ; $7976: $7E
-    ldh  [hScratchA], a                           ; $7977: $E0 $D7
+    ldh  [hScratch0], a                           ; $7977: $E0 $D7
     ld   hl, $7952                                ; $7979: $21 $52 $79
     add  hl, de                                   ; $797C: $19
     ld   a, [hl]                                  ; $797D: $7E
-    ldh  [hScratchB], a                           ; $797E: $E0 $D8
+    ldh  [hScratch1], a                           ; $797E: $E0 $D8
     ld   hl, $7956                                ; $7980: $21 $56 $79
     add  hl, de                                   ; $7983: $19
     ld   a, [hl]                                  ; $7984: $7E
 
 jr_019_7985:
-    ldh  [hScratchC], a                           ; $7985: $E0 $D9
+    ldh  [hScratch2], a                           ; $7985: $E0 $D9
     ld   hl, $795A                                ; $7987: $21 $5A $79
     add  hl, de                                   ; $798A: $19
     ld   a, [hl]                                  ; $798B: $7E
-    ldh  [hScratchD], a                           ; $798C: $E0 $DA
+    ldh  [hScratch3], a                           ; $798C: $E0 $DA
     ld   hl, wEntity0PosX                         ; $798E: $21 $00 $C2
     add  hl, bc                                   ; $7991: $09
-    ldh  a, [hScratchA]                           ; $7992: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7992: $F0 $D7
     add  [hl]                                     ; $7994: $86
     rl   d                                        ; $7995: $CB $12
     ld   [hl], a                                  ; $7997: $77
     ld   hl, wEntitiesPosXSignTable                                ; $7998: $21 $20 $C2
     add  hl, bc                                   ; $799B: $09
-    ldh  a, [hScratchB]                           ; $799C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $799C: $F0 $D8
     rr   d                                        ; $799E: $CB $1A
     adc  [hl]                                     ; $79A0: $8E
     ld   [hl], a                                  ; $79A1: $77
     ld   hl, wEntity0PosY                         ; $79A2: $21 $10 $C2
     add  hl, bc                                   ; $79A5: $09
-    ldh  a, [hScratchC]                           ; $79A6: $F0 $D9
+    ldh  a, [hScratch2]                           ; $79A6: $F0 $D9
     add  [hl]                                     ; $79A8: $86
     rl   d                                        ; $79A9: $CB $12
     ld   [hl], a                                  ; $79AB: $77
     ld   hl, wEntitiesPosYSignTable                                ; $79AC: $21 $30 $C2
     add  hl, bc                                   ; $79AF: $09
-    ldh  a, [hScratchD]                           ; $79B0: $F0 $DA
+    ldh  a, [hScratch3]                           ; $79B0: $F0 $DA
     rr   d                                        ; $79B2: $CB $1A
     adc  [hl]                                     ; $79B4: $8E
     ld   [hl], a                                  ; $79B5: $77
@@ -10259,12 +10259,12 @@ jr_019_7985:
 
     ld   hl, $C440                                ; $79BC: $21 $40 $C4
     add  hl, bc                                   ; $79BF: $09
-    ldh  a, [hScratchA]                           ; $79C0: $F0 $D7
+    ldh  a, [hScratch0]                           ; $79C0: $F0 $D7
     add  [hl]                                     ; $79C2: $86
     ld   [hl], a                                  ; $79C3: $77
     ld   hl, wEntitiesUnknownTableD               ; $79C4: $21 $D0 $C2
     add  hl, bc                                   ; $79C7: $09
-    ldh  a, [hScratchC]                           ; $79C8: $F0 $D9
+    ldh  a, [hScratch2]                           ; $79C8: $F0 $D9
     add  [hl]                                     ; $79CA: $86
     ld   [hl], a                                  ; $79CB: $77
     jp   label_019_7A74                           ; $79CC: $C3 $74 $7A
@@ -10298,7 +10298,7 @@ jr_019_79E6:
     ld   d, b                                     ; $79F3: $50
     ld   hl, wIsFileSelectionArrowShifted         ; $79F4: $21 $00 $D0
     add  hl, de                                   ; $79F7: $19
-    ldh  a, [hScratchA]                           ; $79F8: $F0 $D7
+    ldh  a, [hScratch0]                           ; $79F8: $F0 $D7
     add  [hl]                                     ; $79FA: $86
     ld   [hl], a                                  ; $79FB: $77
     ldh  a, [hFreeWarpDataAddress]                ; $79FC: $F0 $E6
@@ -10308,7 +10308,7 @@ jr_019_79E6:
     ld   d, b                                     ; $7A01: $50
     ld   hl, $D100                                ; $7A02: $21 $00 $D1
     add  hl, de                                   ; $7A05: $19
-    ldh  a, [hScratchC]                           ; $7A06: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7A06: $F0 $D9
     add  [hl]                                     ; $7A08: $86
     ld   [hl], a                                  ; $7A09: $77
     ldh  a, [hFFE8]                               ; $7A0A: $F0 $E8
@@ -10327,7 +10327,7 @@ jr_019_7A0F:
     ld   hl, $D155                                ; $7A1B: $21 $55 $D1
 
 jr_019_7A1E:
-    ldh  a, [hScratchA]                           ; $7A1E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7A1E: $F0 $D7
     add  [hl]                                     ; $7A20: $86
     ld   [hl+], a                                 ; $7A21: $22
     dec  e                                        ; $7A22: $1D
@@ -10337,7 +10337,7 @@ jr_019_7A1E:
     ld   hl, $D175                                ; $7A27: $21 $75 $D1
 
 jr_019_7A2A:
-    ldh  a, [hScratchC]                           ; $7A2A: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7A2A: $F0 $D9
     add  [hl]                                     ; $7A2C: $86
     ld   [hl+], a                                 ; $7A2D: $22
     dec  e                                        ; $7A2E: $1D
@@ -10368,7 +10368,7 @@ jr_019_7A4C:
     ld   hl, $D100                                ; $7A4E: $21 $00 $D1
 
 jr_019_7A51:
-    ldh  a, [hScratchA]                           ; $7A51: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7A51: $F0 $D7
     add  [hl]                                     ; $7A53: $86
     ld   [hl+], a                                 ; $7A54: $22
     dec  e                                        ; $7A55: $1D
@@ -10378,7 +10378,7 @@ jr_019_7A51:
     ld   hl, $D110                                ; $7A5A: $21 $10 $D1
 
 jr_019_7A5D:
-    ldh  a, [hScratchC]                           ; $7A5D: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7A5D: $F0 $D9
     add  [hl]                                     ; $7A5F: $86
     ld   [hl+], a                                 ; $7A60: $22
     dec  e                                        ; $7A61: $1D
@@ -10387,12 +10387,12 @@ jr_019_7A5D:
 jr_019_7A64:
     ld   hl, wEntitiesUnknownTableB               ; $7A64: $21 $B0 $C2
     add  hl, bc                                   ; $7A67: $09
-    ldh  a, [hScratchA]                           ; $7A68: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7A68: $F0 $D7
     add  [hl]                                     ; $7A6A: $86
     ld   [hl], a                                  ; $7A6B: $77
     ld   hl, wEntitiesUnknownTableC               ; $7A6C: $21 $C0 $C2
     add  hl, bc                                   ; $7A6F: $09
-    ldh  a, [hScratchC]                           ; $7A70: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7A70: $F0 $D9
     add  [hl]                                     ; $7A72: $86
     ld   [hl], a                                  ; $7A73: $77
 
@@ -10820,7 +10820,7 @@ jr_019_7C56:
     cp   $01                                      ; $7C56: $FE $01
     jr   z, jr_019_7C6D                           ; $7C58: $28 $13
 
-    ldh  a, [hScratchA]                           ; $7C5A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7C5A: $F0 $D7
     and  $0C                                      ; $7C5C: $E6 $0C
 
 jr_019_7C5E:
@@ -10862,7 +10862,7 @@ jr_019_7C8D:
     ld   hl, $7B50                                ; $7C8D: $21 $50 $7B
 
 jr_019_7C90:
-    ldh  a, [hScratchA]                           ; $7C90: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7C90: $F0 $D7
     and  $1C                                      ; $7C92: $E6 $1C
     xor  $1C                                      ; $7C94: $EE $1C
     sla  a                                        ; $7C96: $CB $27
@@ -11195,7 +11195,7 @@ jr_019_7E38:
 func_019_7E3A:
     call func_019_7E0B                            ; $7E3A: $CD $0B $7E
     ld   a, e                                     ; $7E3D: $7B
-    ldh  [hScratchA], a                           ; $7E3E: $E0 $D7
+    ldh  [hScratch0], a                           ; $7E3E: $E0 $D7
     ld   a, d                                     ; $7E40: $7A
     bit  7, a                                     ; $7E41: $CB $7F
     jr   z, jr_019_7E47                           ; $7E43: $28 $02
@@ -11207,7 +11207,7 @@ jr_019_7E47:
     push af                                       ; $7E47: $F5
     call func_019_7E1B                            ; $7E48: $CD $1B $7E
     ld   a, e                                     ; $7E4B: $7B
-    ldh  [hScratchB], a                           ; $7E4C: $E0 $D8
+    ldh  [hScratch1], a                           ; $7E4C: $E0 $D8
     ld   a, d                                     ; $7E4E: $7A
     bit  7, a                                     ; $7E4F: $CB $7F
     jr   z, jr_019_7E55                           ; $7E51: $28 $02
@@ -11220,11 +11220,11 @@ jr_019_7E55:
     cp   d                                        ; $7E56: $BA
     jr   nc, jr_019_7E5D                          ; $7E57: $30 $04
 
-    ldh  a, [hScratchA]                           ; $7E59: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7E59: $F0 $D7
     jr   jr_019_7E5F                              ; $7E5B: $18 $02
 
 jr_019_7E5D:
-    ldh  a, [hScratchB]                           ; $7E5D: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7E5D: $F0 $D8
 
 jr_019_7E5F:
     ld   e, a                                     ; $7E5F: $5F
@@ -11301,9 +11301,9 @@ label_019_7EA4:
 label_019_7EC4:
     call func_019_7D43                            ; $7EC4: $CD $43 $7D
     ldh  a, [wActiveEntityPosX]                   ; $7EC7: $F0 $EE
-    ldh  [hScratchA], a                           ; $7EC9: $E0 $D7
+    ldh  [hScratch0], a                           ; $7EC9: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7ECB: $F0 $EC
-    ldh  [hScratchB], a                           ; $7ECD: $E0 $D8
+    ldh  [hScratch1], a                           ; $7ECD: $E0 $D8
     ld   a, $02                                   ; $7ECF: $3E $02
     call label_CC7                                ; $7ED1: $CD $C7 $0C
     ld   a, $13                                   ; $7ED4: $3E $13
@@ -11312,11 +11312,11 @@ label_019_7EC4:
 
     ld   a, $36                                   ; $7ED9: $3E $36
     call label_3B86                               ; $7EDB: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $7EDE: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7EDE: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7EE0: $21 $00 $C2
     add  hl, de                                   ; $7EE3: $19
     ld   [hl], a                                  ; $7EE4: $77
-    ldh  a, [hScratchB]                           ; $7EE5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7EE5: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7EE7: $21 $10 $C2
     add  hl, de                                   ; $7EEA: $19
     ld   [hl], a                                  ; $7EEB: $77

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -9151,7 +9151,7 @@ jr_003_7B13:
     add  hl, bc                                   ; $7B1D: $09
     add  hl, de                                   ; $7B1E: $19
     add  [hl]                                     ; $7B1F: $86
-    ldh  [$FFDC], a                               ; $7B20: $E0 $DC
+    ldh  [hScratch5], a                               ; $7B20: $E0 $DC
     and  $F0                                      ; $7B22: $E6 $F0
     ld   hl, hScratch1                            ; $7B24: $21 $D8 $FF
     or   [hl]                                     ; $7B27: $B6
@@ -9271,7 +9271,7 @@ jr_003_7BBB:
     rra                                           ; $7BCF: $1F
     and  $01                                      ; $7BD0: $E6 $01
     ld   e, a                                     ; $7BD2: $5F
-    ldh  a, [$FFDC]                               ; $7BD3: $F0 $DC
+    ldh  a, [hScratch5]                               ; $7BD3: $F0 $DC
     rra                                           ; $7BD5: $1F
     rra                                           ; $7BD6: $1F
     and  $02                                      ; $7BD7: $E6 $02
@@ -9454,7 +9454,7 @@ func_003_7CAB::
     ld   c, a                                     ; $7CC0: $4F
     ld   a, [hl]                                  ; $7CC1: $7E
     sub  $08                                      ; $7CC2: $D6 $08
-    ldh  [$FFDC], a                               ; $7CC4: $E0 $DC
+    ldh  [hScratch5], a                               ; $7CC4: $E0 $DC
     and  $F0                                      ; $7CC6: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $7CC8: $E0 $CD
     or   c                                        ; $7CCA: $B1
@@ -9699,7 +9699,7 @@ func_003_7E0E::
     ld   c, a                                     ; $7E22: $4F
     ld   a, [hl]                                  ; $7E23: $7E
     sub  $07                                      ; $7E24: $D6 $07
-    ldh  [$FFDC], a                               ; $7E26: $E0 $DC
+    ldh  [hScratch5], a                               ; $7E26: $E0 $DC
     and  $F0                                      ; $7E28: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $7E2A: $E0 $CD
     or   c                                        ; $7E2C: $B1

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -2037,7 +2037,7 @@ LiftableRockEntityHandler::
     ld   a, c                                     ; $5328: $79
     ld   [$C50C], a                               ; $5329: $EA $0C $C5
     call IsEntityUnknownFZero                                ; $532C: $CD $00 $0C
-    ldh  [hScratchA], a                           ; $532F: $E0 $D7
+    ldh  [hScratch0], a                           ; $532F: $E0 $D7
     jp   z, $53A8                                 ; $5331: $CA $A8 $53
 
     cp   $01                                      ; $5334: $FE $01
@@ -2057,15 +2057,15 @@ LiftableRockEntityHandler::
     call func_003_64CA                            ; $5349: $CD $CA $64
     jr   c, jr_003_5369                           ; $534C: $38 $1B
 
-    ldh  a, [hScratchA]                           ; $534E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $534E: $F0 $D7
     ld   hl, wEntity0PosX                         ; $5350: $21 $00 $C2
     add  hl, de                                   ; $5353: $19
     ld   [hl], a                                  ; $5354: $77
-    ldh  a, [hScratchB]                           ; $5355: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5355: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5357: $21 $10 $C2
     add  hl, de                                   ; $535A: $19
     ld   [hl], a                                  ; $535B: $77
-    ldh  a, [hScratchD]                           ; $535C: $F0 $DA
+    ldh  a, [hScratch3]                           ; $535C: $F0 $DA
     ld   hl, wEntitiesPosZTable                                ; $535E: $21 $10 $C3
     add  hl, de                                   ; $5361: $19
     ld   [hl], a                                  ; $5362: $77
@@ -2198,12 +2198,12 @@ jr_003_5406:
     ; Smash pot
     ;
 
-    ldh  a, [hScratchA]                           ; $540D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $540D: $F0 $D7
     ld   hl, wEntity0PosX                         ; $540F: $21 $00 $C2
     add  hl, de                                   ; $5412: $19
     ld   [hl], a                                  ; $5413: $77
-    ldh  a, [hScratchB]                           ; $5414: $F0 $D8
-    ld   hl, hScratchD                            ; $5416: $21 $DA $FF
+    ldh  a, [hScratch1]                           ; $5414: $F0 $D8
+    ld   hl, hScratch3                            ; $5416: $21 $DA $FF
     sub  [hl]                                     ; $5419: $96
     ld   hl, wEntity0PosY                         ; $541A: $21 $10 $C2
     add  hl, de                                   ; $541D: $19
@@ -2247,7 +2247,7 @@ jr_003_5455:
     ld   a, $20                                   ; $5459: $3E $20
     ldh  [hSwordIntersectedAreaY], a              ; $545B: $E0 $CD
     ld   a, $19                                   ; $545D: $3E $19
-    ldh  [hBGAttributesBank], a                    ; $545F: $E0 $DF
+    ldh  [hScratch8], a                           ; $545F: $E0 $DF
     call label_3E4D                               ; $5461: $CD $4D $3E
     jp   label_C60                                ; $5464: $C3 $60 $0C
 
@@ -2632,11 +2632,11 @@ jr_003_5670:
     ld   hl, wEntitiesUnknownTableB               ; $5679: $21 $B0 $C2
     add  hl, de                                   ; $567C: $19
     ld   [hl], a                                  ; $567D: $77
-    ldh  a, [hScratchA]                           ; $567E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $567E: $F0 $D7
     ld   hl, wEntity0PosX                         ; $5680: $21 $00 $C2
     add  hl, de                                   ; $5683: $19
     ld   [hl], a                                  ; $5684: $77
-    ldh  a, [hScratchB]                           ; $5685: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5685: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5687: $21 $10 $C2
     add  hl, de                                   ; $568A: $19
     ld   [hl], a                                  ; $568B: $77
@@ -3157,18 +3157,18 @@ func_003_5947::
     jr   c, jr_003_598B                           ; $594C: $38 $3D
 
     push bc                                       ; $594E: $C5
-    ldh  a, [hScratchC]                           ; $594F: $F0 $D9
+    ldh  a, [hScratch2]                           ; $594F: $F0 $D9
     ld   c, a                                     ; $5951: $4F
     ld   hl, $5937                                ; $5952: $21 $37 $59
     add  hl, bc                                   ; $5955: $09
-    ldh  a, [hScratchA]                           ; $5956: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5956: $F0 $D7
     add  [hl]                                     ; $5958: $86
     ld   hl, wEntity0PosX                         ; $5959: $21 $00 $C2
     add  hl, de                                   ; $595C: $19
     ld   [hl], a                                  ; $595D: $77
     ld   hl, $593B                                ; $595E: $21 $3B $59
     add  hl, bc                                   ; $5961: $09
-    ldh  a, [hScratchB]                           ; $5962: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5962: $F0 $D8
     add  [hl]                                     ; $5964: $86
     ld   hl, wEntity0PosY                         ; $5965: $21 $10 $C2
     add  hl, de                                   ; $5968: $19
@@ -3187,7 +3187,7 @@ jr_003_5974:
     ld   hl, wEntity0SpeedY                       ; $5979: $21 $50 $C2
     add  hl, de                                   ; $597C: $19
     ld   [hl], a                                  ; $597D: $77
-    ldh  a, [hScratchC]                           ; $597E: $F0 $D9
+    ldh  a, [hScratch2]                           ; $597E: $F0 $D9
     ld   hl, wEntitiesUnknownTableG               ; $5980: $21 $B0 $C3
     add  hl, de                                   ; $5983: $19
     ld   [hl], a                                  ; $5984: $77
@@ -3214,21 +3214,21 @@ label_003_5998:
     jr   c, jr_003_59D6                           ; $599D: $38 $37
 
     push bc                                       ; $599F: $C5
-    ldh  a, [hScratchC]                           ; $59A0: $F0 $D9
+    ldh  a, [hScratch2]                           ; $59A0: $F0 $D9
     ld   hl, $C380                                ; $59A2: $21 $80 $C3
     add  hl, de                                   ; $59A5: $19
     ld   [hl], a                                  ; $59A6: $77
     ld   c, a                                     ; $59A7: $4F
     ld   hl, $598C                                ; $59A8: $21 $8C $59
     add  hl, bc                                   ; $59AB: $09
-    ldh  a, [hScratchA]                           ; $59AC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $59AC: $F0 $D7
     add  [hl]                                     ; $59AE: $86
     ld   hl, wEntity0PosX                         ; $59AF: $21 $00 $C2
     add  hl, de                                   ; $59B2: $19
     ld   [hl], a                                  ; $59B3: $77
     ld   hl, $598E                                ; $59B4: $21 $8E $59
     add  hl, bc                                   ; $59B7: $09
-    ldh  a, [hScratchB]                           ; $59B8: $F0 $D8
+    ldh  a, [hScratch1]                           ; $59B8: $F0 $D8
     add  [hl]                                     ; $59BA: $86
     ld   hl, wEntity0PosY                         ; $59BB: $21 $10 $C2
     add  hl, de                                   ; $59BE: $19
@@ -4173,12 +4173,12 @@ jr_003_5F2C:
     ldh  [hJingle], a                             ; $5F3A: $E0 $F2
     ld   a, $39                                   ; $5F3C: $3E $39
     call func_003_64CA                            ; $5F3E: $CD $CA $64
-    ldh  a, [hScratchA]                           ; $5F41: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5F41: $F0 $D7
     dec  a                                        ; $5F43: $3D
     ld   hl, wEntity0PosX                         ; $5F44: $21 $00 $C2
     add  hl, de                                   ; $5F47: $19
     ld   [hl], a                                  ; $5F48: $77
-    ldh  a, [hScratchB]                           ; $5F49: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5F49: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5F4B: $21 $10 $C2
     add  hl, de                                   ; $5F4E: $19
     ld   [hl], a                                  ; $5F4F: $77
@@ -4215,7 +4215,7 @@ jr_003_5F5F:
     ld   c, a                                     ; $5F82: $4F
     ld   hl, $5F2F                                ; $5F83: $21 $2F $5F
     add  hl, bc                                   ; $5F86: $09
-    ldh  a, [hScratchA]                           ; $5F87: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5F87: $F0 $D7
     add  [hl]                                     ; $5F89: $86
     ld   hl, wEntity0PosX                         ; $5F8A: $21 $00 $C2
     add  hl, de                                   ; $5F8D: $19
@@ -4226,7 +4226,7 @@ jr_003_5F5F:
     ld   hl, wEntity0SpeedX                       ; $5F94: $21 $40 $C2
     add  hl, de                                   ; $5F97: $19
     ld   [hl], a                                  ; $5F98: $77
-    ldh  a, [hScratchB]                           ; $5F99: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5F99: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5F9B: $21 $10 $C2
     add  hl, de                                   ; $5F9E: $19
     add  $F8                                      ; $5F9F: $C6 $F8
@@ -4733,13 +4733,13 @@ jr_003_626B:
     ld   [hl], $18                                ; $6278: $36 $18
     ld   a, $0C                                   ; $627A: $3E $0C
     call func_003_7E45                            ; $627C: $CD $45 $7E
-    ldh  a, [hScratchB]                           ; $627F: $F0 $D8
+    ldh  a, [hScratch1]                           ; $627F: $F0 $D8
     cpl                                           ; $6281: $2F
     inc  a                                        ; $6282: $3C
     ld   hl, wEntity0SpeedX                       ; $6283: $21 $40 $C2
     add  hl, bc                                   ; $6286: $09
     ld   [hl], a                                  ; $6287: $77
-    ldh  a, [hScratchA]                           ; $6288: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6288: $F0 $D7
     cpl                                           ; $628A: $2F
     inc  a                                        ; $628B: $3C
     ld   hl, wEntity0SpeedY                       ; $628C: $21 $50 $C2
@@ -5034,12 +5034,12 @@ jr_003_6422:
     add  hl, de                                   ; $6426: $19
     ldh  a, [hLinkPositionX]                      ; $6427: $F0 $98
     add  [hl]                                     ; $6429: $86
-    ldh  [hScratchA], a                           ; $642A: $E0 $D7
+    ldh  [hScratch0], a                           ; $642A: $E0 $D7
     ld   hl, $63F2                                ; $642C: $21 $F2 $63
     add  hl, de                                   ; $642F: $19
     ldh  a, [hLinkPositionY]                      ; $6430: $F0 $99
     add  [hl]                                     ; $6432: $86
-    ldh  [hScratchB], a                           ; $6433: $E0 $D8
+    ldh  [hScratch1], a                           ; $6433: $E0 $D8
     ld   a, $07                                   ; $6435: $3E $07
     call label_CC7                                ; $6437: $CD $C7 $0C
     ld   hl, $C520                                ; $643A: $21 $20 $C5
@@ -5186,20 +5186,20 @@ jr_003_64E0:
     ld   hl, wEntitiesPosXTable                   ; $64E8: $21 $00 $C2
     add  hl, bc                                   ; $64EB: $09
     ld   a, [hl]                                  ; $64EC: $7E
-    ldh  [hScratchA], a                           ; $64ED: $E0 $D7
+    ldh  [hScratch0], a                           ; $64ED: $E0 $D7
 
     ld   hl, wEntitiesPosYTable                   ; $64EF: $21 $10 $C2
     add  hl, bc                                   ; $64F2: $09
     ld   a, [hl]                                  ; $64F3: $7E
-    ldh  [hScratchB], a                           ; $64F4: $E0 $D8
+    ldh  [hScratch1], a                           ; $64F4: $E0 $D8
     ld   hl, $C380                                ; $64F6: $21 $80 $C3
     add  hl, bc                                   ; $64F9: $09
     ld   a, [hl]                                  ; $64FA: $7E
-    ldh  [hScratchC], a                           ; $64FB: $E0 $D9
+    ldh  [hScratch2], a                           ; $64FB: $E0 $D9
     ld   hl, wEntitiesPosZTable                                ; $64FD: $21 $10 $C3
     add  hl, bc                                   ; $6500: $09
     ld   a, [hl]                                  ; $6501: $7E
-    ldh  [hScratchD], a                           ; $6502: $E0 $DA
+    ldh  [hScratch3], a                           ; $6502: $E0 $DA
     call func_003_6524                            ; $6504: $CD $24 $65
     ld   hl, $C410                                ; $6507: $21 $10 $C4
     add  hl, de                                   ; $650A: $19
@@ -6116,10 +6116,10 @@ jr_003_69F8:
     call label_2178                               ; $6A05: $CD $78 $21
     ldh  a, [hSwordIntersectedAreaX]              ; $6A08: $F0 $CE
     add  $08                                      ; $6A0A: $C6 $08
-    ldh  [hScratchA], a                           ; $6A0C: $E0 $D7
+    ldh  [hScratch0], a                           ; $6A0C: $E0 $D7
     ldh  a, [hSwordIntersectedAreaY]              ; $6A0E: $F0 $CD
     add  $10                                      ; $6A10: $C6 $10
-    ldh  [hScratchB], a                           ; $6A12: $E0 $D8
+    ldh  [hScratch1], a                           ; $6A12: $E0 $D8
     ld   a, $08                                   ; $6A14: $3E $08
     call label_CC7                                ; $6A16: $CD $C7 $0C
     ld   a, $13                                   ; $6A19: $3E $13
@@ -6187,11 +6187,11 @@ ArrowEntityHandler::
     call func_003_64CA                            ; $6A77: $CD $CA $64
     jr   c, jr_003_6A93                           ; $6A7A: $38 $17
 
-    ldh  a, [hScratchA]                           ; $6A7C: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A7C: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6A7E: $21 $00 $C2
     add  hl, de                                   ; $6A81: $19
     ld   [hl], a                                  ; $6A82: $77
-    ldh  a, [hScratchB]                           ; $6A83: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6A83: $F0 $D8
     ld   hl, wEntity0PosY                         ; $6A85: $21 $10 $C2
     add  hl, de                                   ; $6A88: $19
     ld   [hl], a                                  ; $6A89: $77
@@ -6497,9 +6497,9 @@ func_003_6BDE::
     ldh  a, [$FFEF]                               ; $6C34: $F0 $EF
 
 func_003_6C36::
-    ldh  [hScratchB], a                           ; $6C36: $E0 $D8
+    ldh  [hScratch1], a                           ; $6C36: $E0 $D8
     ldh  a, [wActiveEntityPosX]                   ; $6C38: $F0 $EE
-    ldh  [hScratchA], a                           ; $6C3A: $E0 $D7
+    ldh  [hScratch0], a                           ; $6C3A: $E0 $D7
     ld   a, $05                                   ; $6C3C: $3E $05
     jp   label_CC7                                ; $6C3E: $C3 $C7 $0C
 
@@ -7170,13 +7170,13 @@ jr_003_6FB9:
 func_003_6FCC::
 jr_003_6FCC:
     call func_003_7E45                            ; $6FCC: $CD $45 $7E
-    ldh  a, [hScratchA]                           ; $6FCF: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6FCF: $F0 $D7
     cpl                                           ; $6FD1: $2F
     inc  a                                        ; $6FD2: $3C
     ld   hl, $C400                                ; $6FD3: $21 $00 $C4
     add  hl, bc                                   ; $6FD6: $09
     ld   [hl], a                                  ; $6FD7: $77
-    ldh  a, [hScratchB]                           ; $6FD8: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6FD8: $F0 $D8
     cpl                                           ; $6FDA: $2F
     inc  a                                        ; $6FDB: $3C
     ld   hl, $C3F0                                ; $6FDC: $21 $F0 $C3
@@ -7251,13 +7251,13 @@ jr_003_7042:
 
     ld   a, $30                                   ; $7048: $3E $30
     call func_003_7E45                            ; $704A: $CD $45 $7E
-    ldh  a, [hScratchA]                           ; $704D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $704D: $F0 $D7
     cpl                                           ; $704F: $2F
     inc  a                                        ; $7050: $3C
     ld   hl, wEntity0SpeedY                       ; $7051: $21 $50 $C2
     add  hl, bc                                   ; $7054: $09
     ld   [hl], a                                  ; $7055: $77
-    ldh  a, [hScratchB]                           ; $7056: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7056: $F0 $D8
     cpl                                           ; $7058: $2F
     inc  a                                        ; $7059: $3C
     ld   hl, wEntity0SpeedX                       ; $705A: $21 $40 $C2
@@ -7409,9 +7409,9 @@ jr_003_710D:
 
 label_003_713B:
     ldh  a, [wActiveEntityPosX]                   ; $713B: $F0 $EE
-    ldh  [hScratchA], a                           ; $713D: $E0 $D7
+    ldh  [hScratch0], a                           ; $713D: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $713F: $F0 $EC
-    ldh  [hScratchB], a                           ; $7141: $E0 $D8
+    ldh  [hScratch1], a                           ; $7141: $E0 $D8
     jp   label_D15                                ; $7143: $C3 $15 $0D
 
 jr_003_7146:
@@ -7651,14 +7651,14 @@ jr_003_729D:
     ld   hl, wEntity0PosX                         ; $729D: $21 $00 $C2
     add  hl, bc                                   ; $72A0: $09
     ld   a, [hl]                                  ; $72A1: $7E
-    ldh  [hScratchA], a                           ; $72A2: $E0 $D7
+    ldh  [hScratch0], a                           ; $72A2: $E0 $D7
     ld   hl, wEntity0PosY                         ; $72A4: $21 $10 $C2
     add  hl, bc                                   ; $72A7: $09
     ld   a, [hl]                                  ; $72A8: $7E
     ld   hl, wEntitiesPosZTable                                ; $72A9: $21 $10 $C3
     add  hl, bc                                   ; $72AC: $09
     sub  [hl]                                     ; $72AD: $96
-    ldh  [hScratchB], a                           ; $72AE: $E0 $D8
+    ldh  [hScratch1], a                           ; $72AE: $E0 $D8
     ld   a, $02                                   ; $72B0: $3E $02
     jp   label_CC7                                ; $72B2: $C3 $C7 $0C
 
@@ -7964,13 +7964,13 @@ jr_003_7440:
     call func_003_7565                            ; $7457: $CD $65 $75
     ld   a, $18                                   ; $745A: $3E $18
     call func_003_7E45                            ; $745C: $CD $45 $7E
-    ldh  a, [hScratchA]                           ; $745F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $745F: $F0 $D7
     cpl                                           ; $7461: $2F
     inc  a                                        ; $7462: $3C
     ld   hl, $C400                                ; $7463: $21 $00 $C4
     add  hl, bc                                   ; $7466: $09
     ld   [hl], a                                  ; $7467: $77
-    ldh  a, [hScratchB]                           ; $7468: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7468: $F0 $D8
     cpl                                           ; $746A: $2F
     inc  a                                        ; $746B: $3C
     ld   hl, $C3F0                                ; $746C: $21 $F0 $C3
@@ -8032,12 +8032,12 @@ jr_003_74C1:
     add  hl, de                                   ; $74C8: $19
     ld   a, [$C140]                               ; $74C9: $FA $40 $C1
     add  [hl]                                     ; $74CC: $86
-    ldh  [hScratchA], a                           ; $74CD: $E0 $D7
+    ldh  [hScratch0], a                           ; $74CD: $E0 $D7
     ld   hl, $74E8                                ; $74CF: $21 $E8 $74
     add  hl, de                                   ; $74D2: $19
     ld   a, [$C142]                               ; $74D3: $FA $42 $C1
     add  [hl]                                     ; $74D6: $86
-    ldh  [hScratchB], a                           ; $74D7: $E0 $D8
+    ldh  [hScratch1], a                           ; $74D7: $E0 $D8
     call label_D15                                ; $74D9: $CD $15 $0D
 
 jr_003_74DC:
@@ -8063,16 +8063,16 @@ label_003_74EC:
 
     ldh  a, [hLinkPositionX]                      ; $74F2: $F0 $98
     add  $08                                      ; $74F4: $C6 $08
-    ldh  [hScratchA], a                           ; $74F6: $E0 $D7
+    ldh  [hScratch0], a                           ; $74F6: $E0 $D7
     ldh  a, [hLinkPositionY]                      ; $74F8: $F0 $99
     add  $08                                      ; $74FA: $C6 $08
-    ldh  [hScratchC], a                           ; $74FC: $E0 $D9
+    ldh  [hScratch2], a                           ; $74FC: $E0 $D9
     ld   de, wActiveEntityPosX                    ; $74FE: $11 $EE $FF
     ld   hl, $D5C0                                ; $7501: $21 $C0 $D5
     ld   a, [de]                                  ; $7504: $1A
     add  [hl]                                     ; $7505: $86
     push hl                                       ; $7506: $E5
-    ld   hl, hScratchA                            ; $7507: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $7507: $21 $D7 $FF
     sub  [hl]                                     ; $750A: $96
     cp   $80                                      ; $750B: $FE $80
     jr   c, jr_003_7511                           ; $750D: $38 $02
@@ -8096,7 +8096,7 @@ jr_003_7511:
     ld   a, [de]                                  ; $7520: $1A
     add  [hl]                                     ; $7521: $86
     push hl                                       ; $7522: $E5
-    ld   hl, hScratchC                            ; $7523: $21 $D9 $FF
+    ld   hl, hScratch2                            ; $7523: $21 $D9 $FF
     sub  [hl]                                     ; $7526: $96
     cp   $80                                      ; $7527: $FE $80
     jr   c, jr_003_752D                           ; $7529: $38 $02
@@ -8146,9 +8146,9 @@ jr_003_752D:
 func_003_7565::
 jr_003_7565:
     call func_003_7E45                            ; $7565: $CD $45 $7E
-    ldh  a, [hScratchA]                           ; $7568: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7568: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $756A: $E0 $9B
-    ldh  a, [hScratchB]                           ; $756C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $756C: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $756E: $E0 $9A
 
 jr_003_7570:
@@ -8406,11 +8406,11 @@ jr_003_76AC:
     call func_003_64CA                            ; $76EA: $CD $CA $64
     jr   c, jr_003_770D                           ; $76ED: $38 $1E
 
-    ldh  a, [hScratchA]                           ; $76EF: $F0 $D7
+    ldh  a, [hScratch0]                           ; $76EF: $F0 $D7
     ld   hl, wEntity0PosX                         ; $76F1: $21 $00 $C2
     add  hl, de                                   ; $76F4: $19
     ld   [hl], a                                  ; $76F5: $77
-    ldh  a, [hScratchB]                           ; $76F6: $F0 $D8
+    ldh  a, [hScratch1]                           ; $76F6: $F0 $D8
     ld   hl, wEntity0PosY                         ; $76F8: $21 $10 $C2
     add  hl, de                                   ; $76FB: $19
     ld   [hl], a                                  ; $76FC: $77
@@ -8419,7 +8419,7 @@ jr_003_76AC:
     ld   a, c                                     ; $7701: $79
     inc  a                                        ; $7702: $3C
     ld   [hl], a                                  ; $7703: $77
-    ldh  a, [hScratchC]                           ; $7704: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7704: $F0 $D9
     and  $01                                      ; $7706: $E6 $01
     ld   hl, wEntitiesUnknownTableG               ; $7708: $21 $B0 $C3
     add  hl, de                                   ; $770B: $19
@@ -8637,11 +8637,11 @@ jr_003_77DD:
     call func_003_783B                            ; $7823: $CD $3B $78
     ld   hl, $C400                                ; $7826: $21 $00 $C4
     add  hl, de                                   ; $7829: $19
-    ldh  a, [hScratchA]                           ; $782A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $782A: $F0 $D7
     ld   [hl], a                                  ; $782C: $77
     ld   hl, $C3F0                                ; $782D: $21 $F0 $C3
     add  hl, de                                   ; $7830: $19
-    ldh  a, [hScratchB]                           ; $7831: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7831: $F0 $D8
     ld   [hl], a                                  ; $7833: $77
 
 jr_003_7834:
@@ -8653,7 +8653,7 @@ jr_003_7834:
     ret                                           ; $783A: $C9
 
 func_003_783B::
-    ldh  [hScratchA], a                           ; $783B: $E0 $D7
+    ldh  [hScratch0], a                           ; $783B: $E0 $D7
     ldh  a, [hLinkPositionX]                      ; $783D: $F0 $98
     push af                                       ; $783F: $F5
     ld   hl, wEntity0PosX                         ; $7840: $21 $00 $C2
@@ -8667,7 +8667,7 @@ func_003_783B::
     ld   a, [hl]                                  ; $784E: $7E
     ldh  [hLinkPositionY], a                      ; $784F: $E0 $99
     push de                                       ; $7851: $D5
-    ldh  a, [hScratchA]                           ; $7852: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7852: $F0 $D7
     call func_003_7E45                            ; $7854: $CD $45 $7E
     pop  de                                       ; $7857: $D1
     pop  af                                       ; $7858: $F1
@@ -8706,10 +8706,10 @@ func_003_7893::
     ld   hl, $C470                                ; $7893: $21 $70 $C4
     add  hl, bc                                   ; $7896: $09
     ld   a, [hl]                                  ; $7897: $7E
-    ldh  [hScratchA], a                           ; $7898: $E0 $D7
+    ldh  [hScratch0], a                           ; $7898: $E0 $D7
     xor  a                                        ; $789A: $AF
     ld   [hl], a                                  ; $789B: $77
-    ldh  [hScratchB], a                           ; $789C: $E0 $D8
+    ldh  [hScratch1], a                           ; $789C: $E0 $D8
     ld   [$C503], a                               ; $789E: $EA $03 $C5
     ld   [$C50D], a                               ; $78A1: $EA $0D $C5
     ld   hl, wEntitiesPosZTable                                ; $78A4: $21 $10 $C3
@@ -8761,7 +8761,7 @@ jr_003_78E3:
     cp   $67                                      ; $78E7: $FE $67
     jr   z, jr_003_7907                           ; $78E9: $28 $1C
 
-    ldh  a, [hScratchD]                           ; $78EB: $F0 $DA
+    ldh  a, [hScratch3]                           ; $78EB: $F0 $DA
     and  a                                        ; $78ED: $A7
     jp   z, label_003_7A18                        ; $78EE: $CA $18 $7A
 
@@ -8797,7 +8797,7 @@ jr_003_790C:
 
     ld   hl, $C470                                ; $7915: $21 $70 $C4
     add  hl, bc                                   ; $7918: $09
-    ldh  a, [hScratchA]                           ; $7919: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7919: $F0 $D7
     cp   [hl]                                     ; $791B: $BE
     jr   z, jr_003_7973                           ; $791C: $28 $55
 
@@ -8805,7 +8805,7 @@ jr_003_790C:
     cp   $03                                      ; $791F: $FE $03
     jr   z, jr_003_7973                           ; $7921: $28 $50
 
-    ldh  a, [hScratchA]                           ; $7923: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7923: $F0 $D7
     cp   $03                                      ; $7925: $FE $03
     jr   z, jr_003_7973                           ; $7927: $28 $4A
 
@@ -8851,18 +8851,18 @@ label_003_795C:
     ld   hl, wEntity0PosX                         ; $795C: $21 $00 $C2
     add  hl, bc                                   ; $795F: $09
     ld   a, [hl]                                  ; $7960: $7E
-    ldh  [hScratchA], a                           ; $7961: $E0 $D7
+    ldh  [hScratch0], a                           ; $7961: $E0 $D7
     ld   hl, wEntity0PosY                         ; $7963: $21 $10 $C2
     add  hl, bc                                   ; $7966: $09
     ld   a, [hl]                                  ; $7967: $7E
-    ldh  [hScratchB], a                           ; $7968: $E0 $D8
+    ldh  [hScratch1], a                           ; $7968: $E0 $D8
     ld   a, $0E                                   ; $796A: $3E $0E
     ldh  [hJingle], a                             ; $796C: $E0 $F2
     ld   a, $01                                   ; $796E: $3E $01
     call label_CC7                                ; $7970: $CD $C7 $0C
 
 jr_003_7973:
-    ldh  a, [hScratchD]                           ; $7973: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7973: $F0 $DA
     inc  a                                        ; $7975: $3C
     cp   $F1                                      ; $7976: $FE $F1
     jr   c, jr_003_799C                           ; $7978: $38 $22
@@ -8897,7 +8897,7 @@ jr_003_799C:
     cp   $61                                      ; $799E: $FE $61
     jr   z, jr_003_79AC                           ; $79A0: $28 $0A
 
-    ldh  a, [hScratchD]                           ; $79A2: $F0 $DA
+    ldh  a, [hScratch3]                           ; $79A2: $F0 $DA
     cp   $50                                      ; $79A4: $FE $50
     jr   z, jr_003_79AC                           ; $79A6: $28 $04
 
@@ -8988,7 +8988,7 @@ jr_003_7A18:
     and  $03                                      ; $7A28: $E6 $03
     sla  a                                        ; $7A2A: $CB $27
     sla  a                                        ; $7A2C: $CB $27
-    ldh  [hScratchA], a                           ; $7A2E: $E0 $D7
+    ldh  [hScratch0], a                           ; $7A2E: $E0 $D7
     ld   hl, wEntitiesCollisionsTable             ; $7A30: $21 $A0 $C2
     add  hl, bc                                   ; $7A33: $09
     xor  a                                        ; $7A34: $AF
@@ -9095,7 +9095,7 @@ jr_003_7A84:
 
     sub  $08                                      ; $7AD3: $D6 $08
     push af                                       ; $7AD5: $F5
-    ldh  a, [hScratchA]                           ; $7AD6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7AD6: $F0 $D7
     ld   c, a                                     ; $7AD8: $4F
     pop  af                                       ; $7AD9: $F1
     ld   hl, $785F                                ; $7ADA: $21 $5F $78
@@ -9105,7 +9105,7 @@ jr_003_7A84:
     ldh  [$FFDB], a                               ; $7AE0: $E0 $DB
     swap a                                        ; $7AE2: $CB $37
     and  $0F                                      ; $7AE4: $E6 $0F
-    ldh  [hScratchB], a                           ; $7AE6: $E0 $D8
+    ldh  [hScratch1], a                           ; $7AE6: $E0 $D8
     pop  bc                                       ; $7AE8: $C1
     push bc                                       ; $7AE9: $C5
     ld   a, e                                     ; $7AEA: $7B
@@ -9144,7 +9144,7 @@ jr_003_7B0E:
 jr_003_7B13:
     sub  $10                                      ; $7B13: $D6 $10
     push af                                       ; $7B15: $F5
-    ldh  a, [hScratchA]                           ; $7B16: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7B16: $F0 $D7
     ld   c, a                                     ; $7B18: $4F
     pop  af                                       ; $7B19: $F1
     ld   hl, $786F                                ; $7B1A: $21 $6F $78
@@ -9153,7 +9153,7 @@ jr_003_7B13:
     add  [hl]                                     ; $7B1F: $86
     ldh  [$FFDC], a                               ; $7B20: $E0 $DC
     and  $F0                                      ; $7B22: $E6 $F0
-    ld   hl, hScratchB                            ; $7B24: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $7B24: $21 $D8 $FF
     or   [hl]                                     ; $7B27: $B6
     ld   c, a                                     ; $7B28: $4F
     ld   hl, wRoomObjects                         ; $7B29: $21 $11 $D7
@@ -9172,7 +9172,7 @@ jr_003_7B13:
     ld   d, a                                     ; $7B3D: $57
     call label_2A2C                               ; $7B3E: $CD $2C $2A
     pop  de                                       ; $7B41: $D1
-    ldh  [hScratchD], a                           ; $7B42: $E0 $DA
+    ldh  [hScratch3], a                           ; $7B42: $E0 $DA
     ldh  a, [hActiveEntityType]                     ; $7B44: $F0 $EB
     cp   $CC                                      ; $7B46: $FE $CC
     jr   z, jr_003_7B4E                           ; $7B48: $28 $04
@@ -9181,7 +9181,7 @@ jr_003_7B13:
     jr   nz, jr_003_7B5D                          ; $7B4C: $20 $0F
 
 jr_003_7B4E:
-    ldh  a, [hScratchD]                           ; $7B4E: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7B4E: $F0 $DA
     cp   $05                                      ; $7B50: $FE $05
     jp   z, label_003_7CA7                        ; $7B52: $CA $A7 $7C
 
@@ -9191,7 +9191,7 @@ jr_003_7B4E:
     jp   label_003_7C75                           ; $7B5A: $C3 $75 $7C
 
 jr_003_7B5D:
-    ldh  a, [hScratchD]                           ; $7B5D: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7B5D: $F0 $DA
     and  a                                        ; $7B5F: $A7
     jp   z, label_003_7CA7                        ; $7B60: $CA $A7 $7C
 
@@ -9257,7 +9257,7 @@ jr_003_7BA7:
 
 jr_003_7BBB:
     push de                                       ; $7BBB: $D5
-    ldh  a, [hScratchD]                           ; $7BBC: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7BBC: $F0 $DA
     sub  $7C                                      ; $7BBE: $D6 $7C
     sla  a                                        ; $7BC0: $CB $27
     sla  a                                        ; $7BC2: $CB $27
@@ -9285,7 +9285,7 @@ jr_003_7BBB:
     jp   z, label_003_7CA7                        ; $7BE1: $CA $A7 $7C
 
 label_003_7BE4:
-    ldh  a, [hScratchD]                           ; $7BE4: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7BE4: $F0 $DA
     cp   $D0                                      ; $7BE6: $FE $D0
     jr   c, jr_003_7C2B                           ; $7BE8: $38 $41
 
@@ -9392,7 +9392,7 @@ jr_003_7C5A:
 
 label_003_7C75:
 jr_003_7C75:
-    ldh  a, [hScratchD]                           ; $7C75: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7C75: $F0 $DA
     cp   $60                                      ; $7C77: $FE $60
     jr   nz, jr_003_7C91                          ; $7C79: $20 $16
 
@@ -9567,11 +9567,11 @@ jr_003_7D6B:
     ld   a, [wIsIndoor]                           ; $7D6D: $FA $A5 $DB
     ld   d, a                                     ; $7D70: $57
     call label_2A2C                               ; $7D71: $CD $2C $2A
-    ldh  [hScratchB], a                           ; $7D74: $E0 $D8
+    ldh  [hScratch1], a                           ; $7D74: $E0 $D8
     and  a                                        ; $7D76: $A7
     jp   z, label_003_7E03                        ; $7D77: $CA $03 $7E
 
-    ldh  [hScratchD], a                           ; $7D7A: $E0 $DA
+    ldh  [hScratch3], a                           ; $7D7A: $E0 $DA
     cp   $FF                                      ; $7D7C: $FE $FF
     jp   z, label_003_7E05                        ; $7D7E: $CA $05 $7E
 
@@ -9631,7 +9631,7 @@ jr_003_7DC0:
     jp   label_003_7E03                           ; $7DCA: $C3 $03 $7E
 
 label_003_7DCD:
-    ldh  a, [hScratchD]                           ; $7DCD: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7DCD: $F0 $DA
     cp   $A0                                      ; $7DCF: $FE $A0
     jr   nc, jr_003_7E03                          ; $7DD1: $30 $30
 
@@ -9716,11 +9716,11 @@ func_003_7E0E::
     ld   a, [wIsIndoor]                           ; $7E3B: $FA $A5 $DB
     ld   d, a                                     ; $7E3E: $57
     call label_2A2C                               ; $7E3F: $CD $2C $2A
-    ldh  [hScratchD], a                           ; $7E42: $E0 $DA
+    ldh  [hScratch3], a                           ; $7E42: $E0 $DA
     ret                                           ; $7E44: $C9
 
 func_003_7E45::
-    ldh  [hScratchB], a                           ; $7E45: $E0 $D8
+    ldh  [hScratch1], a                           ; $7E45: $E0 $D8
     and  a                                        ; $7E47: $A7
     jp   z, label_003_7EC3                        ; $7E48: $CA $C3 $7E
 
@@ -9728,7 +9728,7 @@ func_003_7E45::
     dec  e                                        ; $7E4E: $1D
     dec  e                                        ; $7E4F: $1D
     ld   a, e                                     ; $7E50: $7B
-    ldh  [hScratchC], a                           ; $7E51: $E0 $D9
+    ldh  [hScratch2], a                           ; $7E51: $E0 $D9
     ld   a, d                                     ; $7E53: $7A
     bit  7, a                                     ; $7E54: $CB $7F
     jr   z, jr_003_7E5A                           ; $7E56: $28 $02
@@ -9740,7 +9740,7 @@ jr_003_7E5A:
     ldh  [$FFE3], a                               ; $7E5A: $E0 $E3
     call func_003_7ED9                            ; $7E5C: $CD $D9 $7E
     ld   a, e                                     ; $7E5F: $7B
-    ldh  [hScratchD], a                           ; $7E60: $E0 $DA
+    ldh  [hScratch3], a                           ; $7E60: $E0 $DA
     ld   a, d                                     ; $7E62: $7A
     bit  7, a                                     ; $7E63: $CB $7F
     jr   z, jr_003_7E69                           ; $7E65: $28 $02
@@ -9766,8 +9766,8 @@ jr_003_7E69:
 jr_003_7E7E:
     xor  a                                        ; $7E7E: $AF
     ldh  [$FFE2], a                               ; $7E7F: $E0 $E2
-    ldh  [hScratchA], a                           ; $7E81: $E0 $D7
-    ldh  a, [hScratchB]                           ; $7E83: $F0 $D8
+    ldh  [hScratch0], a                           ; $7E81: $E0 $D7
+    ldh  a, [hScratch1]                           ; $7E83: $F0 $D8
     ld   d, a                                     ; $7E85: $57
 
 jr_003_7E86:
@@ -9782,7 +9782,7 @@ jr_003_7E86:
 
 jr_003_7E94:
     sub  [hl]                                     ; $7E94: $96
-    ld   hl, hScratchA                            ; $7E95: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $7E95: $21 $D7 $FF
     inc  [hl]                                     ; $7E98: $34
 
 jr_003_7E99:
@@ -9794,49 +9794,49 @@ jr_003_7E99:
     and  a                                        ; $7E9F: $A7
     jr   z, jr_003_7EAC                           ; $7EA0: $28 $0A
 
-    ldh  a, [hScratchA]                           ; $7EA2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7EA2: $F0 $D7
     push af                                       ; $7EA4: $F5
-    ldh  a, [hScratchB]                           ; $7EA5: $F0 $D8
-    ldh  [hScratchA], a                           ; $7EA7: $E0 $D7
+    ldh  a, [hScratch1]                           ; $7EA5: $F0 $D8
+    ldh  [hScratch0], a                           ; $7EA7: $E0 $D7
     pop  af                                       ; $7EA9: $F1
-    ldh  [hScratchB], a                           ; $7EAA: $E0 $D8
+    ldh  [hScratch1], a                           ; $7EAA: $E0 $D8
 
 jr_003_7EAC:
-    ldh  a, [hScratchC]                           ; $7EAC: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7EAC: $F0 $D9
     and  a                                        ; $7EAE: $A7
-    ldh  a, [hScratchA]                           ; $7EAF: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7EAF: $F0 $D7
     jr   nz, jr_003_7EB7                          ; $7EB1: $20 $04
 
     cpl                                           ; $7EB3: $2F
     inc  a                                        ; $7EB4: $3C
-    ldh  [hScratchA], a                           ; $7EB5: $E0 $D7
+    ldh  [hScratch0], a                           ; $7EB5: $E0 $D7
 
 jr_003_7EB7:
-    ldh  a, [hScratchD]                           ; $7EB7: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7EB7: $F0 $DA
     and  a                                        ; $7EB9: $A7
-    ldh  a, [hScratchB]                           ; $7EBA: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7EBA: $F0 $D8
     jr   z, jr_003_7EC2                           ; $7EBC: $28 $04
 
     cpl                                           ; $7EBE: $2F
     inc  a                                        ; $7EBF: $3C
-    ldh  [hScratchB], a                           ; $7EC0: $E0 $D8
+    ldh  [hScratch1], a                           ; $7EC0: $E0 $D8
 
 jr_003_7EC2:
     ret                                           ; $7EC2: $C9
 
 label_003_7EC3:
     xor  a                                        ; $7EC3: $AF
-    ldh  [hScratchA], a                           ; $7EC4: $E0 $D7
+    ldh  [hScratch0], a                           ; $7EC4: $E0 $D7
     ret                                           ; $7EC6: $C9
 
 func_003_7EC7::
 label_003_7EC7:
     call func_003_7E45                            ; $7EC7: $CD $45 $7E
-    ldh  a, [hScratchA]                           ; $7ECA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7ECA: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $7ECC: $21 $50 $C2
     add  hl, bc                                   ; $7ECF: $09
     ld   [hl], a                                  ; $7ED0: $77
-    ldh  a, [hScratchB]                           ; $7ED1: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7ED1: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $7ED3: $21 $40 $C2
     add  hl, bc                                   ; $7ED6: $09
     ld   [hl], a                                  ; $7ED7: $77
@@ -9878,7 +9878,7 @@ jr_003_7EFC:
 func_003_7EFE::
     call func_003_7ED9                            ; $7EFE: $CD $D9 $7E
     ld   a, e                                     ; $7F01: $7B
-    ldh  [hScratchA], a                           ; $7F02: $E0 $D7
+    ldh  [hScratch0], a                           ; $7F02: $E0 $D7
     ld   a, d                                     ; $7F04: $7A
     bit  7, a                                     ; $7F05: $CB $7F
     jr   z, jr_003_7F0B                           ; $7F07: $28 $02
@@ -9890,7 +9890,7 @@ jr_003_7F0B:
     push af                                       ; $7F0B: $F5
     call func_003_7EE9                            ; $7F0C: $CD $E9 $7E
     ld   a, e                                     ; $7F0F: $7B
-    ldh  [hScratchB], a                           ; $7F10: $E0 $D8
+    ldh  [hScratch1], a                           ; $7F10: $E0 $D8
     ld   a, d                                     ; $7F12: $7A
     bit  7, a                                     ; $7F13: $CB $7F
     jr   z, jr_003_7F19                           ; $7F15: $28 $02
@@ -9903,11 +9903,11 @@ jr_003_7F19:
     cp   d                                        ; $7F1A: $BA
     jr   nc, jr_003_7F21                          ; $7F1B: $30 $04
 
-    ldh  a, [hScratchA]                           ; $7F1D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7F1D: $F0 $D7
     jr   jr_003_7F23                              ; $7F1F: $18 $02
 
 jr_003_7F21:
-    ldh  a, [hScratchB]                           ; $7F21: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7F21: $F0 $D8
 
 jr_003_7F23:
     ld   e, a                                     ; $7F23: $5F

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -1841,7 +1841,7 @@ jr_036_4A6A:
     ld   l, a                                     ; $4A70: $6F
     add  hl, bc                                   ; $4A71: $09
     ld   a, [hl]                                  ; $4A72: $7E
-    ldh  [hScratchA], a                           ; $4A73: $E0 $D7
+    ldh  [hScratch0], a                           ; $4A73: $E0 $D7
     pop  bc                                       ; $4A75: $C1
     ret                                           ; $4A76: $C9
 
@@ -2208,10 +2208,10 @@ jr_036_4C7C:
     ret  nc                                       ; $4CA5: $D0
 
     ldh  a, [wActiveEntityPosX]                   ; $4CA6: $F0 $EE
-    ldh  [hScratchA], a                           ; $4CA8: $E0 $D7
+    ldh  [hScratch0], a                           ; $4CA8: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4CAA: $F0 $EC
     add  $0C                                      ; $4CAC: $C6 $0C
-    ldh  [hScratchB], a                           ; $4CAE: $E0 $D8
+    ldh  [hScratch1], a                           ; $4CAE: $E0 $D8
     call label_D15                                ; $4CB0: $CD $15 $0D
     ret                                           ; $4CB3: $C9
 
@@ -2345,9 +2345,9 @@ jr_036_4D5C:
     ld   [$C13E], a                               ; $4D5E: $EA $3E $C1
     ld   a, $14                                   ; $4D61: $3E $14
     call label_3BB5                               ; $4D63: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $4D66: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4D66: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $4D68: $E0 $9B
-    ldh  a, [hScratchB]                           ; $4D6A: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4D6A: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $4D6C: $E0 $9A
 
 jr_036_4D6E:
@@ -2535,7 +2535,7 @@ jr_036_4E5C:
 
 func_036_4E7F:
     xor  a                                        ; $4E7F: $AF
-    ldh  [hScratchA], a                           ; $4E80: $E0 $D7
+    ldh  [hScratch0], a                           ; $4E80: $E0 $D7
     ld   e, a                                     ; $4E82: $5F
     ld   d, a                                     ; $4E83: $57
 
@@ -2552,7 +2552,7 @@ jr_036_4E84:
     and  a                                        ; $4E92: $A7
     jr   z, jr_036_4E99                           ; $4E93: $28 $04
 
-    ld   hl, hScratchA                            ; $4E95: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $4E95: $21 $D7 $FF
     inc  [hl]                                     ; $4E98: $34
 
 jr_036_4E99:
@@ -2561,7 +2561,7 @@ jr_036_4E99:
     and  $0F                                      ; $4E9B: $E6 $0F
     jr   nz, jr_036_4E84                          ; $4E9D: $20 $E5
 
-    ldh  a, [hScratchA]                           ; $4E9F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4E9F: $F0 $D7
     ret                                           ; $4EA1: $C9
 
     call func_036_4E7F                            ; $4EA2: $CD $7F $4E
@@ -3108,7 +3108,7 @@ func_036_51DF:
     ret                                           ; $51F5: $C9
 
 func_036_51F6:
-    ldh  a, [hScratchA]                           ; $51F6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $51F6: $F0 $D7
     inc  a                                        ; $51F8: $3C
     bit  5, a                                     ; $51F9: $CB $6F
     jr   z, jr_036_51FF                           ; $51FB: $28 $02
@@ -3116,8 +3116,8 @@ func_036_51F6:
     ld   a, $1F                                   ; $51FD: $3E $1F
 
 jr_036_51FF:
-    ldh  [hScratchA], a                           ; $51FF: $E0 $D7
-    ldh  a, [hScratchB]                           ; $5201: $F0 $D8
+    ldh  [hScratch0], a                           ; $51FF: $E0 $D7
+    ldh  a, [hScratch1]                           ; $5201: $F0 $D8
     sub  $02                                      ; $5203: $D6 $02
     and  a                                        ; $5205: $A7
     jr   nz, jr_036_520A                          ; $5206: $20 $02
@@ -3125,8 +3125,8 @@ jr_036_51FF:
     ld   a, $02                                   ; $5208: $3E $02
 
 jr_036_520A:
-    ldh  [hScratchB], a                           ; $520A: $E0 $D8
-    ldh  a, [hScratchC]                           ; $520C: $F0 $D9
+    ldh  [hScratch1], a                           ; $520A: $E0 $D8
+    ldh  a, [hScratch2]                           ; $520C: $F0 $D9
     sub  $04                                      ; $520E: $D6 $04
     cp   $14                                      ; $5210: $FE $14
     jr   nc, jr_036_5216                          ; $5212: $30 $02
@@ -3134,11 +3134,11 @@ jr_036_520A:
     ld   a, $14                                   ; $5214: $3E $14
 
 jr_036_5216:
-    ldh  [hScratchC], a                           ; $5216: $E0 $D9
+    ldh  [hScratch2], a                           ; $5216: $E0 $D9
     ret                                           ; $5218: $C9
 
 func_036_5219:
-    ldh  a, [hScratchA]                           ; $5219: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5219: $F0 $D7
     dec  a                                        ; $521B: $3D
     cp   $03                                      ; $521C: $FE $03
     jr   nc, jr_036_5222                          ; $521E: $30 $02
@@ -3146,8 +3146,8 @@ func_036_5219:
     ld   a, $03                                   ; $5220: $3E $03
 
 jr_036_5222:
-    ldh  [hScratchA], a                           ; $5222: $E0 $D7
-    ldh  a, [hScratchB]                           ; $5224: $F0 $D8
+    ldh  [hScratch0], a                           ; $5222: $E0 $D7
+    ldh  a, [hScratch1]                           ; $5224: $F0 $D8
     bit  5, a                                     ; $5226: $CB $6F
     jr   nz, jr_036_5234                          ; $5228: $20 $0A
 
@@ -3166,8 +3166,8 @@ jr_036_5234:
     ld   a, $20                                   ; $523A: $3E $20
 
 jr_036_523C:
-    ldh  [hScratchB], a                           ; $523C: $E0 $D8
-    ldh  a, [hScratchC]                           ; $523E: $F0 $D9
+    ldh  [hScratch1], a                           ; $523C: $E0 $D8
+    ldh  a, [hScratch2]                           ; $523E: $F0 $D9
     add  $04                                      ; $5240: $C6 $04
     bit  7, a                                     ; $5242: $CB $7F
     jr   z, jr_036_5248                           ; $5244: $28 $02
@@ -3175,7 +3175,7 @@ jr_036_523C:
     ld   a, $7C                                   ; $5246: $3E $7C
 
 jr_036_5248:
-    ldh  [hScratchC], a                           ; $5248: $E0 $D9
+    ldh  [hScratch2], a                           ; $5248: $E0 $D9
     ret                                           ; $524A: $C9
 
     ld   a, $02                                   ; $524B: $3E $02
@@ -3204,7 +3204,7 @@ jr_036_526E:
     push hl                                       ; $526E: $E5
     ld   a, [hl]                                  ; $526F: $7E
     and  $1F                                      ; $5270: $E6 $1F
-    ldh  [hScratchA], a                           ; $5272: $E0 $D7
+    ldh  [hScratch0], a                           ; $5272: $E0 $D7
     ld   a, [hl+]                                 ; $5274: $2A
     and  $E0                                      ; $5275: $E6 $E0
     swap a                                        ; $5277: $CB $37
@@ -3213,10 +3213,10 @@ jr_036_526E:
     and  $03                                      ; $527B: $E6 $03
     swap a                                        ; $527D: $CB $37
     or   e                                        ; $527F: $B3
-    ldh  [hScratchB], a                           ; $5280: $E0 $D8
+    ldh  [hScratch1], a                           ; $5280: $E0 $D8
     ld   a, [hl]                                  ; $5282: $7E
     and  $7C                                      ; $5283: $E6 $7C
-    ldh  [hScratchC], a                           ; $5285: $E0 $D9
+    ldh  [hScratch2], a                           ; $5285: $E0 $D9
     ld   hl, wEntitiesUnknownTableC               ; $5287: $21 $C0 $C2
     add  hl, bc                                   ; $528A: $09
     ld   a, [hl]                                  ; $528B: $7E
@@ -3231,18 +3231,18 @@ jr_036_5294:
 
 jr_036_5297:
     pop  hl                                       ; $5297: $E1
-    ldh  a, [hScratchA]                           ; $5298: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5298: $F0 $D7
     ld   e, a                                     ; $529A: $5F
-    ldh  a, [hScratchB]                           ; $529B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $529B: $F0 $D8
     and  $0E                                      ; $529D: $E6 $0E
     swap a                                        ; $529F: $CB $37
     or   e                                        ; $52A1: $B3
     ld   [hl+], a                                 ; $52A2: $22
-    ldh  a, [hScratchB]                           ; $52A3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $52A3: $F0 $D8
     and  $30                                      ; $52A5: $E6 $30
     swap a                                        ; $52A7: $CB $37
     ld   e, a                                     ; $52A9: $5F
-    ldh  a, [hScratchC]                           ; $52AA: $F0 $D9
+    ldh  a, [hScratch2]                           ; $52AA: $F0 $D9
     or   e                                        ; $52AC: $B3
     ld   [hl], a                                  ; $52AD: $77
     ld   a, $02                                   ; $52AE: $3E $02
@@ -3927,9 +3927,9 @@ jr_036_5661:
     ld   [$C13E], a                               ; $5663: $EA $3E $C1
     ld   a, $20                                   ; $5666: $3E $20
     call label_3BB5                               ; $5668: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $566B: $F0 $D7
+    ldh  a, [hScratch0]                           ; $566B: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $566D: $E0 $9B
-    ldh  a, [hScratchB]                           ; $566F: $F0 $D8
+    ldh  a, [hScratch1]                           ; $566F: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $5671: $E0 $9A
 
 jr_036_5673:
@@ -5064,9 +5064,9 @@ func_036_5C8B:
 
 func_036_5CAB:
     ldh  a, [wActiveEntityPosX]                   ; $5CAB: $F0 $EE
-    ldh  [hScratchA], a                           ; $5CAD: $E0 $D7
+    ldh  [hScratch0], a                           ; $5CAD: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $5CAF: $F0 $EC
-    ldh  [hScratchB], a                           ; $5CB1: $E0 $D8
+    ldh  [hScratch1], a                           ; $5CB1: $E0 $D8
     ld   a, $02                                   ; $5CB3: $3E $02
     call label_CC7                                ; $5CB5: $CD $C7 $0C
     ld   a, $13                                   ; $5CB8: $3E $13
@@ -5085,9 +5085,9 @@ func_036_5CBD:
     ld   [$C13E], a                               ; $5CC9: $EA $3E $C1
     ld   a, $20                                   ; $5CCC: $3E $20
     call label_3BB5                               ; $5CCE: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $5CD1: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5CD1: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $5CD3: $E0 $9B
-    ldh  a, [hScratchB]                           ; $5CD5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5CD5: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $5CD7: $E0 $9A
     ld   a, $30                                   ; $5CD9: $3E $30
     call func_036_6C83                            ; $5CDB: $CD $83 $6C
@@ -5398,7 +5398,7 @@ func_036_5EC2:
     xor  a                                        ; $5EC2: $AF
     ld   e, a                                     ; $5EC3: $5F
     ld   d, a                                     ; $5EC4: $57
-    ldh  [hScratchA], a                           ; $5EC5: $E0 $D7
+    ldh  [hScratch0], a                           ; $5EC5: $E0 $D7
 
 jr_036_5EC7:
     ld   hl, wEntitiesTypeTable                   ; $5EC7: $21 $A0 $C3
@@ -5413,7 +5413,7 @@ jr_036_5EC7:
     and  a                                        ; $5ED5: $A7
     jr   z, jr_036_5EDC                           ; $5ED6: $28 $04
 
-    ld   hl, hScratchA                            ; $5ED8: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $5ED8: $21 $D7 $FF
     inc  [hl]                                     ; $5EDB: $34
 
 jr_036_5EDC:
@@ -5422,7 +5422,7 @@ jr_036_5EDC:
     and  $0F                                      ; $5EDE: $E6 $0F
     jr   nz, jr_036_5EC7                          ; $5EE0: $20 $E5
 
-    ldh  a, [hScratchA]                           ; $5EE2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5EE2: $F0 $D7
     cp   $06                                      ; $5EE4: $FE $06
     ret  nc                                       ; $5EE6: $D0
 
@@ -5605,13 +5605,13 @@ jr_036_5FDA:
     call func_036_6BF8                            ; $5FDB: $CD $F8 $6B
     dec  [hl]                                     ; $5FDE: $35
     ld   a, [hl]                                  ; $5FDF: $7E
-    ldh  [hScratchA], a                           ; $5FE0: $E0 $D7
+    ldh  [hScratch0], a                           ; $5FE0: $E0 $D7
     call func_036_6AEC                            ; $5FE2: $CD $EC $6A
     ld   a, [hl]                                  ; $5FE5: $7E
     bit  7, a                                     ; $5FE6: $CB $7F
     jr   z, jr_036_604E                           ; $5FE8: $28 $64
 
-    ldh  a, [hScratchA]                           ; $5FEA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5FEA: $F0 $D7
     bit  7, a                                     ; $5FEC: $CB $7F
     jr   z, jr_036_604E                           ; $5FEE: $28 $5E
 
@@ -5652,10 +5652,10 @@ jr_036_6014:
     ld   e, [hl]                                  ; $6026: $5E
     call func_036_6C23                            ; $6027: $CD $23 $6C
     ld   a, [hl]                                  ; $602A: $7E
-    ldh  [hScratchA], a                           ; $602B: $E0 $D7
+    ldh  [hScratch0], a                           ; $602B: $E0 $D7
     call func_036_6C28                            ; $602D: $CD $28 $6C
     ld   a, [hl]                                  ; $6030: $7E
-    ldh  [hScratchB], a                           ; $6031: $E0 $D8
+    ldh  [hScratch1], a                           ; $6031: $E0 $D8
     ld   a, $36                                   ; $6033: $3E $36
     call label_9DE                                ; $6035: $CD $DE $09
     ld   hl, wRoomObjects                         ; $6038: $21 $11 $D7
@@ -5719,9 +5719,9 @@ func_036_6084:
     cp   $10                                      ; $6087: $FE $10
     jr   nc, jr_036_60B2                          ; $6089: $30 $27
 
-    ldh  [hScratchA], a                           ; $608B: $E0 $D7
+    ldh  [hScratch0], a                           ; $608B: $E0 $D7
     ld   a, e                                     ; $608D: $7B
-    ldh  [hScratchB], a                           ; $608E: $E0 $D8
+    ldh  [hScratch1], a                           ; $608E: $E0 $D8
     call func_036_6B9A                            ; $6090: $CD $9A $6B
     cp   $10                                      ; $6093: $FE $10
     jr   nc, jr_036_60B2                          ; $6095: $30 $1B
@@ -6096,10 +6096,10 @@ jr_036_629E:
 func_036_629F:
     call func_036_6C23                            ; $629F: $CD $23 $6C
     ld   a, [hl]                                  ; $62A2: $7E
-    ldh  [hScratchA], a                           ; $62A3: $E0 $D7
+    ldh  [hScratch0], a                           ; $62A3: $E0 $D7
     call func_036_6C28                            ; $62A5: $CD $28 $6C
     ld   a, [hl]                                  ; $62A8: $7E
-    ldh  [hScratchB], a                           ; $62A9: $E0 $D8
+    ldh  [hScratch1], a                           ; $62A9: $E0 $D8
     ld   de, $0000                                ; $62AB: $11 $00 $00
 
 jr_036_62AE:
@@ -6125,7 +6125,7 @@ jr_036_62C3:
     inc  [hl]                                     ; $62C7: $34
     ld   hl, wEntity0PosX                         ; $62C8: $21 $00 $C2
     add  hl, de                                   ; $62CB: $19
-    ldh  a, [hScratchA]                           ; $62CC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $62CC: $F0 $D7
     cp   [hl]                                     ; $62CE: $BE
     jr   nz, jr_036_62EA                          ; $62CF: $20 $19
 
@@ -6135,7 +6135,7 @@ jr_036_62C3:
 
     ld   hl, wEntity0PosY                         ; $62D7: $21 $10 $C2
     add  hl, de                                   ; $62DA: $19
-    ldh  a, [hScratchB]                           ; $62DB: $F0 $D8
+    ldh  a, [hScratch1]                           ; $62DB: $F0 $D8
     sub  [hl]                                     ; $62DD: $96
     bit  7, a                                     ; $62DE: $CB $7F
     jr   z, jr_036_62E4                           ; $62E0: $28 $02
@@ -6152,7 +6152,7 @@ jr_036_62E4:
 jr_036_62EA:
     ld   hl, wEntity0PosY                         ; $62EA: $21 $10 $C2
     add  hl, de                                   ; $62ED: $19
-    ldh  a, [hScratchB]                           ; $62EE: $F0 $D8
+    ldh  a, [hScratch1]                           ; $62EE: $F0 $D8
     cp   [hl]                                     ; $62F0: $BE
     jr   nz, jr_036_631A                          ; $62F1: $20 $27
 
@@ -6162,7 +6162,7 @@ jr_036_62EA:
 
     ld   hl, wEntity0PosX                         ; $62F9: $21 $00 $C2
     add  hl, de                                   ; $62FC: $19
-    ldh  a, [hScratchA]                           ; $62FD: $F0 $D7
+    ldh  a, [hScratch0]                           ; $62FD: $F0 $D7
     sub  [hl]                                     ; $62FF: $96
     bit  7, a                                     ; $6300: $CB $7F
     jr   z, jr_036_6306                           ; $6302: $28 $02
@@ -6416,7 +6416,7 @@ label_036_6423:
     ld   e, [hl]                                  ; $643E: $5E
     call func_036_6C62                            ; $643F: $CD $62 $6C
     sub  e                                        ; $6442: $93
-    ldh  [hScratchA], a                           ; $6443: $E0 $D7
+    ldh  [hScratch0], a                           ; $6443: $E0 $D7
     call func_036_6BEE                            ; $6445: $CD $EE $6B
     and  a                                        ; $6448: $A7
     jr   nz, jr_036_644C                          ; $6449: $20 $01
@@ -6437,7 +6437,7 @@ jr_036_6454:
     ld   e, [hl]                                  ; $6457: $5E
     call func_036_6C70                            ; $6458: $CD $70 $6C
     sub  e                                        ; $645B: $93
-    ldh  [hScratchB], a                           ; $645C: $E0 $D8
+    ldh  [hScratch1], a                           ; $645C: $E0 $D8
     call func_036_6BF3                            ; $645E: $CD $F3 $6B
     and  a                                        ; $6461: $A7
     jr   nz, jr_036_6465                          ; $6462: $20 $01
@@ -6454,10 +6454,10 @@ jr_036_6465:
     ld   [hl], a                                  ; $646C: $77
 
 jr_036_646D:
-    ldh  a, [hScratchA]                           ; $646D: $F0 $D7
+    ldh  a, [hScratch0]                           ; $646D: $F0 $D7
     and  $FE                                      ; $646F: $E6 $FE
     ld   e, a                                     ; $6471: $5F
-    ldh  a, [hScratchB]                           ; $6472: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6472: $F0 $D8
     and  $FE                                      ; $6474: $E6 $FE
     push af                                       ; $6476: $F5
     push de                                       ; $6477: $D5
@@ -6935,7 +6935,7 @@ jr_036_66EC:
     ret  nz                                       ; $66F2: $C0
 
     xor  a                                        ; $66F3: $AF
-    ldh  [hScratchA], a                           ; $66F4: $E0 $D7
+    ldh  [hScratch0], a                           ; $66F4: $E0 $D7
     ld   e, $00                                   ; $66F6: $1E $00
     ld   d, e                                     ; $66F8: $53
 
@@ -6952,7 +6952,7 @@ jr_036_66F9:
     and  a                                        ; $6707: $A7
     ret  nz                                       ; $6708: $C0
 
-    ld   hl, hScratchA                            ; $6709: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $6709: $21 $D7 $FF
     inc  [hl]                                     ; $670C: $34
 
 jr_036_670D:
@@ -7420,12 +7420,12 @@ jr_036_6999:
     ld   [hl], a                                  ; $69B3: $77
     call func_036_6C23                            ; $69B4: $CD $23 $6C
     ld   a, [hl]                                  ; $69B7: $7E
-    ldh  [hScratchA], a                           ; $69B8: $E0 $D7
+    ldh  [hScratch0], a                           ; $69B8: $E0 $D7
     call func_036_6C28                            ; $69BA: $CD $28 $6C
     ld   a, [hl]                                  ; $69BD: $7E
     call func_036_6C2D                            ; $69BE: $CD $2D $6C
     sub  [hl]                                     ; $69C1: $96
-    ldh  [hScratchB], a                           ; $69C2: $E0 $D8
+    ldh  [hScratch1], a                           ; $69C2: $E0 $D8
     ld   a, $02                                   ; $69C4: $3E $02
     call label_CC7                                ; $69C6: $CD $C7 $0C
     call $3F5E                                    ; $69C9: $CD $5E $3F
@@ -7447,7 +7447,7 @@ jr_036_69CC:
     db   $EB                                      ; $69DA: $EB
     sub  $E9                                      ; $69DB: $D6 $E9
     sla  a                                        ; $69DD: $CB $27
-    ldh  [hScratchA], a                           ; $69DF: $E0 $D7
+    ldh  [hScratch0], a                           ; $69DF: $E0 $D7
     ld   d, $00                                   ; $69E1: $16 $00
     call func_036_6C02                            ; $69E3: $CD $02 $6C
     ldh  a, [hActiveEntityWalking]                ; $69E6: $F0 $F0
@@ -7467,7 +7467,7 @@ jr_036_69F2:
     sla  a                                        ; $69F9: $CB $27
     ld   e, a                                     ; $69FB: $5F
     push de                                       ; $69FC: $D5
-    ldh  a, [hScratchA]                           ; $69FD: $F0 $D7
+    ldh  a, [hScratch0]                           ; $69FD: $F0 $D7
     ld   e, a                                     ; $69FF: $5F
     ld   hl, $69D3                                ; $6A00: $21 $D3 $69
     add  hl, de                                   ; $6A03: $19
@@ -7486,7 +7486,7 @@ jr_036_6A0A:
     sla  a                                        ; $6A11: $CB $27
     ld   e, a                                     ; $6A13: $5F
     push de                                       ; $6A14: $D5
-    ldh  a, [hScratchA]                           ; $6A15: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A15: $F0 $D7
     ld   e, a                                     ; $6A17: $5F
     ld   hl, $69CD                                ; $6A18: $21 $CD $69
     add  hl, de                                   ; $6A1B: $19
@@ -7788,7 +7788,7 @@ func_036_6BAB:
     ld   d, a                                     ; $6BAE: $57
     push af                                       ; $6BAF: $F5
     ld   a, e                                     ; $6BB0: $7B
-    ldh  [hScratchA], a                           ; $6BB1: $E0 $D7
+    ldh  [hScratch0], a                           ; $6BB1: $E0 $D7
     call func_036_6B9A                            ; $6BB3: $CD $9A $6B
     ld   d, a                                     ; $6BB6: $57
     ld   a, e                                     ; $6BB7: $7B
@@ -7799,17 +7799,17 @@ func_036_6BAB:
     ld   a, $03                                   ; $6BBE: $3E $03
 
 jr_036_6BC0:
-    ldh  [hScratchB], a                           ; $6BC0: $E0 $D8
+    ldh  [hScratch1], a                           ; $6BC0: $E0 $D8
     ld   a, d                                     ; $6BC2: $7A
     pop  de                                       ; $6BC3: $D1
     cp   d                                        ; $6BC4: $BA
     jr   nc, jr_036_6BCB                          ; $6BC5: $30 $04
 
-    ldh  a, [hScratchA]                           ; $6BC7: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6BC7: $F0 $D7
     jr   jr_036_6BCD                              ; $6BC9: $18 $02
 
 jr_036_6BCB:
-    ldh  a, [hScratchB]                           ; $6BCB: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6BCB: $F0 $D8
 
 jr_036_6BCD:
     ld   e, a                                     ; $6BCD: $5F
@@ -8434,11 +8434,11 @@ jr_036_6EA0:
     call label_3B86                               ; $6EA7: $CD $86 $3B
     jr   c, jr_036_6EC6                           ; $6EAA: $38 $1A
 
-    ldh  a, [hScratchA]                           ; $6EAC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6EAC: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6EAE: $21 $00 $C2
     add  hl, de                                   ; $6EB1: $19
     ld   [hl], a                                  ; $6EB2: $77
-    ldh  a, [hScratchB]                           ; $6EB3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6EB3: $F0 $D8
     ld   hl, wEntity0PosY                         ; $6EB5: $21 $10 $C2
     add  hl, de                                   ; $6EB8: $19
     ld   [hl], a                                  ; $6EB9: $77
@@ -8782,7 +8782,7 @@ jr_036_707A:
     ld   hl, $7056                                ; $707A: $21 $56 $70
     add  hl, bc                                   ; $707D: $09
     add  [hl]                                     ; $707E: $86
-    ld   hl, hScratchD                            ; $707F: $21 $DA $FF
+    ld   hl, hScratch3                            ; $707F: $21 $DA $FF
     sub  [hl]                                     ; $7082: $96
     ld   hl, wEntity0PosY                         ; $7083: $21 $10 $C2
     add  hl, de                                   ; $7086: $19

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -24,11 +24,11 @@ EntityTableBHandler0::
 
     ld   a, $5C                                   ; $401F: $3E $5C
     call label_3B86                               ; $4021: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $4024: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4024: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4026: $21 $00 $C2
     add  hl, de                                   ; $4029: $19
     ld   [hl], a                                  ; $402A: $77
-    ldh  a, [hScratchB]                           ; $402B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $402B: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $402D: $21 $10 $C2
     add  hl, de                                   ; $4030: $19
     sub  $18                                      ; $4031: $D6 $18
@@ -115,9 +115,9 @@ jr_004_409E:
     ld   [$C13E], a                               ; $40B7: $EA $3E $C1
     ld   a, $14                                   ; $40BA: $3E $14
     call label_3BB5                               ; $40BC: $CD $B5 $3B
-    ldh  a, [hScratchA]                               ; $40BF: $F0 $D7
+    ldh  a, [hScratch0]                               ; $40BF: $F0 $D7
     ldh  [hLinkPositionYIncrement], a                               ; $40C1: $E0 $9B
-    ldh  a, [hScratchB]                               ; $40C3: $F0 $D8
+    ldh  a, [hScratch1]                               ; $40C3: $F0 $D8
     ldh  [hLinkPositionXIncrement], a                               ; $40C5: $E0 $9A
 
 jr_004_40C7:
@@ -180,11 +180,11 @@ jr_004_4118:
 
     ld   a, $5C                                   ; $411F: $3E $5C
     call label_3B86                               ; $4121: $CD $86 $3B
-    ldh  a, [hScratchA]                               ; $4124: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4124: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4126: $21 $00 $C2
     add  hl, de                                   ; $4129: $19
     ld   [hl], a                                  ; $412A: $77
-    ldh  a, [hScratchB]                               ; $412B: $F0 $D8
+    ldh  a, [hScratch1]                               ; $412B: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $412D: $21 $10 $C2
     add  hl, de                                   ; $4130: $19
     sub  $26                                      ; $4131: $D6 $26
@@ -351,13 +351,13 @@ jr_004_4210:
     ld   [hl], $20                                ; $4226: $36 $20
     ld   a, $08                                   ; $4228: $3E $08
     call label_3BB5                               ; $422A: $CD $B5 $3B
-    ldh  a, [hScratchA]                               ; $422D: $F0 $D7
+    ldh  a, [hScratch0]                               ; $422D: $F0 $D7
     cpl                                           ; $422F: $2F
     inc  a                                        ; $4230: $3C
     ld   hl, wEntitiesSpeedYTable                                ; $4231: $21 $50 $C2
     add  hl, bc                                   ; $4234: $09
     ld   [hl], a                                  ; $4235: $77
-    ldh  a, [hScratchB]                               ; $4236: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4236: $F0 $D8
     cpl                                           ; $4238: $2F
     inc  a                                        ; $4239: $3C
     ld   hl, wEntitiesSpeedXTable                                ; $423A: $21 $40 $C2
@@ -650,12 +650,12 @@ jr_004_43FF:
     call label_3B86                               ; $4409: $CD $86 $3B
     jr   c, jr_004_4438                           ; $440C: $38 $2A
 
-    ldh  a, [hScratchA]                               ; $440E: $F0 $D7
+    ldh  a, [hScratch0]                               ; $440E: $F0 $D7
     sub  $0C                                      ; $4410: $D6 $0C
     ld   hl, wEntity0PosX                         ; $4412: $21 $00 $C2
     add  hl, de                                   ; $4415: $19
     ld   [hl], a                                  ; $4416: $77
-    ldh  a, [hScratchB]                               ; $4417: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4417: $F0 $D8
     sub  $14                                      ; $4419: $D6 $14
     ld   hl, wEntitiesPosYTable                   ; $441B: $21 $10 $C2
     add  hl, de                                   ; $441E: $19
@@ -691,12 +691,12 @@ jr_004_4438:
     ld   c, a                                     ; $444F: $4F
     ld   hl, $449D                                ; $4450: $21 $9D $44
     add  hl, bc                                   ; $4453: $09
-    ldh  a, [hScratchA]                               ; $4454: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4454: $F0 $D7
     add  [hl]                                     ; $4456: $86
     ld   hl, wEntity0PosX                         ; $4457: $21 $00 $C2
     add  hl, de                                   ; $445A: $19
     ld   [hl], a                                  ; $445B: $77
-    ldh  a, [hScratchB]                               ; $445C: $F0 $D8
+    ldh  a, [hScratch1]                               ; $445C: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $445E: $21 $10 $C2
     add  hl, de                                   ; $4461: $19
     ld   [hl], a                                  ; $4462: $77
@@ -793,11 +793,11 @@ jr_004_44E2:
 
     ld   a, $5C                                   ; $44F3: $3E $5C
     call label_3B86                               ; $44F5: $CD $86 $3B
-    ldh  a, [hScratchA]                               ; $44F8: $F0 $D7
+    ldh  a, [hScratch0]                               ; $44F8: $F0 $D7
     ld   hl, wEntity0PosX                         ; $44FA: $21 $00 $C2
     add  hl, de                                   ; $44FD: $19
     ld   [hl], a                                  ; $44FE: $77
-    ldh  a, [hScratchB]                               ; $44FF: $F0 $D8
+    ldh  a, [hScratch1]                               ; $44FF: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4501: $21 $10 $C2
     add  hl, de                                   ; $4504: $19
     ld   [hl], a                                  ; $4505: $77
@@ -843,7 +843,7 @@ jr_004_4535:
     call label_3BB5                               ; $4549: $CD $B5 $3B
     ld   hl, wEntitiesSpeedXTable                                ; $454C: $21 $40 $C2
     add  hl, bc                                   ; $454F: $09
-    ldh  a, [hScratchB]                               ; $4550: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4550: $F0 $D8
     sub  [hl]                                     ; $4552: $96
     and  $80                                      ; $4553: $E6 $80
     jr   z, jr_004_4559                           ; $4555: $28 $02
@@ -855,7 +855,7 @@ jr_004_4559:
     inc  [hl]                                     ; $4559: $34
     ld   hl, wEntitiesSpeedYTable                                ; $455A: $21 $50 $C2
     add  hl, bc                                   ; $455D: $09
-    ldh  a, [hScratchA]                               ; $455E: $F0 $D7
+    ldh  a, [hScratch0]                               ; $455E: $F0 $D7
     sub  [hl]                                     ; $4560: $96
     and  $80                                      ; $4561: $E6 $80
     jr   z, jr_004_4567                           ; $4563: $28 $02
@@ -923,12 +923,12 @@ jr_004_45A6:
     ld   c, a                                     ; $45BE: $4F
     ld   hl, $449D                                ; $45BF: $21 $9D $44
     add  hl, bc                                   ; $45C2: $09
-    ldh  a, [hScratchA]                               ; $45C3: $F0 $D7
+    ldh  a, [hScratch0]                               ; $45C3: $F0 $D7
     add  [hl]                                     ; $45C5: $86
     ld   hl, wEntity0PosX                         ; $45C6: $21 $00 $C2
     add  hl, de                                   ; $45C9: $19
     ld   [hl], a                                  ; $45CA: $77
-    ldh  a, [hScratchB]                               ; $45CB: $F0 $D8
+    ldh  a, [hScratch1]                               ; $45CB: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $45CD: $21 $10 $C2
     add  hl, de                                   ; $45D0: $19
     ld   [hl], a                                  ; $45D1: $77
@@ -963,21 +963,21 @@ jr_004_45F1:
     ldh  [hLinkPositionY], a                      ; $45FD: $E0 $99
     ld   a, $20                                   ; $45FF: $3E $20
     call label_3BB5                               ; $4601: $CD $B5 $3B
-    ldh  a, [hScratchB]                               ; $4604: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4604: $F0 $D8
     cpl                                           ; $4606: $2F
     inc  a                                        ; $4607: $3C
     push af                                       ; $4608: $F5
-    ldh  a, [hScratchA]                               ; $4609: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4609: $F0 $D7
     push af                                       ; $460B: $F5
     ld   a, $04                                   ; $460C: $3E $04
     call label_3BB5                               ; $460E: $CD $B5 $3B
-    ld   hl, hScratchB                                ; $4611: $21 $D8 $FF
+    ld   hl, hScratch1                                ; $4611: $21 $D8 $FF
     pop  af                                       ; $4614: $F1
     add  [hl]                                     ; $4615: $86
     ld   hl, wEntitiesSpeedXTable                                ; $4616: $21 $40 $C2
     add  hl, bc                                   ; $4619: $09
     ld   [hl], a                                  ; $461A: $77
-    ld   hl, hScratchA                                ; $461B: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $461B: $21 $D7 $FF
     pop  af                                       ; $461E: $F1
     add  [hl]                                     ; $461F: $86
     ld   hl, wEntitiesSpeedYTable                                ; $4620: $21 $50 $C2
@@ -1136,11 +1136,11 @@ jr_004_486D:
 
     ld   a, $5C                                   ; $4875: $3E $5C
     call label_3B86                               ; $4877: $CD $86 $3B
-    ldh  a, [hScratchA]                               ; $487A: $F0 $D7
+    ldh  a, [hScratch0]                               ; $487A: $F0 $D7
     ld   hl, wEntity0PosX                         ; $487C: $21 $00 $C2
     add  hl, de                                   ; $487F: $19
     ld   [hl], a                                  ; $4880: $77
-    ldh  a, [hScratchB]                               ; $4881: $F0 $D8
+    ldh  a, [hScratch1]                               ; $4881: $F0 $D8
     cp   $14                                      ; $4883: $FE $14
     jr   nc, jr_004_4889                          ; $4885: $30 $02
 
@@ -1307,7 +1307,7 @@ jr_004_4972:
     ld   c, a                                     ; $4980: $4F
     ld   hl, $496B                                ; $4981: $21 $6B $49
     add  hl, bc                                   ; $4984: $09
-    ldh  a, [hScratchA]                               ; $4985: $F0 $D7
+    ldh  a, [hScratch0]                               ; $4985: $F0 $D7
     add  [hl]                                     ; $4987: $86
     ld   hl, wEntity0PosX                         ; $4988: $21 $00 $C2
     add  hl, de                                   ; $498B: $19
@@ -1324,7 +1324,7 @@ jr_004_4972:
     ld   hl, wEntitiesWalkingTable                ; $499D: $21 $90 $C2
     add  hl, de                                   ; $49A0: $19
     ld   [hl], $01                                ; $49A1: $36 $01
-    ldh  a, [hScratchB]                               ; $49A3: $F0 $D8
+    ldh  a, [hScratch1]                               ; $49A3: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $49A5: $21 $10 $C2
     add  hl, de                                   ; $49A8: $19
     ld   [hl], a                                  ; $49A9: $77
@@ -2878,11 +2878,11 @@ jr_004_547E:
 
     ld   a, $0C                                   ; $54AF: $3E $0C
     call label_3BB5                               ; $54B1: $CD $B5 $3B
-    ldh  a, [hScratchA]                               ; $54B4: $F0 $D7
+    ldh  a, [hScratch0]                               ; $54B4: $F0 $D7
     cpl                                           ; $54B6: $2F
     inc  a                                        ; $54B7: $3C
     ldh  [hLinkPositionYIncrement], a                               ; $54B8: $E0 $9B
-    ldh  a, [hScratchB]                               ; $54BA: $F0 $D8
+    ldh  a, [hScratch1]                               ; $54BA: $F0 $D8
     cpl                                           ; $54BC: $2F
     inc  a                                        ; $54BD: $3C
     ldh  [hLinkPositionXIncrement], a                               ; $54BE: $E0 $9A
@@ -3122,7 +3122,7 @@ label_004_5623:
     ld   a, $0D                                   ; $5626: $3E $0D
 
 jr_004_5628:
-    ldh  [hScratchA], a                               ; $5628: $E0 $D7
+    ldh  [hScratch0], a                               ; $5628: $E0 $D7
     push de                                       ; $562A: $D5
     ldh  a, [$FFEF]                               ; $562B: $F0 $EF
     sub  $0F                                      ; $562D: $D6 $0F
@@ -3140,7 +3140,7 @@ jr_004_5628:
     ld   d, $00                                   ; $5642: $16 $00
     ld   hl, wRoomObjects                       ; $5644: $21 $11 $D7
     add  hl, de                                   ; $5647: $19
-    ldh  a, [hScratchA]                               ; $5648: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5648: $F0 $D7
     ld   [hl], a                                  ; $564A: $77
     call label_2887                               ; $564B: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $564E: $F0 $FE
@@ -3148,7 +3148,7 @@ jr_004_5628:
     jr   z, jr_004_565F                           ; $5651: $28 $0C
 
     push bc                                       ; $5653: $C5
-    ldh  a, [hScratchA]                               ; $5654: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5654: $F0 $D7
     ld   [$DDD8], a                               ; $5656: $EA $D8 $DD
     ld   a, $04                                   ; $5659: $3E $04
     call label_91D                                ; $565B: $CD $1D $09
@@ -3321,7 +3321,7 @@ jr_004_5750:
 DropHeartContainer:
     ld   a, $36                                   ; $5751: $3E $36
     call label_3B86                               ; $5753: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $5756: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5756: $F0 $D7
     cp   $88                                      ; $5758: $FE $88
     jr   c, jr_004_575E                           ; $575A: $38 $02
 
@@ -3337,7 +3337,7 @@ jr_004_5764:
     ld   hl, wEntity0PosX                         ; $5764: $21 $00 $C2
     add  hl, de                                   ; $5767: $19
     ld   [hl], a                                  ; $5768: $77
-    ldh  a, [hScratchB]                               ; $5769: $F0 $D8
+    ldh  a, [hScratch1]                               ; $5769: $F0 $D8
     cp   $70                                      ; $576B: $FE $70
     jr   c, jr_004_5771                           ; $576D: $38 $02
 
@@ -3356,7 +3356,7 @@ jr_004_5777:
     ld   hl, wEntitiesSpeedZTable                                ; $577C: $21 $20 $C3
     add  hl, de                                   ; $577F: $19
     ld   [hl], $10                                ; $5780: $36 $10
-    ldh  a, [hScratchD]                               ; $5782: $F0 $DA
+    ldh  a, [hScratch3]                               ; $5782: $F0 $DA
     ld   hl, wEntitiesPosZTable                                ; $5784: $21 $10 $C3
     add  hl, de                                   ; $5787: $19
     ld   [hl], a                                  ; $5788: $77
@@ -3483,14 +3483,14 @@ jr_004_5924:
     ld   hl, $C3D0                                ; $592F: $21 $D0 $C3
     add  hl, bc                                   ; $5932: $09
     ld   a, [hl]                                  ; $5933: $7E
-    ldh  [hScratchA], a                               ; $5934: $E0 $D7
+    ldh  [hScratch0], a                               ; $5934: $E0 $D7
     ld   hl, wEntitiesUnknownTableD               ; $5936: $21 $D0 $C2
     add  hl, bc                                   ; $5939: $09
     ld   a, [hl]                                  ; $593A: $7E
     cp   $04                                      ; $593B: $FE $04
     jp   nc, label_004_5A04                       ; $593D: $D2 $04 $5A
 
-    ldh  a, [hScratchA]                               ; $5940: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5940: $F0 $D7
     sub  $0C                                      ; $5942: $D6 $0C
     and  $7F                                      ; $5944: $E6 $7F
     ld   e, a                                     ; $5946: $5F
@@ -3513,7 +3513,7 @@ jr_004_5924:
     cp   $03                                      ; $5965: $FE $03
     jp   nc, label_004_5A04                       ; $5967: $D2 $04 $5A
 
-    ldh  a, [hScratchA]                               ; $596A: $F0 $D7
+    ldh  a, [hScratch0]                               ; $596A: $F0 $D7
     sub  $18                                      ; $596C: $D6 $18
     and  $7F                                      ; $596E: $E6 $7F
     ld   e, a                                     ; $5970: $5F
@@ -3536,7 +3536,7 @@ jr_004_5924:
     cp   $02                                      ; $598F: $FE $02
     jr   nc, jr_004_5A04                          ; $5991: $30 $71
 
-    ldh  a, [hScratchA]                               ; $5993: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5993: $F0 $D7
     sub  $24                                      ; $5995: $D6 $24
     and  $7F                                      ; $5997: $E6 $7F
     ld   e, a                                     ; $5999: $5F
@@ -3559,7 +3559,7 @@ jr_004_5924:
     and  a                                        ; $59B8: $A7
     jr   nz, jr_004_5A04                          ; $59B9: $20 $49
 
-    ldh  a, [hScratchA]                               ; $59BB: $F0 $D7
+    ldh  a, [hScratch0]                               ; $59BB: $F0 $D7
     sub  $2E                                      ; $59BD: $D6 $2E
     and  $7F                                      ; $59BF: $E6 $7F
     ld   e, a                                     ; $59C1: $5F
@@ -3610,9 +3610,9 @@ func_004_5A05:
 label_004_5A05:
     call func_004_7FA9                            ; $5A05: $CD $A9 $7F
     ldh  a, [wActiveEntityPosX]                               ; $5A08: $F0 $EE
-    ldh  [hScratchA], a                               ; $5A0A: $E0 $D7
+    ldh  [hScratch0], a                               ; $5A0A: $E0 $D7
     ldh  a, [wActiveEntityPosY]                               ; $5A0C: $F0 $EC
-    ldh  [hScratchB], a                               ; $5A0E: $E0 $D8
+    ldh  [hScratch1], a                               ; $5A0E: $E0 $D8
     ld   a, $02                                   ; $5A10: $3E $02
     call label_CC7                                ; $5A12: $CD $C7 $0C
     ld   a, $13                                   ; $5A15: $3E $13
@@ -3685,7 +3685,7 @@ jr_004_5AA9:
     inc  a                                        ; $5AB1: $3C
     and  $1F                                      ; $5AB2: $E6 $1F
     ld   [hl], a                                  ; $5AB4: $77
-    ldh  [hScratchA], a                               ; $5AB5: $E0 $D7
+    ldh  [hScratch0], a                               ; $5AB5: $E0 $D7
     ld   hl, $C460                                ; $5AB7: $21 $60 $C4
     add  hl, bc                                   ; $5ABA: $09
     ld   e, [hl]                                  ; $5ABB: $5E
@@ -3698,7 +3698,7 @@ jr_004_5AA9:
     push de                                       ; $5AC8: $D5
     ld   hl, $D000                                ; $5AC9: $21 $00 $D0
     add  hl, de                                   ; $5ACC: $19
-    ldh  a, [hScratchA]                               ; $5ACD: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5ACD: $F0 $D7
     ld   e, a                                     ; $5ACF: $5F
     add  hl, de                                   ; $5AD0: $19
     ldh  a, [wActiveEntityPosX]                               ; $5AD1: $F0 $EE
@@ -3706,7 +3706,7 @@ jr_004_5AA9:
     pop  de                                       ; $5AD4: $D1
     ld   hl, $D100                                ; $5AD5: $21 $00 $D1
     add  hl, de                                   ; $5AD8: $19
-    ldh  a, [hScratchA]                               ; $5AD9: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5AD9: $F0 $D7
     ld   e, a                                     ; $5ADB: $5F
     add  hl, de                                   ; $5ADC: $19
     ldh  a, [wActiveEntityPosY]                               ; $5ADD: $F0 $EC
@@ -3829,7 +3829,7 @@ jr_004_5B7E:
     ld   hl, $C3D0                                ; $5B88: $21 $D0 $C3
     add  hl, bc                                   ; $5B8B: $09
     ld   a, [hl]                                  ; $5B8C: $7E
-    ldh  [hScratchA], a                               ; $5B8D: $E0 $D7
+    ldh  [hScratch0], a                               ; $5B8D: $E0 $D7
     ld   hl, $C460                                ; $5B8F: $21 $60 $C4
     add  hl, bc                                   ; $5B92: $09
     ld   e, [hl]                                  ; $5B93: $5E
@@ -3843,7 +3843,7 @@ jr_004_5B7E:
     push de                                       ; $5BA0: $D5
     ld   hl, $D000                                ; $5BA1: $21 $00 $D0
     add  hl, de                                   ; $5BA4: $19
-    ldh  a, [hScratchA]                               ; $5BA5: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5BA5: $F0 $D7
     sub  $09                                      ; $5BA7: $D6 $09
     and  $1F                                      ; $5BA9: $E6 $1F
     ld   e, a                                     ; $5BAB: $5F
@@ -3854,7 +3854,7 @@ jr_004_5B7E:
     pop  de                                       ; $5BB1: $D1
     ld   hl, $D100                                ; $5BB2: $21 $00 $D1
     add  hl, de                                   ; $5BB5: $19
-    ldh  a, [hScratchA]                               ; $5BB6: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5BB6: $F0 $D7
     sub  $09                                      ; $5BB8: $D6 $09
     and  $1F                                      ; $5BBA: $E6 $1F
     ld   e, a                                     ; $5BBC: $5F
@@ -3870,7 +3870,7 @@ jr_004_5B7E:
     push de                                       ; $5BCD: $D5
     ld   hl, $D000                                ; $5BCE: $21 $00 $D0
     add  hl, de                                   ; $5BD1: $19
-    ldh  a, [hScratchA]                               ; $5BD2: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5BD2: $F0 $D7
     sub  $10                                      ; $5BD4: $D6 $10
     and  $1F                                      ; $5BD6: $E6 $1F
     ld   e, a                                     ; $5BD8: $5F
@@ -3881,7 +3881,7 @@ jr_004_5B7E:
     pop  de                                       ; $5BDE: $D1
     ld   hl, $D100                                ; $5BDF: $21 $00 $D1
     add  hl, de                                   ; $5BE2: $19
-    ldh  a, [hScratchA]                               ; $5BE3: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5BE3: $F0 $D7
     sub  $10                                      ; $5BE5: $D6 $10
     and  $1F                                      ; $5BE7: $E6 $1F
     ld   e, a                                     ; $5BE9: $5F
@@ -4201,7 +4201,7 @@ jr_004_5D25:
     push af                                       ; $5DAB: $F5
     rla                                           ; $5DAC: $17
     and  $40                                      ; $5DAD: $E6 $40
-    ldh  [hScratchA], a                               ; $5DAF: $E0 $D7
+    ldh  [hScratch0], a                               ; $5DAF: $E0 $D7
     pop  af                                       ; $5DB1: $F1
     and  $0F                                      ; $5DB2: $E6 $0F
     ldh  [$FFED], a                               ; $5DB4: $E0 $ED
@@ -4214,7 +4214,7 @@ jr_004_5D25:
     rla                                           ; $5DBE: $17
     rla                                           ; $5DBF: $17
     and  $E0                                      ; $5DC0: $E6 $E0
-    ld   hl, hScratchA                                ; $5DC2: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $5DC2: $21 $D7 $FF
     add  [hl]                                     ; $5DC5: $86
     ld   e, a                                     ; $5DC6: $5F
     ld   d, b                                     ; $5DC7: $50
@@ -4388,11 +4388,11 @@ func_004_5EC6:
 
     ld   hl, wEntity0PosX                         ; $5ECD: $21 $00 $C2
     add  hl, de                                   ; $5ED0: $19
-    ldh  a, [hScratchA]                               ; $5ED1: $F0 $D7
+    ldh  a, [hScratch0]                               ; $5ED1: $F0 $D7
     ld   [hl], a                                  ; $5ED3: $77
     ld   hl, wEntitiesPosYTable                   ; $5ED4: $21 $10 $C2
     add  hl, de                                   ; $5ED7: $19
-    ldh  a, [hScratchB]                               ; $5ED8: $F0 $D8
+    ldh  a, [hScratch1]                               ; $5ED8: $F0 $D8
     ld   [hl], a                                  ; $5EDA: $77
     push bc                                       ; $5EDB: $C5
     ld   c, e                                     ; $5EDC: $4B
@@ -5023,9 +5023,9 @@ jr_004_62E7:
 
 label_004_62F6:
     ldh  a, [wActiveEntityPosY]                               ; $62F6: $F0 $EC
-    ldh  [hScratchB], a                               ; $62F8: $E0 $D8
+    ldh  [hScratch1], a                               ; $62F8: $E0 $D8
     ldh  a, [wActiveEntityPosX]                               ; $62FA: $F0 $EE
-    ldh  [hScratchA], a                               ; $62FC: $E0 $D7
+    ldh  [hScratch0], a                               ; $62FC: $E0 $D7
     ld   a, $01                                   ; $62FE: $3E $01
     call label_CC7                                ; $6300: $CD $C7 $0C
     ld   a, JINGLE_WATER_DIVE                     ; $6303: $3E $0E
@@ -5494,7 +5494,7 @@ jr_004_6575:
     ldh  [hLinkPositionY], a                      ; $65B2: $E0 $99
     ld   a, $08                                   ; $65B4: $3E $08
     call label_3BB5                               ; $65B6: $CD $B5 $3B
-    ldh  a, [hScratchA]                               ; $65B9: $F0 $D7
+    ldh  a, [hScratch0]                               ; $65B9: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                                ; $65BB: $21 $50 $C2
     add  hl, bc                                   ; $65BE: $09
     sub  [hl]                                     ; $65BF: $96
@@ -5506,7 +5506,7 @@ jr_004_6575:
     dec  [hl]                                     ; $65C6: $35
 
 jr_004_65C7:
-    ldh  a, [hScratchB]                               ; $65C7: $F0 $D8
+    ldh  a, [hScratch1]                               ; $65C7: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                                ; $65C9: $21 $40 $C2
     add  hl, bc                                   ; $65CC: $09
     sub  [hl]                                     ; $65CD: $96
@@ -5549,7 +5549,7 @@ jr_004_65F1:
     ldh  [hLinkPositionY], a                      ; $65FD: $E0 $99
     ld   a, $03                                   ; $65FF: $3E $03
     call label_3BB5                               ; $6601: $CD $B5 $3B
-    ldh  a, [hScratchA]                               ; $6604: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6604: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                                ; $6606: $21 $50 $C2
     add  hl, bc                                   ; $6609: $09
     sub  [hl]                                     ; $660A: $96
@@ -5564,7 +5564,7 @@ jr_004_65F1:
     dec  [hl]                                     ; $6614: $35
 
 jr_004_6615:
-    ldh  a, [hScratchB]                               ; $6615: $F0 $D8
+    ldh  a, [hScratch1]                               ; $6615: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                                ; $6617: $21 $40 $C2
     add  hl, bc                                   ; $661A: $09
     sub  [hl]                                     ; $661B: $96
@@ -5962,7 +5962,7 @@ jr_004_686D:
     push de                                       ; $686D: $D5
     call label_3BB5                               ; $686E: $CD $B5 $3B
     pop  de                                       ; $6871: $D1
-    ldh  a, [hScratchA]                               ; $6872: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6872: $F0 $D7
     bit  0, e                                     ; $6874: $CB $43
     jr   z, jr_004_687A                           ; $6876: $28 $02
 
@@ -5971,7 +5971,7 @@ jr_004_686D:
 
 jr_004_687A:
     ldh  [hLinkPositionYIncrement], a                               ; $687A: $E0 $9B
-    ldh  a, [hScratchB]                               ; $687C: $F0 $D8
+    ldh  a, [hScratch1]                               ; $687C: $F0 $D8
     bit  0, e                                     ; $687E: $CB $43
     jr   z, jr_004_6884                           ; $6880: $28 $02
 
@@ -6116,7 +6116,7 @@ label_004_6910:
     inc  e                                        ; $6953: $1C
 
 jr_004_6954:
-    ldh  a, [hScratchA]                               ; $6954: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6954: $F0 $D7
     bit  0, e                                     ; $6956: $CB $43
     jr   nz, jr_004_695C                          ; $6958: $20 $02
 
@@ -6127,7 +6127,7 @@ jr_004_695C:
     ld   hl, wEntitiesSpeedYTable                                ; $695C: $21 $50 $C2
     add  hl, bc                                   ; $695F: $09
     ld   [hl], a                                  ; $6960: $77
-    ldh  a, [hScratchB]                               ; $6961: $F0 $D8
+    ldh  a, [hScratch1]                               ; $6961: $F0 $D8
     bit  0, e                                     ; $6963: $CB $43
     jr   nz, jr_004_6969                          ; $6965: $20 $02
 
@@ -6381,7 +6381,7 @@ jr_004_6AA6:
     jr   z, jr_004_6B31                           ; $6AD3: $28 $5C
 
     xor  a                                        ; $6AD5: $AF
-    ldh  [hScratchA], a                               ; $6AD6: $E0 $D7
+    ldh  [hScratch0], a                               ; $6AD6: $E0 $D7
     ld   hl, $C380                                ; $6AD8: $21 $80 $C3
     add  hl, bc                                   ; $6ADB: $09
     ld   a, [hl]                                  ; $6ADC: $7E
@@ -6394,7 +6394,7 @@ jr_004_6AA6:
     ld   a, [hl]                                  ; $6AE7: $7E
     jr   nz, jr_004_6AF0                          ; $6AE8: $20 $06
 
-    ld   hl, hScratchA                                ; $6AEA: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $6AEA: $21 $D7 $FF
     inc  [hl]                                     ; $6AED: $34
     cpl                                           ; $6AEE: $2F
     inc  a                                        ; $6AEF: $3C
@@ -6405,7 +6405,7 @@ jr_004_6AF0:
     ld   [hl], a                                  ; $6AF4: $77
     ld   hl, $C440                                ; $6AF5: $21 $40 $C4
     add  hl, bc                                   ; $6AF8: $09
-    ldh  a, [hScratchA]                               ; $6AF9: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6AF9: $F0 $D7
     and  a                                        ; $6AFB: $A7
     ld   a, [hl]                                  ; $6AFC: $7E
     jr   z, jr_004_6B02                           ; $6AFD: $28 $03
@@ -6425,7 +6425,7 @@ jr_004_6B0B:
     ld   a, [hl]                                  ; $6B0D: $7E
     jr   nz, jr_004_6B16                          ; $6B0E: $20 $06
 
-    ld   hl, hScratchA                                ; $6B10: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $6B10: $21 $D7 $FF
     inc  [hl]                                     ; $6B13: $34
     cpl                                           ; $6B14: $2F
     inc  a                                        ; $6B15: $3C
@@ -6436,7 +6436,7 @@ jr_004_6B16:
     ld   [hl], a                                  ; $6B1A: $77
     ld   hl, $C440                                ; $6B1B: $21 $40 $C4
     add  hl, bc                                   ; $6B1E: $09
-    ldh  a, [hScratchA]                               ; $6B1F: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6B1F: $F0 $D7
     and  a                                        ; $6B21: $A7
     ld   a, [hl]                                  ; $6B22: $7E
     jr   nz, jr_004_6B28                          ; $6B23: $20 $03
@@ -6505,16 +6505,16 @@ jr_004_6B7C:
     sub  [hl]                                     ; $6B84: $96
     sra  a                                        ; $6B85: $CB $2F
     sra  a                                        ; $6B87: $CB $2F
-    ldh  [hScratchA], a                               ; $6B89: $E0 $D7
-    ldh  [hScratchC], a                               ; $6B8B: $E0 $D9
+    ldh  [hScratch0], a                               ; $6B89: $E0 $D7
+    ldh  [hScratch2], a                               ; $6B8B: $E0 $D9
     ldh  a, [wActiveEntityPosY]                               ; $6B8D: $F0 $EC
     ld   hl, wEntitiesPosYTable                   ; $6B8F: $21 $10 $C2
     add  hl, bc                                   ; $6B92: $09
     sub  [hl]                                     ; $6B93: $96
     sra  a                                        ; $6B94: $CB $2F
     sra  a                                        ; $6B96: $CB $2F
-    ldh  [hScratchB], a                               ; $6B98: $E0 $D8
-    ldh  [hScratchD], a                               ; $6B9A: $E0 $DA
+    ldh  [hScratch1], a                               ; $6B98: $E0 $D8
+    ldh  [hScratch3], a                               ; $6B9A: $E0 $DA
     ld   a, [$C3C0]                               ; $6B9C: $FA $C0 $C3
     ld   e, a                                     ; $6B9F: $5F
     ld   d, $00                                   ; $6BA0: $16 $00
@@ -6528,12 +6528,12 @@ jr_004_6B7C:
 jr_004_6BAD:
     ldh  [$FFDB], a                               ; $6BAD: $E0 $DB
     ldh  a, [wActiveEntityPosY]                               ; $6BAF: $F0 $EC
-    ld   hl, hScratchB                                ; $6BB1: $21 $D8 $FF
+    ld   hl, hScratch1                                ; $6BB1: $21 $D8 $FF
     add  [hl]                                     ; $6BB4: $86
     ld   [de], a                                  ; $6BB5: $12
     inc  de                                       ; $6BB6: $13
     ldh  a, [wActiveEntityPosX]                               ; $6BB7: $F0 $EE
-    ld   hl, hScratchA                                ; $6BB9: $21 $D7 $FF
+    ld   hl, hScratch0                                ; $6BB9: $21 $D7 $FF
     add  [hl]                                     ; $6BBC: $86
     ld   [de], a                                  ; $6BBD: $12
     inc  de                                       ; $6BBE: $13
@@ -6543,14 +6543,14 @@ jr_004_6BAD:
     ld   a, $00                                   ; $6BC3: $3E $00
     ld   [de], a                                  ; $6BC5: $12
     inc  de                                       ; $6BC6: $13
-    ldh  a, [hScratchA]                               ; $6BC7: $F0 $D7
-    ld   hl, hScratchC                                ; $6BC9: $21 $D9 $FF
+    ldh  a, [hScratch0]                               ; $6BC7: $F0 $D7
+    ld   hl, hScratch2                                ; $6BC9: $21 $D9 $FF
     add  [hl]                                     ; $6BCC: $86
-    ldh  [hScratchA], a                               ; $6BCD: $E0 $D7
-    ldh  a, [hScratchB]                               ; $6BCF: $F0 $D8
-    ld   hl, hScratchD                                ; $6BD1: $21 $DA $FF
+    ldh  [hScratch0], a                               ; $6BCD: $E0 $D7
+    ldh  a, [hScratch1]                               ; $6BCF: $F0 $D8
+    ld   hl, hScratch3                                ; $6BD1: $21 $DA $FF
     add  [hl]                                     ; $6BD4: $86
-    ldh  [hScratchB], a                               ; $6BD5: $E0 $D8
+    ldh  [hScratch1], a                               ; $6BD5: $E0 $D8
     ldh  a, [$FFDB]                               ; $6BD7: $F0 $DB
     dec  a                                        ; $6BD9: $3D
     jr   nz, jr_004_6BAD                          ; $6BDA: $20 $D1
@@ -6601,9 +6601,9 @@ func_004_6BE1:
 
 label_004_6C20:
     ldh  a, [wActiveEntityPosX]                               ; $6C20: $F0 $EE
-    ldh  [hScratchA], a                               ; $6C22: $E0 $D7
+    ldh  [hScratch0], a                               ; $6C22: $E0 $D7
     ldh  a, [wActiveEntityPosY]                               ; $6C24: $F0 $EC
-    ldh  [hScratchB], a                               ; $6C26: $E0 $D8
+    ldh  [hScratch1], a                               ; $6C26: $E0 $D8
     ld   a, $05                                   ; $6C28: $3E $05
     jp   label_CC7                                ; $6C2A: $C3 $C7 $0C
 
@@ -6670,15 +6670,15 @@ label_004_6C20:
 
     ld   a, $08                                   ; $6C86: $3E $08
     ldh  [hNoiseSfx], a                            ; $6C88: $E0 $F4
-    ldh  a, [hScratchA]                               ; $6C8A: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6C8A: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6C8C: $21 $00 $C2
     add  hl, de                                   ; $6C8F: $19
     ld   [hl], a                                  ; $6C90: $77
-    ldh  a, [hScratchB]                               ; $6C91: $F0 $D8
+    ldh  a, [hScratch1]                               ; $6C91: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6C93: $21 $10 $C2
     add  hl, de                                   ; $6C96: $19
     ld   [hl], a                                  ; $6C97: $77
-    ldh  a, [hScratchC]                               ; $6C98: $F0 $D9
+    ldh  a, [hScratch2]                               ; $6C98: $F0 $D9
     ld   hl, $C380                                ; $6C9A: $21 $80 $C3
     add  hl, de                                   ; $6C9D: $19
     ld   [hl], a                                  ; $6C9E: $77
@@ -6721,11 +6721,11 @@ jr_004_6CB4:
     call label_3B86                               ; $6CD1: $CD $86 $3B
     jr   c, jr_004_6D0E                           ; $6CD4: $38 $38
 
-    ldh  a, [hScratchA]                               ; $6CD6: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6CD6: $F0 $D7
     ld   hl, wEntity0PosX                         ; $6CD8: $21 $00 $C2
     add  hl, de                                   ; $6CDB: $19
     ld   [hl], a                                  ; $6CDC: $77
-    ldh  a, [hScratchB]                               ; $6CDD: $F0 $D8
+    ldh  a, [hScratch1]                               ; $6CDD: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6CDF: $21 $10 $C2
     add  hl, de                                   ; $6CE2: $19
     ld   [hl], a                                  ; $6CE3: $77
@@ -6739,7 +6739,7 @@ jr_004_6CB4:
     add  hl, de                                   ; $6CF2: $19
     ld   [hl], $C0                                ; $6CF3: $36 $C0
     push bc                                       ; $6CF5: $C5
-    ldh  a, [hScratchC]                               ; $6CF6: $F0 $D9
+    ldh  a, [hScratch2]                               ; $6CF6: $F0 $D9
     ld   c, a                                     ; $6CF8: $4F
     ld   hl, $6C51                                ; $6CF9: $21 $51 $6C
     add  hl, bc                                   ; $6CFC: $09
@@ -7005,7 +7005,7 @@ jr_004_6E53:
 func_004_6E55:
     call func_004_6E35                            ; $6E55: $CD $35 $6E
     ld   a, e                                     ; $6E58: $7B
-    ldh  [hScratchA], a                               ; $6E59: $E0 $D7
+    ldh  [hScratch0], a                               ; $6E59: $E0 $D7
     ld   a, d                                     ; $6E5B: $7A
     bit  7, a                                     ; $6E5C: $CB $7F
     jr   z, jr_004_6E62                           ; $6E5E: $28 $02
@@ -7017,7 +7017,7 @@ jr_004_6E62:
     push af                                       ; $6E62: $F5
     call func_004_6E45                            ; $6E63: $CD $45 $6E
     ld   a, e                                     ; $6E66: $7B
-    ldh  [hScratchB], a                               ; $6E67: $E0 $D8
+    ldh  [hScratch1], a                               ; $6E67: $E0 $D8
     ld   a, d                                     ; $6E69: $7A
     bit  7, a                                     ; $6E6A: $CB $7F
     jr   z, jr_004_6E70                           ; $6E6C: $28 $02
@@ -7030,11 +7030,11 @@ jr_004_6E70:
     cp   d                                        ; $6E71: $BA
     jr   nc, jr_004_6E78                          ; $6E72: $30 $04
 
-    ldh  a, [hScratchA]                               ; $6E74: $F0 $D7
+    ldh  a, [hScratch0]                               ; $6E74: $F0 $D7
     jr   jr_004_6E7A                              ; $6E76: $18 $02
 
 jr_004_6E78:
-    ldh  a, [hScratchB]                               ; $6E78: $F0 $D8
+    ldh  a, [hScratch1]                               ; $6E78: $F0 $D8
 
 jr_004_6E7A:
     ld   e, a                                     ; $6E7A: $5F
@@ -9305,11 +9305,11 @@ jr_004_7ACA:
     call label_3B86                               ; $7AF5: $CD $86 $3B
     ld   a, $26                                   ; $7AF8: $3E $26
     ldh  [hNoiseSfx], a                            ; $7AFA: $E0 $F4
-    ldh  a, [hScratchA]                               ; $7AFC: $F0 $D7
+    ldh  a, [hScratch0]                               ; $7AFC: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7AFE: $21 $00 $C2
     add  hl, de                                   ; $7B01: $19
     ld   [hl], a                                  ; $7B02: $77
-    ldh  a, [hScratchB]                               ; $7B03: $F0 $D8
+    ldh  a, [hScratch1]                               ; $7B03: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7B05: $21 $10 $C2
     add  hl, de                                   ; $7B08: $19
     ld   [hl], a                                  ; $7B09: $77
@@ -9929,11 +9929,11 @@ func_004_7EC0:
     jr   c, jr_004_7EE4                           ; $7EC5: $38 $1D
 
     call PlayBombExplosionSfx                                ; $7EC7: $CD $4B $0C
-    ldh  a, [hScratchA]                               ; $7ECA: $F0 $D7
+    ldh  a, [hScratch0]                               ; $7ECA: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7ECC: $21 $00 $C2
     add  hl, de                                   ; $7ECF: $19
     ld   [hl], a                                  ; $7ED0: $77
-    ldh  a, [hScratchB]                               ; $7ED1: $F0 $D8
+    ldh  a, [hScratch1]                               ; $7ED1: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7ED3: $21 $10 $C2
     add  hl, de                                   ; $7ED6: $19
     ld   [hl], a                                  ; $7ED7: $77

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -6567,7 +6567,7 @@ func_004_6BE1:
     ldh  a, [wActiveEntityPosY]                               ; $6BEA: $F0 $EC
     sub  $10                                      ; $6BEC: $D6 $10
     add  $04                                      ; $6BEE: $C6 $04
-    ldh  [$FFDC], a                               ; $6BF0: $E0 $DC
+    ldh  [hScratch5], a                               ; $6BF0: $E0 $DC
     and  $F0                                      ; $6BF2: $E6 $F0
     or   e                                        ; $6BF4: $B3
     ld   e, a                                     ; $6BF5: $5F

--- a/src/code/entities/bank5.asm
+++ b/src/code/entities/bank5.asm
@@ -184,9 +184,9 @@ jr_005_40DC:
     jr   z, jr_005_40FA                           ; $40EE: $28 $0A
 
     ldh  a, [hLinkPositionX]                      ; $40F0: $F0 $98
-    ldh  [hScratchA], a                           ; $40F2: $E0 $D7
+    ldh  [hScratch0], a                           ; $40F2: $E0 $D7
     ldh  a, [$FFB3]                               ; $40F4: $F0 $B3
-    ldh  [hScratchB], a                           ; $40F6: $E0 $D8
+    ldh  [hScratch1], a                           ; $40F6: $E0 $D8
     jr   jr_005_4129                              ; $40F8: $18 $2F
 
 jr_005_40FA:
@@ -219,11 +219,11 @@ jr_005_4127:
     jr   jr_005_4137                              ; $4127: $18 $0E
 
 jr_005_4129:
-    ldh  a, [hScratchA]                           ; $4129: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4129: $F0 $D7
     ld   hl, wEntitiesUnknownTableB               ; $412B: $21 $B0 $C2
     add  hl, bc                                   ; $412E: $09
     ld   [hl], a                                  ; $412F: $77
-    ldh  a, [hScratchB]                           ; $4130: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4130: $F0 $D8
     ld   hl, wEntitiesUnknownTableC               ; $4132: $21 $C0 $C2
     add  hl, bc                                   ; $4135: $09
     ld   [hl], a                                  ; $4136: $77
@@ -488,17 +488,17 @@ label_005_4297:
 
     ld   e, $0F                                   ; $42A7: $1E $0F
     ld   a, $FF                                   ; $42A9: $3E $FF
-    ldh  [hScratchA], a                           ; $42AB: $E0 $D7
+    ldh  [hScratch0], a                           ; $42AB: $E0 $D7
     jr   jr_005_42B7                              ; $42AD: $18 $08
 
 jr_005_42AF:
     ld   e, $00                                   ; $42AF: $1E $00
     ld   a, $01                                   ; $42B1: $3E $01
-    ldh  [hScratchA], a                           ; $42B3: $E0 $D7
+    ldh  [hScratch0], a                           ; $42B3: $E0 $D7
     ld   a, $10                                   ; $42B5: $3E $10
 
 jr_005_42B7:
-    ldh  [hScratchB], a                           ; $42B7: $E0 $D8
+    ldh  [hScratch1], a                           ; $42B7: $E0 $D8
 
 jr_005_42B9:
     ld   a, e                                     ; $42B9: $7B
@@ -571,11 +571,11 @@ jr_005_42B9:
     ret                                           ; $4322: $C9
 
 jr_005_4323:
-    ld   hl, hScratchA                            ; $4323: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $4323: $21 $D7 $FF
     ld   a, e                                     ; $4326: $7B
     add  [hl]                                     ; $4327: $86
     ld   e, a                                     ; $4328: $5F
-    ld   hl, hScratchB                            ; $4329: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $4329: $21 $D8 $FF
     cp   [hl]                                     ; $432C: $BE
     jr   nz, jr_005_42B9                          ; $432D: $20 $8A
 
@@ -844,7 +844,7 @@ jr_005_4473:
     jr   nz, jr_005_4455                          ; $4476: $20 $DD
 
     ld   a, b                                     ; $4478: $78
-    ldh  [hScratchA], a                           ; $4479: $E0 $D7
+    ldh  [hScratch0], a                           ; $4479: $E0 $D7
     pop  bc                                       ; $447B: $C1
     and  $01                                      ; $447C: $E6 $01
     jr   z, jr_005_4499                           ; $447E: $28 $19
@@ -874,7 +874,7 @@ jr_005_4492:
     call func_005_44B5                            ; $4496: $CD $B5 $44
 
 jr_005_4499:
-    ldh  a, [hScratchA]                           ; $4499: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4499: $F0 $D7
     and  $02                                      ; $449B: $E6 $02
     jr   z, jr_005_44CA                           ; $449D: $28 $2B
 
@@ -1270,13 +1270,13 @@ jr_005_4685:
 
     ld   a, $0C                                   ; $46BB: $3E $0C
     call label_3BB5                               ; $46BD: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $46C0: $F0 $D7
+    ldh  a, [hScratch0]                           ; $46C0: $F0 $D7
     cpl                                           ; $46C2: $2F
     inc  a                                        ; $46C3: $3C
     ld   hl, wEntity0SpeedY                       ; $46C4: $21 $50 $C2
     add  hl, bc                                   ; $46C7: $09
     ld   [hl], a                                  ; $46C8: $77
-    ldh  a, [hScratchB]                           ; $46C9: $F0 $D8
+    ldh  a, [hScratch1]                           ; $46C9: $F0 $D8
     cpl                                           ; $46CB: $2F
     inc  a                                        ; $46CC: $3C
 
@@ -1902,15 +1902,15 @@ jr_005_4A46:
 
     ld   a, $02                                   ; $4A59: $3E $02
     call label_3B86                               ; $4A5B: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $4A5E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4A5E: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4A60: $21 $00 $C2
     add  hl, de                                   ; $4A63: $19
     ld   [hl], a                                  ; $4A64: $77
-    ldh  a, [hScratchB]                           ; $4A65: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4A65: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4A67: $21 $10 $C2
     add  hl, de                                   ; $4A6A: $19
     ld   [hl], a                                  ; $4A6B: $77
-    ldh  a, [hScratchD]                           ; $4A6C: $F0 $DA
+    ldh  a, [hScratch3]                           ; $4A6C: $F0 $DA
     ld   hl, wEntitiesPosZTable                                ; $4A6E: $21 $10 $C3
     add  hl, de                                   ; $4A71: $19
     ld   [hl], a                                  ; $4A72: $77
@@ -2448,12 +2448,12 @@ jr_005_4D5D:
 
     ld   a, $3F                                   ; $4D67: $3E $3F
     call label_3B86                               ; $4D69: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $4D6C: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4D6C: $F0 $D7
     add  $06                                      ; $4D6E: $C6 $06
     ld   hl, wEntity0PosX                         ; $4D70: $21 $00 $C2
     add  hl, de                                   ; $4D73: $19
     ld   [hl], a                                  ; $4D74: $77
-    ldh  a, [hScratchB]                           ; $4D75: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4D75: $F0 $D8
     sub  $03                                      ; $4D77: $D6 $03
     ld   hl, wEntity0PosY                         ; $4D79: $21 $10 $C2
     add  hl, de                                   ; $4D7C: $19
@@ -2698,7 +2698,7 @@ label_005_4EE0:
     call label_3B86                               ; $4EFB: $CD $86 $3B
     jr   c, jr_005_4F39                           ; $4EFE: $38 $39
 
-    ldh  a, [hScratchB]                           ; $4F00: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4F00: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4F02: $21 $10 $C2
     add  hl, de                                   ; $4F05: $19
     sub  $08                                      ; $4F06: $D6 $08
@@ -2715,7 +2715,7 @@ label_005_4EE0:
     ld   c, a                                     ; $4F15: $4F
     ld   hl, $4E5E                                ; $4F16: $21 $5E $4E
     add  hl, bc                                   ; $4F19: $09
-    ldh  a, [hScratchA]                           ; $4F1A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4F1A: $F0 $D7
     add  [hl]                                     ; $4F1C: $86
     ld   hl, wEntity0PosX                         ; $4F1D: $21 $00 $C2
     add  hl, de                                   ; $4F20: $19
@@ -3952,12 +3952,12 @@ jr_005_561E:
     ld   hl, wEntitiesUnknownTableD               ; $5638: $21 $D0 $C2
     add  hl, de                                   ; $563B: $19
     ld   [hl], $02                                ; $563C: $36 $02
-    ldh  a, [hScratchA]                           ; $563E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $563E: $F0 $D7
     sub  $14                                      ; $5640: $D6 $14
     ld   hl, wEntity0PosX                         ; $5642: $21 $00 $C2
     add  hl, de                                   ; $5645: $19
     ld   [hl], a                                  ; $5646: $77
-    ldh  a, [hScratchB]                           ; $5647: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5647: $F0 $D8
     sub  $04                                      ; $5649: $D6 $04
     ld   hl, wEntity0PosY                         ; $564B: $21 $10 $C2
     add  hl, de                                   ; $564E: $19
@@ -4762,12 +4762,12 @@ jr_005_5AA7:
     ld   c, a                                     ; $5AB1: $4F
     ld   hl, $5A7D                                ; $5AB2: $21 $7D $5A
     add  hl, bc                                   ; $5AB5: $09
-    ldh  a, [hScratchA]                           ; $5AB6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5AB6: $F0 $D7
     add  [hl]                                     ; $5AB8: $86
     ld   hl, wEntity0PosX                         ; $5AB9: $21 $00 $C2
     add  hl, de                                   ; $5ABC: $19
     ld   [hl], a                                  ; $5ABD: $77
-    ldh  a, [hScratchB]                           ; $5ABE: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5ABE: $F0 $D8
     sub  $10                                      ; $5AC0: $D6 $10
     ld   hl, wEntity0PosY                         ; $5AC2: $21 $10 $C2
     add  hl, de                                   ; $5AC5: $19
@@ -5348,7 +5348,7 @@ jr_005_5E0E:
 
     jr   nc, jr_005_5E2C                          ; $5E1A: $30 $10
 
-    ldh  a, [hScratchB]                           ; $5E1C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5E1C: $F0 $D8
     call nc, $CCD0                                ; $5E1E: $D4 $D0 $CC
     ret  z                                        ; $5E21: $C8
 
@@ -5497,12 +5497,12 @@ jr_005_5EB0:
     srl  c                                        ; $5ED7: $CB $39
     ld   hl, $5E1B                                ; $5ED9: $21 $1B $5E
     add  hl, bc                                   ; $5EDC: $09
-    ldh  a, [hScratchA]                           ; $5EDD: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5EDD: $F0 $D7
     add  [hl]                                     ; $5EDF: $86
     ld   hl, wEntity0PosX                         ; $5EE0: $21 $00 $C2
     add  hl, de                                   ; $5EE3: $19
     ld   [hl], a                                  ; $5EE4: $77
-    ldh  a, [hScratchB]                           ; $5EE5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5EE5: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5EE7: $21 $10 $C2
     add  hl, de                                   ; $5EEA: $19
     add  $0C                                      ; $5EEB: $C6 $0C
@@ -6491,16 +6491,16 @@ jr_005_63CC:
     ld   [hl], $40                                ; $6421: $36 $40
     ldh  a, [wActiveEntityPosX]                   ; $6423: $F0 $EE
     add  $F8                                      ; $6425: $C6 $F8
-    ldh  [hScratchA], a                           ; $6427: $E0 $D7
+    ldh  [hScratch0], a                           ; $6427: $E0 $D7
     call func_005_6432                            ; $6429: $CD $32 $64
     ldh  a, [wActiveEntityPosX]                   ; $642C: $F0 $EE
     add  $08                                      ; $642E: $C6 $08
-    ldh  [hScratchA], a                           ; $6430: $E0 $D7
+    ldh  [hScratch0], a                           ; $6430: $E0 $D7
 
 func_005_6432:
     ldh  a, [wActiveEntityPosY]                   ; $6432: $F0 $EC
     sub  $10                                      ; $6434: $D6 $10
-    ldh  [hScratchB], a                           ; $6436: $E0 $D8
+    ldh  [hScratch1], a                           ; $6436: $E0 $D8
     ld   a, $02                                   ; $6438: $3E $02
     call label_CC7                                ; $643A: $CD $C7 $0C
     ld   hl, $C520                                ; $643D: $21 $20 $C5
@@ -6666,9 +6666,9 @@ jr_005_6522:
     ret  nz                                       ; $6526: $C0
 
     ldh  a, [wActiveEntityPosX]                   ; $6527: $F0 $EE
-    ldh  [hScratchA], a                           ; $6529: $E0 $D7
+    ldh  [hScratch0], a                           ; $6529: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $652B: $F0 $EC
-    ldh  [hScratchB], a                           ; $652D: $E0 $D8
+    ldh  [hScratch1], a                           ; $652D: $E0 $D8
     ld   a, $0A                                   ; $652F: $3E $0A
     jp   label_CC7                                ; $6531: $C3 $C7 $0C
 
@@ -6748,16 +6748,16 @@ jr_005_6581:
     ld   c, a                                     ; $6593: $4F
     ld   hl, $657A                                ; $6594: $21 $7A $65
     add  hl, bc                                   ; $6597: $09
-    ldh  a, [hScratchA]                           ; $6598: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6598: $F0 $D7
     add  [hl]                                     ; $659A: $86
     ld   hl, wEntity0PosX                         ; $659B: $21 $00 $C2
     add  hl, de                                   ; $659E: $19
     ld   [hl], a                                  ; $659F: $77
-    ldh  a, [hScratchB]                           ; $65A0: $F0 $D8
+    ldh  a, [hScratch1]                           ; $65A0: $F0 $D8
     ld   hl, wEntity0PosY                         ; $65A2: $21 $10 $C2
     add  hl, de                                   ; $65A5: $19
     ld   [hl], a                                  ; $65A6: $77
-    ldh  a, [hScratchD]                           ; $65A7: $F0 $DA
+    ldh  a, [hScratch3]                           ; $65A7: $F0 $DA
     ld   hl, wEntitiesPosZTable                                ; $65A9: $21 $10 $C3
     add  hl, de                                   ; $65AC: $19
     ld   [hl], a                                  ; $65AD: $77
@@ -6798,11 +6798,11 @@ func_005_65D9:
     ld   hl, wEntitiesUnknownTableB               ; $65E0: $21 $B0 $C2
     add  hl, de                                   ; $65E3: $19
     ld   [hl], $01                                ; $65E4: $36 $01
-    ldh  a, [hScratchA]                           ; $65E6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $65E6: $F0 $D7
     ld   hl, wEntity0PosX                         ; $65E8: $21 $00 $C2
     add  hl, de                                   ; $65EB: $19
     ld   [hl], a                                  ; $65EC: $77
-    ldh  a, [hScratchB]                           ; $65ED: $F0 $D8
+    ldh  a, [hScratch1]                           ; $65ED: $F0 $D8
     ld   hl, wEntity0PosY                         ; $65EF: $21 $10 $C2
     add  hl, de                                   ; $65F2: $19
     ld   [hl], a                                  ; $65F3: $77
@@ -6848,14 +6848,14 @@ jr_005_6613:
     ld   c, a                                     ; $6625: $4F
     ld   hl, $6600                                ; $6626: $21 $00 $66
     add  hl, bc                                   ; $6629: $09
-    ldh  a, [hScratchA]                           ; $662A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $662A: $F0 $D7
     add  [hl]                                     ; $662C: $86
     ld   hl, wEntity0PosX                         ; $662D: $21 $00 $C2
     add  hl, de                                   ; $6630: $19
     ld   [hl], a                                  ; $6631: $77
     ld   hl, $6604                                ; $6632: $21 $04 $66
     add  hl, bc                                   ; $6635: $09
-    ldh  a, [hScratchB]                           ; $6636: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6636: $F0 $D8
     add  [hl]                                     ; $6638: $86
     ld   hl, wEntity0PosY                         ; $6639: $21 $10 $C2
     add  hl, de                                   ; $663C: $19
@@ -7287,7 +7287,7 @@ jr_005_689B:
     inc  a                                        ; $68A0: $3C
     and  $3F                                      ; $68A1: $E6 $3F
     ld   [hl], a                                  ; $68A3: $77
-    ldh  [hScratchA], a                           ; $68A4: $E0 $D7
+    ldh  [hScratch0], a                           ; $68A4: $E0 $D7
     rra                                           ; $68A6: $1F
     rra                                           ; $68A7: $1F
     nop                                           ; $68A8: $00
@@ -7319,7 +7319,7 @@ jr_005_689B:
     push de                                       ; $68D5: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $68D6: $21 $00 $D0
     add  hl, de                                   ; $68D9: $19
-    ldh  a, [hScratchA]                           ; $68DA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $68DA: $F0 $D7
     ld   e, a                                     ; $68DC: $5F
     add  hl, de                                   ; $68DD: $19
     ldh  a, [wActiveEntityPosX]                   ; $68DE: $F0 $EE
@@ -7327,7 +7327,7 @@ jr_005_689B:
     pop  de                                       ; $68E1: $D1
     ld   hl, $D100                                ; $68E2: $21 $00 $D1
     add  hl, de                                   ; $68E5: $19
-    ldh  a, [hScratchA]                           ; $68E6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $68E6: $F0 $D7
     ld   e, a                                     ; $68E8: $5F
     add  hl, de                                   ; $68E9: $19
     ldh  a, [wActiveEntityPosY]                   ; $68EA: $F0 $EC
@@ -7498,12 +7498,12 @@ jr_005_69CB:
     add  hl, de                                   ; $69D6: $19
     ldh  a, [wActiveEntityPosX]                   ; $69D7: $F0 $EE
     add  [hl]                                     ; $69D9: $86
-    ldh  [hScratchA], a                           ; $69DA: $E0 $D7
+    ldh  [hScratch0], a                           ; $69DA: $E0 $D7
     ld   hl, $69AD                                ; $69DC: $21 $AD $69
     add  hl, de                                   ; $69DF: $19
     ldh  a, [wActiveEntityPosY]                   ; $69E0: $F0 $EC
     add  [hl]                                     ; $69E2: $86
-    ldh  [hScratchB], a                           ; $69E3: $E0 $D8
+    ldh  [hScratch1], a                           ; $69E3: $E0 $D8
     ld   a, $02                                   ; $69E5: $3E $02
     call label_CC7                                ; $69E7: $CD $C7 $0C
     xor  a                                        ; $69EA: $AF
@@ -7531,14 +7531,14 @@ jr_005_69EB:
     ld   c, [hl]                                  ; $6A07: $4E
     ld   hl, $69A1                                ; $6A08: $21 $A1 $69
     add  hl, bc                                   ; $6A0B: $09
-    ldh  a, [hScratchA]                           ; $6A0C: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A0C: $F0 $D7
     add  [hl]                                     ; $6A0E: $86
     ld   hl, wEntity0PosX                         ; $6A0F: $21 $00 $C2
     add  hl, de                                   ; $6A12: $19
     ld   [hl], a                                  ; $6A13: $77
     ld   hl, $69A5                                ; $6A14: $21 $A5 $69
     add  hl, bc                                   ; $6A17: $09
-    ldh  a, [hScratchB]                           ; $6A18: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6A18: $F0 $D8
     add  [hl]                                     ; $6A1A: $86
     ld   hl, wEntity0PosY                         ; $6A1B: $21 $10 $C2
     add  hl, de                                   ; $6A1E: $19
@@ -7593,7 +7593,7 @@ func_005_6A5F:
     ld   hl, $C3D0                                ; $6A5F: $21 $D0 $C3
     add  hl, bc                                   ; $6A62: $09
     ld   a, [hl]                                  ; $6A63: $7E
-    ldh  [hScratchA], a                           ; $6A64: $E0 $D7
+    ldh  [hScratch0], a                           ; $6A64: $E0 $D7
     push bc                                       ; $6A66: $C5
     ld   hl, $C460                                ; $6A67: $21 $60 $C4
     add  hl, bc                                   ; $6A6A: $09
@@ -7611,7 +7611,7 @@ func_005_6A5F:
     push de                                       ; $6A7E: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $6A7F: $21 $00 $D0
     add  hl, de                                   ; $6A82: $19
-    ldh  a, [hScratchA]                           ; $6A83: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A83: $F0 $D7
     sub  c                                        ; $6A85: $91
     and  $3F                                      ; $6A86: $E6 $3F
     ld   e, a                                     ; $6A88: $5F
@@ -7622,7 +7622,7 @@ func_005_6A5F:
     pop  de                                       ; $6A8E: $D1
     ld   hl, $D100                                ; $6A8F: $21 $00 $D1
     add  hl, de                                   ; $6A92: $19
-    ldh  a, [hScratchA]                           ; $6A93: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A93: $F0 $D7
     sub  c                                        ; $6A95: $91
     and  $3F                                      ; $6A96: $E6 $3F
     ld   e, a                                     ; $6A98: $5F
@@ -7638,7 +7638,7 @@ func_005_6AA5:
     ld   hl, $C3D0                                ; $6AA5: $21 $D0 $C3
     add  hl, bc                                   ; $6AA8: $09
     ld   a, [hl]                                  ; $6AA9: $7E
-    ldh  [hScratchA], a                           ; $6AAA: $E0 $D7
+    ldh  [hScratch0], a                           ; $6AAA: $E0 $D7
     push bc                                       ; $6AAC: $C5
     ld   hl, $C460                                ; $6AAD: $21 $60 $C4
     add  hl, bc                                   ; $6AB0: $09
@@ -7656,7 +7656,7 @@ func_005_6AA5:
     push de                                       ; $6AC4: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $6AC5: $21 $00 $D0
     add  hl, de                                   ; $6AC8: $19
-    ldh  a, [hScratchA]                           ; $6AC9: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6AC9: $F0 $D7
     sub  c                                        ; $6ACB: $91
     and  $3F                                      ; $6ACC: $E6 $3F
     ld   e, a                                     ; $6ACE: $5F
@@ -7667,7 +7667,7 @@ func_005_6AA5:
     pop  de                                       ; $6AD4: $D1
     ld   hl, $D100                                ; $6AD5: $21 $00 $D1
     add  hl, de                                   ; $6AD8: $19
-    ldh  a, [hScratchA]                           ; $6AD9: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6AD9: $F0 $D7
     sub  c                                        ; $6ADB: $91
     and  $3F                                      ; $6ADC: $E6 $3F
     ld   e, a                                     ; $6ADE: $5F
@@ -9099,9 +9099,9 @@ func_005_7283:
     call label_3B18                               ; $72B9: $CD $18 $3B
     ld   a, $18                                   ; $72BC: $3E $18
     call label_3BB5                               ; $72BE: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $72C1: $F0 $D7
+    ldh  a, [hScratch0]                           ; $72C1: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $72C3: $E0 $9B
-    ldh  a, [hScratchB]                           ; $72C5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $72C5: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $72C7: $E0 $9A
 
 jr_005_72C9:
@@ -9501,11 +9501,11 @@ jr_005_74C5:
     add  hl, de                                   ; $74E8: $19
     ld   a, [hl]                                  ; $74E9: $7E
     call label_3BB5                               ; $74EA: $CD $B5 $3B
-    ldh  a, [hScratchB]                           ; $74ED: $F0 $D8
+    ldh  a, [hScratch1]                           ; $74ED: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $74EF: $21 $40 $C2
     add  hl, bc                                   ; $74F2: $09
     ld   [hl], a                                  ; $74F3: $77
-    ldh  a, [hScratchA]                           ; $74F4: $F0 $D7
+    ldh  a, [hScratch0]                           ; $74F4: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $74F6: $21 $50 $C2
     add  hl, bc                                   ; $74F9: $09
     ld   [hl], a                                  ; $74FA: $77
@@ -9591,9 +9591,9 @@ label_005_7550:
 label_005_7570:
     call func_005_7A40                            ; $7570: $CD $40 $7A
     ldh  a, [wActiveEntityPosX]                   ; $7573: $F0 $EE
-    ldh  [hScratchA], a                           ; $7575: $E0 $D7
+    ldh  [hScratch0], a                           ; $7575: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7577: $F0 $EC
-    ldh  [hScratchB], a                           ; $7579: $E0 $D8
+    ldh  [hScratch1], a                           ; $7579: $E0 $D8
     ld   a, $02                                   ; $757B: $3E $02
     call label_CC7                                ; $757D: $CD $C7 $0C
     ld   a, $13                                   ; $7580: $3E $13
@@ -9610,16 +9610,16 @@ label_005_758C:
     ld   a, $36                                   ; $758C: $3E $36
     call label_3B86                               ; $758E: $CD $86 $3B
     ld   a, $48                                   ; $7591: $3E $48
-    ldh  [hScratchA], a                           ; $7593: $E0 $D7
+    ldh  [hScratch0], a                           ; $7593: $E0 $D7
     ld   a, $10                                   ; $7595: $3E $10
-    ldh  [hScratchB], a                           ; $7597: $E0 $D8
+    ldh  [hScratch1], a                           ; $7597: $E0 $D8
 
 jr_005_7599:
-    ldh  a, [hScratchB]                           ; $7599: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7599: $F0 $D8
     ld   hl, wEntity0PosY                         ; $759B: $21 $10 $C2
     add  hl, de                                   ; $759E: $19
     ld   [hl], a                                  ; $759F: $77
-    ldh  a, [hScratchA]                           ; $75A0: $F0 $D7
+    ldh  a, [hScratch0]                           ; $75A0: $F0 $D7
     ld   hl, wEntity0PosX                         ; $75A2: $21 $00 $C2
     add  hl, de                                   ; $75A5: $19
     ld   [hl], a                                  ; $75A6: $77
@@ -9674,11 +9674,11 @@ jr_005_75C0:
     ld   a, $02                                   ; $75F4: $3E $02
     call label_3B86                               ; $75F6: $CD $86 $3B
     call PlayBombExplosionSfx                                ; $75F9: $CD $4B $0C
-    ldh  a, [hScratchA]                           ; $75FC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $75FC: $F0 $D7
     ld   hl, wEntity0PosX                         ; $75FE: $21 $00 $C2
     add  hl, de                                   ; $7601: $19
     ld   [hl], a                                  ; $7602: $77
-    ldh  a, [hScratchB]                           ; $7603: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7603: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7605: $21 $10 $C2
     add  hl, de                                   ; $7608: $19
     ld   [hl], a                                  ; $7609: $77
@@ -9772,8 +9772,8 @@ func_005_766E:
     ld   hl, $C3D0                                ; $7687: $21 $D0 $C3
     add  hl, bc                                   ; $768A: $09
     ld   a, [hl]                                  ; $768B: $7E
-    ldh  [hScratchA], a                           ; $768C: $E0 $D7
-    ldh  a, [hScratchA]                           ; $768E: $F0 $D7
+    ldh  [hScratch0], a                           ; $768C: $E0 $D7
+    ldh  a, [hScratch0]                           ; $768E: $F0 $D7
     sub  $0C                                      ; $7690: $D6 $0C
     and  $7F                                      ; $7692: $E6 $7F
     ld   e, a                                     ; $7694: $5F
@@ -9790,7 +9790,7 @@ func_005_766E:
     ldh  [hActiveEntityUnknownG], a               ; $76A6: $E0 $F1
     ld   de, $72CC                                ; $76A8: $11 $CC $72
     call RenderAnimatedActiveEntity                               ; $76AB: $CD $C0 $3B
-    ldh  a, [hScratchA]                           ; $76AE: $F0 $D7
+    ldh  a, [hScratch0]                           ; $76AE: $F0 $D7
     sub  $18                                      ; $76B0: $D6 $18
     and  $7F                                      ; $76B2: $E6 $7F
     ld   e, a                                     ; $76B4: $5F
@@ -9807,7 +9807,7 @@ func_005_766E:
     ldh  [hActiveEntityUnknownG], a               ; $76C6: $E0 $F1
     ld   de, $72CC                                ; $76C8: $11 $CC $72
     call RenderAnimatedActiveEntity                               ; $76CB: $CD $C0 $3B
-    ldh  a, [hScratchA]                           ; $76CE: $F0 $D7
+    ldh  a, [hScratch0]                           ; $76CE: $F0 $D7
     sub  $24                                      ; $76D0: $D6 $24
     and  $7F                                      ; $76D2: $E6 $7F
     ld   e, a                                     ; $76D4: $5F
@@ -10557,7 +10557,7 @@ jr_005_7B22:
 func_005_7B24:
     call func_005_7B04                            ; $7B24: $CD $04 $7B
     ld   a, e                                     ; $7B27: $7B
-    ldh  [hScratchA], a                           ; $7B28: $E0 $D7
+    ldh  [hScratch0], a                           ; $7B28: $E0 $D7
     ld   a, d                                     ; $7B2A: $7A
     bit  7, a                                     ; $7B2B: $CB $7F
     jr   z, jr_005_7B31                           ; $7B2D: $28 $02
@@ -10569,7 +10569,7 @@ jr_005_7B31:
     push af                                       ; $7B31: $F5
     call func_005_7B14                            ; $7B32: $CD $14 $7B
     ld   a, e                                     ; $7B35: $7B
-    ldh  [hScratchB], a                           ; $7B36: $E0 $D8
+    ldh  [hScratch1], a                           ; $7B36: $E0 $D8
     ld   a, d                                     ; $7B38: $7A
     bit  7, a                                     ; $7B39: $CB $7F
     jr   z, jr_005_7B3F                           ; $7B3B: $28 $02
@@ -10582,11 +10582,11 @@ jr_005_7B3F:
     cp   d                                        ; $7B40: $BA
     jr   nc, jr_005_7B47                          ; $7B41: $30 $04
 
-    ldh  a, [hScratchA]                           ; $7B43: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7B43: $F0 $D7
     jr   jr_005_7B49                              ; $7B45: $18 $02
 
 jr_005_7B47:
-    ldh  a, [hScratchB]                           ; $7B47: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7B47: $F0 $D8
 
 jr_005_7B49:
     ld   e, a                                     ; $7B49: $5F
@@ -11142,11 +11142,11 @@ jr_005_7E3A:
     call label_3B86                               ; $7E40: $CD $86 $3B
     jr   c, jr_005_7E61                           ; $7E43: $38 $1C
 
-    ldh  a, [hScratchA]                           ; $7E45: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7E45: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7E47: $21 $00 $C2
     add  hl, de                                   ; $7E4A: $19
     ld   [hl], a                                  ; $7E4B: $77
-    ldh  a, [hScratchB]                           ; $7E4C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7E4C: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7E4E: $21 $10 $C2
     add  hl, de                                   ; $7E51: $19
     ld   [hl], a                                  ; $7E52: $77

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -312,11 +312,11 @@ jr_006_41C7:
 
     ld   a, $02                                   ; $41DF: $3E $02
     call label_3B86                               ; $41E1: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $41E4: $F0 $D7
+    ldh  a, [hScratch0]                           ; $41E4: $F0 $D7
     ld   hl, wEntity0PosX                         ; $41E6: $21 $00 $C2
     add  hl, de                                   ; $41E9: $19
     ld   [hl], a                                  ; $41EA: $77
-    ldh  a, [hScratchB]                           ; $41EB: $F0 $D8
+    ldh  a, [hScratch1]                           ; $41EB: $F0 $D8
     ld   hl, wEntity0PosY                         ; $41ED: $21 $10 $C2
     add  hl, de                                   ; $41F0: $19
     ld   [hl], a                                  ; $41F1: $77
@@ -591,11 +591,11 @@ jr_006_434B:
 
     ld   a, $08                                   ; $437F: $3E $08
     call label_3BB5                               ; $4381: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $4384: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4384: $F0 $D7
     cpl                                           ; $4386: $2F
     inc  a                                        ; $4387: $3C
     ldh  [hLinkPositionYIncrement], a             ; $4388: $E0 $9B
-    ldh  a, [hScratchB]                           ; $438A: $F0 $D8
+    ldh  a, [hScratch1]                           ; $438A: $F0 $D8
     cpl                                           ; $438C: $2F
     inc  a                                        ; $438D: $3C
     ldh  [hLinkPositionXIncrement], a             ; $438E: $E0 $9A
@@ -839,12 +839,12 @@ jr_006_44F1:
     call label_3B86                               ; $4521: $CD $86 $3B
     ld   a, e                                     ; $4524: $7B
     ld   [$D201], a                               ; $4525: $EA $01 $D2
-    ldh  a, [hScratchB]                           ; $4528: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4528: $F0 $D8
     add  $10                                      ; $452A: $C6 $10
     ld   hl, wEntity0PosY                         ; $452C: $21 $10 $C2
     add  hl, de                                   ; $452F: $19
     ld   [hl], a                                  ; $4530: $77
-    ldh  a, [hScratchA]                           ; $4531: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4531: $F0 $D7
     add  $30                                      ; $4533: $C6 $30
     ld   hl, wEntity0PosX                         ; $4535: $21 $00 $C2
     add  hl, de                                   ; $4538: $19
@@ -1635,7 +1635,7 @@ jr_006_49D2:
     and  a                                        ; $49D9: $A7
     jp   nz, label_006_4AA7                       ; $49DA: $C2 $A7 $4A
 
-    ldh  [hScratchA], a                           ; $49DD: $E0 $D7
+    ldh  [hScratch0], a                           ; $49DD: $E0 $D7
     ld   e, $0F                                   ; $49DF: $1E $0F
     ld   d, b                                     ; $49E1: $50
 
@@ -1664,9 +1664,9 @@ jr_006_49E2:
     and  a                                        ; $4A01: $A7
     jr   nz, jr_006_4A09                          ; $4A02: $20 $05
 
-    ldh  a, [hScratchA]                           ; $4A04: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4A04: $F0 $D7
     inc  a                                        ; $4A06: $3C
-    ldh  [hScratchA], a                           ; $4A07: $E0 $D7
+    ldh  [hScratch0], a                           ; $4A07: $E0 $D7
 
 jr_006_4A09:
     dec  e                                        ; $4A09: $1D
@@ -1674,7 +1674,7 @@ jr_006_4A09:
     cp   $FF                                      ; $4A0B: $FE $FF
     jr   nz, jr_006_49E2                          ; $4A0D: $20 $D3
 
-    ldh  a, [hScratchA]                           ; $4A0F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4A0F: $F0 $D7
     cp   $03                                      ; $4A11: $FE $03
     jp   nz, label_006_4AA7                       ; $4A13: $C2 $A7 $4A
 
@@ -1699,7 +1699,7 @@ jr_006_4A1B:
     ld   hl, $C380                                ; $4A2C: $21 $80 $C3
     add  hl, de                                   ; $4A2F: $19
     ld   a, [hl]                                  ; $4A30: $7E
-    ld   hl, hScratchC                            ; $4A31: $21 $D9 $FF
+    ld   hl, hScratch2                            ; $4A31: $21 $D9 $FF
     add  hl, bc                                   ; $4A34: $09
     ld   [hl], a                                  ; $4A35: $77
     inc  bc                                       ; $4A36: $03
@@ -1713,8 +1713,8 @@ jr_006_4A37:
     pop  bc                                       ; $4A3D: $C1
     call label_C20                                ; $4A3E: $CD $20 $0C
     ld   e, $00                                   ; $4A41: $1E $00
-    ldh  a, [hScratchC]                           ; $4A43: $F0 $D9
-    ld   hl, hScratchD                            ; $4A45: $21 $DA $FF
+    ldh  a, [hScratch2]                           ; $4A43: $F0 $D9
+    ld   hl, hScratch3                            ; $4A45: $21 $DA $FF
     cp   [hl]                                     ; $4A48: $BE
     jr   nz, jr_006_4A62                          ; $4A49: $20 $17
 
@@ -1915,10 +1915,10 @@ jr_006_4B53:
     ret  nc                                       ; $4B68: $D0
 
     ldh  a, [wActiveEntityPosX]                   ; $4B69: $F0 $EE
-    ldh  [hScratchA], a                           ; $4B6B: $E0 $D7
+    ldh  [hScratch0], a                           ; $4B6B: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $4B6D: $F0 $EC
     add  $0C                                      ; $4B6F: $C6 $0C
-    ldh  [hScratchB], a                           ; $4B71: $E0 $D8
+    ldh  [hScratch1], a                           ; $4B71: $E0 $D8
     jp   label_D15                                ; $4B73: $C3 $15 $0D
 
     nop                                           ; $4B76: $00
@@ -2186,14 +2186,14 @@ jr_006_4CCE:
     ld   c, a                                     ; $4CE3: $4F
     ld   hl, $4BF8                                ; $4CE4: $21 $F8 $4B
     add  hl, bc                                   ; $4CE7: $09
-    ldh  a, [hScratchA]                           ; $4CE8: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4CE8: $F0 $D7
     add  [hl]                                     ; $4CEA: $86
     ld   hl, wEntity0PosX                         ; $4CEB: $21 $00 $C2
     add  hl, de                                   ; $4CEE: $19
     ld   [hl], a                                  ; $4CEF: $77
     ld   hl, $4C00                                ; $4CF0: $21 $00 $4C
     add  hl, bc                                   ; $4CF3: $09
-    ldh  a, [hScratchB]                           ; $4CF4: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4CF4: $F0 $D8
     add  [hl]                                     ; $4CF6: $86
     ld   hl, wEntity0PosY                         ; $4CF7: $21 $10 $C2
     add  hl, de                                   ; $4CFA: $19
@@ -2404,9 +2404,9 @@ jr_006_4EF2:
     ld   [$C13E], a                               ; $4EFD: $EA $3E $C1
     ld   a, $10                                   ; $4F00: $3E $10
     call label_3BB5                               ; $4F02: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $4F05: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4F05: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $4F07: $E0 $9B
-    ldh  a, [hScratchB]                           ; $4F09: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4F09: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $4F0B: $E0 $9A
 
 jr_006_4F0D:
@@ -2470,7 +2470,7 @@ jr_006_4F48:
     and  $07                                      ; $4F6F: $E6 $07
     add  $04                                      ; $4F71: $C6 $04
     call label_3BB5                               ; $4F73: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $4F76: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4F76: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $4F78: $21 $50 $C2
     call func_006_4FA3                            ; $4F7B: $CD $A3 $4F
     ld   hl, wEntitiesCollisionsTable             ; $4F7E: $21 $A0 $C2
@@ -2484,7 +2484,7 @@ jr_006_4F48:
     ld   [hl], b                                  ; $4F8B: $70
 
 jr_006_4F8C:
-    ldh  a, [hScratchB]                           ; $4F8C: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4F8C: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $4F8E: $21 $40 $C2
     call func_006_4FA3                            ; $4F91: $CD $A3 $4F
     ld   hl, wEntitiesCollisionsTable             ; $4F94: $21 $A0 $C2
@@ -2737,10 +2737,10 @@ jr_006_5102:
     jr   nz, jr_006_5117                          ; $5106: $20 $0F
 
     ldh  a, [wActiveEntityPosX]                   ; $5108: $F0 $EE
-    ldh  [hScratchA], a                           ; $510A: $E0 $D7
+    ldh  [hScratch0], a                           ; $510A: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $510C: $F0 $EC
     add  $0A                                      ; $510E: $C6 $0A
-    ldh  [hScratchB], a                           ; $5110: $E0 $D8
+    ldh  [hScratch1], a                           ; $5110: $E0 $D8
     ld   a, $0B                                   ; $5112: $3E $0B
     call label_CC7                                ; $5114: $CD $C7 $0C
 
@@ -2881,12 +2881,12 @@ jr_006_51D0:
     call label_3B86                               ; $51D6: $CD $86 $3B
     jr   c, jr_006_51F6                           ; $51D9: $38 $1B
 
-    ldh  a, [hScratchA]                           ; $51DB: $F0 $D7
+    ldh  a, [hScratch0]                           ; $51DB: $F0 $D7
     sub  $0C                                      ; $51DD: $D6 $0C
     ld   hl, wEntity0PosX                         ; $51DF: $21 $00 $C2
     add  hl, de                                   ; $51E2: $19
     ld   [hl], a                                  ; $51E3: $77
-    ldh  a, [hScratchB]                           ; $51E4: $F0 $D8
+    ldh  a, [hScratch1]                           ; $51E4: $F0 $D8
     sub  $00                                      ; $51E6: $D6 $00
     ld   hl, wEntity0PosY                         ; $51E8: $21 $10 $C2
     add  hl, de                                   ; $51EB: $19
@@ -3211,14 +3211,14 @@ jr_006_5394:
     call label_3B86                               ; $53B6: $CD $86 $3B
     jr   c, jr_006_5411                           ; $53B9: $38 $56
 
-    ldh  a, [hScratchA]                           ; $53BB: $F0 $D7
+    ldh  a, [hScratch0]                           ; $53BB: $F0 $D7
     ld   hl, wEntity0PosX                         ; $53BD: $21 $00 $C2
     add  hl, de                                   ; $53C0: $19
     dec  a                                        ; $53C1: $3D
     ld   [hl], a                                  ; $53C2: $77
-    ldh  [hScratchA], a                           ; $53C3: $E0 $D7
-    ldh  a, [hScratchB]                           ; $53C5: $F0 $D8
-    ld   hl, hScratchD                            ; $53C7: $21 $DA $FF
+    ldh  [hScratch0], a                           ; $53C3: $E0 $D7
+    ldh  a, [hScratch1]                           ; $53C5: $F0 $D8
+    ld   hl, hScratch3                            ; $53C7: $21 $DA $FF
     sub  [hl]                                     ; $53CA: $96
     ld   hl, wEntity0PosY                         ; $53CB: $21 $10 $C2
     add  hl, de                                   ; $53CE: $19
@@ -3237,21 +3237,21 @@ jr_006_53D3:
     call label_3B86                               ; $53DF: $CD $86 $3B
     jr   c, jr_006_5411                           ; $53E2: $38 $2D
 
-    ldh  a, [hScratchA]                           ; $53E4: $F0 $D7
+    ldh  a, [hScratch0]                           ; $53E4: $F0 $D7
     ld   hl, wEntity0PosX                         ; $53E6: $21 $00 $C2
     add  hl, de                                   ; $53E9: $19
     add  $07                                      ; $53EA: $C6 $07
     ld   [hl], a                                  ; $53EC: $77
-    ldh  [hScratchA], a                           ; $53ED: $E0 $D7
-    ldh  a, [hScratchB]                           ; $53EF: $F0 $D8
-    ld   hl, hScratchD                            ; $53F1: $21 $DA $FF
+    ldh  [hScratch0], a                           ; $53ED: $E0 $D7
+    ldh  a, [hScratch1]                           ; $53EF: $F0 $D8
+    ld   hl, hScratch3                            ; $53F1: $21 $DA $FF
     sub  [hl]                                     ; $53F4: $96
     ld   hl, wEntity0PosY                         ; $53F5: $21 $10 $C2
     add  hl, de                                   ; $53F8: $19
 
 jr_006_53F9:
     ld   [hl], a                                  ; $53F9: $77
-    ldh  [hScratchB], a                           ; $53FA: $E0 $D8
+    ldh  [hScratch1], a                           ; $53FA: $E0 $D8
     ld   hl, wEntitiesUnknowTableF                ; $53FC: $21 $F0 $C2
     add  hl, de                                   ; $53FF: $19
     ld   [hl], $0F                                ; $5400: $36 $0F
@@ -3671,15 +3671,15 @@ jr_006_564A:
     call label_27DD                               ; $5650: $CD $DD $27
     ld   a, $30                                   ; $5653: $3E $30
     call label_3B86                               ; $5655: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $5658: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5658: $F0 $D7
     ld   hl, wEntity0PosX                         ; $565A: $21 $00 $C2
     add  hl, de                                   ; $565D: $19
     ld   [hl], a                                  ; $565E: $77
-    ldh  a, [hScratchB]                           ; $565F: $F0 $D8
+    ldh  a, [hScratch1]                           ; $565F: $F0 $D8
     ld   hl, wEntity0PosY                         ; $5661: $21 $10 $C2
     add  hl, de                                   ; $5664: $19
     ld   [hl], a                                  ; $5665: $77
-    ldh  a, [hScratchD]                           ; $5666: $F0 $DA
+    ldh  a, [hScratch3]                           ; $5666: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $5668: $21 $10 $C3
     add  hl, de                                   ; $566B: $19
     ld   [hl], a                                  ; $566C: $77
@@ -3694,7 +3694,7 @@ jr_006_564A:
     ld   [hl], $10                                ; $567D: $36 $10
     call func_006_65DB                            ; $567F: $CD $DB $65
     ldh  a, [wActiveEntityPosX]                   ; $5682: $F0 $EE
-    ldh  [hScratchA], a                           ; $5684: $E0 $D7
+    ldh  [hScratch0], a                           ; $5684: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $5686: $F0 $EC
     jr   jr_006_56BB                              ; $5688: $18 $31
 
@@ -3718,7 +3718,7 @@ jr_006_568A:
     ld   hl, wIsFileSelectionArrowShifted         ; $56A1: $21 $00 $D0
     add  hl, de                                   ; $56A4: $19
     ld   a, [hl]                                  ; $56A5: $7E
-    ldh  [hScratchA], a                           ; $56A6: $E0 $D7
+    ldh  [hScratch0], a                           ; $56A6: $E0 $D7
     ld   hl, $D200                                ; $56A8: $21 $00 $D2
     add  hl, de                                   ; $56AB: $19
     ld   a, [hl]                                  ; $56AC: $7E
@@ -3734,7 +3734,7 @@ jr_006_568A:
     ld   [hl], $FF                                ; $56B9: $36 $FF
 
 jr_006_56BB:
-    ldh  [hScratchB], a                           ; $56BB: $E0 $D8
+    ldh  [hScratch1], a                           ; $56BB: $E0 $D8
     ld   a, $02                                   ; $56BD: $3E $02
     call label_CC7                                ; $56BF: $CD $C7 $0C
     ld   a, $13                                   ; $56C2: $3E $13
@@ -4119,7 +4119,7 @@ jr_006_58D8:
     ld   hl, $C3D0                                ; $58D8: $21 $D0 $C3
     add  hl, bc                                   ; $58DB: $09
     ld   a, [hl]                                  ; $58DC: $7E
-    ldh  [hScratchA], a                           ; $58DD: $E0 $D7
+    ldh  [hScratch0], a                           ; $58DD: $E0 $D7
     ldh  a, [hFrameCounter]                       ; $58DF: $F0 $E7
     and  $01                                      ; $58E1: $E6 $01
     jr   z, jr_006_58ED                           ; $58E3: $28 $08
@@ -4140,7 +4140,7 @@ jr_006_58F3:
     ld   d, b                                     ; $58F6: $50
     ld   hl, $58C3                                ; $58F7: $21 $C3 $58
     add  hl, de                                   ; $58FA: $19
-    ldh  a, [hScratchA]                           ; $58FB: $F0 $D7
+    ldh  a, [hScratch0]                           ; $58FB: $F0 $D7
     sub  [hl]                                     ; $58FD: $96
     and  $FF                                      ; $58FE: $E6 $FF
     ld   e, a                                     ; $5900: $5F
@@ -4862,11 +4862,11 @@ jr_006_5CE5:
     ld   hl, wEntity0PosX                         ; $5CFE: $21 $00 $C2
     add  hl, bc                                   ; $5D01: $09
     ld   a, [hl]                                  ; $5D02: $7E
-    ldh  [hScratchA], a                           ; $5D03: $E0 $D7
+    ldh  [hScratch0], a                           ; $5D03: $E0 $D7
     ld   hl, wEntity0PosY                         ; $5D05: $21 $10 $C2
     add  hl, bc                                   ; $5D08: $09
     ld   a, [hl]                                  ; $5D09: $7E
-    ldh  [hScratchB], a                           ; $5D0A: $E0 $D8
+    ldh  [hScratch1], a                           ; $5D0A: $E0 $D8
     ld   de, $0000                                ; $5D0C: $11 $00 $00
 
 jr_006_5D0F:
@@ -4891,7 +4891,7 @@ jr_006_5D0F:
     ld   hl, wEntity0PosX                         ; $5D29: $21 $00 $C2
     add  hl, de                                   ; $5D2C: $19
     ld   l, [hl]                                  ; $5D2D: $6E
-    ldh  a, [hScratchA]                           ; $5D2E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5D2E: $F0 $D7
     sub  l                                        ; $5D30: $95
     bit  7, a                                     ; $5D31: $CB $7F
     jr   z, jr_006_5D37                           ; $5D33: $28 $02
@@ -4906,7 +4906,7 @@ jr_006_5D37:
     ld   hl, wEntity0PosY                         ; $5D3B: $21 $10 $C2
     add  hl, de                                   ; $5D3E: $19
     ld   l, [hl]                                  ; $5D3F: $6E
-    ldh  a, [hScratchB]                           ; $5D40: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5D40: $F0 $D8
     sub  l                                        ; $5D42: $95
     bit  7, a                                     ; $5D43: $CB $7F
     jr   z, jr_006_5D49                           ; $5D45: $28 $02
@@ -5011,7 +5011,7 @@ jr_006_5DBA:
 
     ld   a, $20                                   ; $5DD5: $3E $20
     call label_3BB5                               ; $5DD7: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $5DDA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5DDA: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $5DDC: $21 $50 $C2
     add  hl, bc                                   ; $5DDF: $09
     sub  [hl]                                     ; $5DE0: $96
@@ -5023,7 +5023,7 @@ jr_006_5DBA:
 
 jr_006_5DE7:
     dec  [hl]                                     ; $5DE7: $35
-    ldh  a, [hScratchB]                           ; $5DE8: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5DE8: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $5DEA: $21 $40 $C2
     add  hl, bc                                   ; $5DED: $09
     sub  [hl]                                     ; $5DEE: $96
@@ -5067,7 +5067,7 @@ func_006_5E14:
 
     ld   a, $20                                   ; $5E20: $3E $20
     call label_3BB5                               ; $5E22: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $5E25: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5E25: $F0 $D7
     cpl                                           ; $5E27: $2F
     inc  a                                        ; $5E28: $3C
     ld   hl, wEntity0SpeedY                       ; $5E29: $21 $50 $C2
@@ -5081,7 +5081,7 @@ func_006_5E14:
 
 jr_006_5E34:
     dec  [hl]                                     ; $5E34: $35
-    ldh  a, [hScratchB]                           ; $5E35: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5E35: $F0 $D8
     cpl                                           ; $5E37: $2F
     inc  a                                        ; $5E38: $3C
     ld   hl, wEntity0SpeedX                       ; $5E39: $21 $40 $C2
@@ -5690,11 +5690,11 @@ jr_006_619F:
     call label_3B86                               ; $61B7: $CD $86 $3B
     jr   c, jr_006_61EB                           ; $61BA: $38 $2F
 
-    ldh  a, [hScratchA]                           ; $61BC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $61BC: $F0 $D7
     ld   hl, wEntity0PosX                         ; $61BE: $21 $00 $C2
     add  hl, de                                   ; $61C1: $19
     ld   [hl], a                                  ; $61C2: $77
-    ldh  a, [hScratchB]                           ; $61C3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $61C3: $F0 $D8
     ld   hl, wEntity0PosY                         ; $61C5: $21 $10 $C2
     add  hl, de                                   ; $61C8: $19
     ld   [hl], a                                  ; $61C9: $77
@@ -5900,11 +5900,11 @@ jr_006_62EF:
     call label_3B86                               ; $62F5: $CD $86 $3B
     jr   c, jr_006_6311                           ; $62F8: $38 $17
 
-    ldh  a, [hScratchA]                           ; $62FA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $62FA: $F0 $D7
     ld   hl, wEntity0PosX                         ; $62FC: $21 $00 $C2
     add  hl, de                                   ; $62FF: $19
     ld   [hl], a                                  ; $6300: $77
-    ldh  a, [hScratchB]                           ; $6301: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6301: $F0 $D8
     ld   hl, wEntity0PosY                         ; $6303: $21 $10 $C2
     add  hl, de                                   ; $6306: $19
     ld   [hl], a                                  ; $6307: $77
@@ -6414,7 +6414,7 @@ jr_006_65B2:
 func_006_65B4:
     call func_006_6594                            ; $65B4: $CD $94 $65
     ld   a, e                                     ; $65B7: $7B
-    ldh  [hScratchA], a                           ; $65B8: $E0 $D7
+    ldh  [hScratch0], a                           ; $65B8: $E0 $D7
     ld   a, d                                     ; $65BA: $7A
     bit  7, a                                     ; $65BB: $CB $7F
     jr   z, jr_006_65C1                           ; $65BD: $28 $02
@@ -6426,7 +6426,7 @@ jr_006_65C1:
     push af                                       ; $65C1: $F5
     call func_006_65A4                            ; $65C2: $CD $A4 $65
     ld   a, e                                     ; $65C5: $7B
-    ldh  [hScratchB], a                           ; $65C6: $E0 $D8
+    ldh  [hScratch1], a                           ; $65C6: $E0 $D8
     ld   a, d                                     ; $65C8: $7A
     bit  7, a                                     ; $65C9: $CB $7F
     jr   z, jr_006_65CF                           ; $65CB: $28 $02
@@ -6439,11 +6439,11 @@ jr_006_65CF:
     cp   d                                        ; $65D0: $BA
     jr   nc, jr_006_65D7                          ; $65D1: $30 $04
 
-    ldh  a, [hScratchA]                           ; $65D3: $F0 $D7
+    ldh  a, [hScratch0]                           ; $65D3: $F0 $D7
     jr   jr_006_65D9                              ; $65D5: $18 $02
 
 jr_006_65D7:
-    ldh  a, [hScratchB]                           ; $65D7: $F0 $D8
+    ldh  a, [hScratch1]                           ; $65D7: $F0 $D8
 
 jr_006_65D9:
     ld   e, a                                     ; $65D9: $5F
@@ -7178,12 +7178,12 @@ jr_006_6A0F:
 
     ld   a, $20                                   ; $6A15: $3E $20
     call label_3BB5                               ; $6A17: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $6A1A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6A1A: $F0 $D7
     cpl                                           ; $6A1C: $2F
     inc  a                                        ; $6A1D: $3C
     ld   hl, wEntity0SpeedY                       ; $6A1E: $21 $50 $C2
     call func_006_6A2B                            ; $6A21: $CD $2B $6A
-    ldh  a, [hScratchB]                           ; $6A24: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6A24: $F0 $D8
     cpl                                           ; $6A26: $2F
     inc  a                                        ; $6A27: $3C
     ld   hl, wEntity0SpeedX                       ; $6A28: $21 $40 $C2
@@ -7543,11 +7543,11 @@ jr_006_6C53:
     ldh  [hLinkPositionY], a                      ; $6C59: $E0 $99
     pop  af                                       ; $6C5B: $F1
     ldh  [hLinkPositionX], a                      ; $6C5C: $E0 $98
-    ldh  a, [hScratchA]                           ; $6C5E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $6C5E: $F0 $D7
     ld   hl, wEntitiesUnknownTableC               ; $6C60: $21 $C0 $C2
     add  hl, bc                                   ; $6C63: $09
     ld   [hl], a                                  ; $6C64: $77
-    ldh  a, [hScratchB]                           ; $6C65: $F0 $D8
+    ldh  a, [hScratch1]                           ; $6C65: $F0 $D8
     ld   hl, wEntitiesUnknownTableB               ; $6C67: $21 $B0 $C2
     add  hl, bc                                   ; $6C6A: $09
     ld   [hl], a                                  ; $6C6B: $77
@@ -8026,7 +8026,7 @@ jr_006_6F03:
     ld   hl, wEntitiesUnknownTableB               ; $6F15: $21 $B0 $C2
     add  hl, bc                                   ; $6F18: $09
     ldh  a, [wActiveEntityPosX]                   ; $6F19: $F0 $EE
-    ldh  [hScratchA], a                           ; $6F1B: $E0 $D7
+    ldh  [hScratch0], a                           ; $6F1B: $E0 $D7
     ld   e, [hl]                                  ; $6F1D: $5E
     inc  [hl]                                     ; $6F1E: $34
     ld   a, [hl]                                  ; $6F1F: $7E
@@ -8054,7 +8054,7 @@ jr_006_6F3C:
     ld   hl, $6EDD                                ; $6F3D: $21 $DD $6E
     add  hl, de                                   ; $6F40: $19
     ld   a, [hl]                                  ; $6F41: $7E
-    ldh  [hScratchB], a                           ; $6F42: $E0 $D8
+    ldh  [hScratch1], a                           ; $6F42: $E0 $D8
     jp   label_006_7035                           ; $6F44: $C3 $35 $70
 
 jr_006_6F47:
@@ -8240,9 +8240,9 @@ label_006_700A:
 label_006_702A:
     call func_006_64CC                            ; $702A: $CD $CC $64
     ldh  a, [wActiveEntityPosX]                   ; $702D: $F0 $EE
-    ldh  [hScratchA], a                           ; $702F: $E0 $D7
+    ldh  [hScratch0], a                           ; $702F: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7031: $F0 $EC
-    ldh  [hScratchB], a                           ; $7033: $E0 $D8
+    ldh  [hScratch1], a                           ; $7033: $E0 $D8
 
 label_006_7035:
     ld   a, $02                                   ; $7035: $3E $02
@@ -8253,11 +8253,11 @@ label_006_7035:
 
     ld   a, $36                                   ; $703F: $3E $36
     call label_3B86                               ; $7041: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $7044: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7044: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7046: $21 $00 $C2
     add  hl, de                                   ; $7049: $19
     ld   [hl], a                                  ; $704A: $77
-    ldh  a, [hScratchB]                           ; $704B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $704B: $F0 $D8
     ld   hl, wEntity0PosY                         ; $704D: $21 $10 $C2
     add  hl, de                                   ; $7050: $19
     ld   [hl], a                                  ; $7051: $77
@@ -8504,12 +8504,12 @@ jr_006_71BA:
     ld   hl, wEntitiesUnknownTableD               ; $71D2: $21 $D0 $C2
     add  hl, de                                   ; $71D5: $19
     ld   [hl], $01                                ; $71D6: $36 $01
-    ldh  a, [hScratchA]                           ; $71D8: $F0 $D7
+    ldh  a, [hScratch0]                           ; $71D8: $F0 $D7
     ld   hl, wEntity0PosX                         ; $71DA: $21 $00 $C2
     add  hl, de                                   ; $71DD: $19
     add  $00                                      ; $71DE: $C6 $00
     ld   [hl], a                                  ; $71E0: $77
-    ldh  a, [hScratchB]                           ; $71E1: $F0 $D8
+    ldh  a, [hScratch1]                           ; $71E1: $F0 $D8
     ld   hl, wEntity0PosY                         ; $71E3: $21 $10 $C2
     add  hl, de                                   ; $71E6: $19
     sub  $0E                                      ; $71E7: $D6 $0E
@@ -8760,13 +8760,13 @@ func_006_7335:
     ld   [hl], $02                                ; $7351: $36 $02
     ld   a, $10                                   ; $7353: $3E $10
     call label_3BB5                               ; $7355: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $7358: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7358: $F0 $D7
     cpl                                           ; $735A: $2F
     inc  a                                        ; $735B: $3C
     ld   hl, wEntity0SpeedY                       ; $735C: $21 $50 $C2
     add  hl, bc                                   ; $735F: $09
     ld   [hl], a                                  ; $7360: $77
-    ldh  a, [hScratchB]                           ; $7361: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7361: $F0 $D8
     cpl                                           ; $7363: $2F
     inc  a                                        ; $7364: $3C
     ld   hl, wEntity0SpeedX                       ; $7365: $21 $40 $C2
@@ -9361,14 +9361,14 @@ jr_006_76E9:
     jr   c, jr_006_772D                           ; $76EE: $38 $3D
 
     push bc                                       ; $76F0: $C5
-    ldh  a, [hScratchC]                           ; $76F1: $F0 $D9
+    ldh  a, [hScratch2]                           ; $76F1: $F0 $D9
     ld   hl, $C380                                ; $76F3: $21 $80 $C3
     add  hl, de                                   ; $76F6: $19
     ld   [hl], a                                  ; $76F7: $77
     ld   c, a                                     ; $76F8: $4F
     ld   hl, $7618                                ; $76F9: $21 $18 $76
     add  hl, bc                                   ; $76FC: $09
-    ldh  a, [hScratchA]                           ; $76FD: $F0 $D7
+    ldh  a, [hScratch0]                           ; $76FD: $F0 $D7
     add  [hl]                                     ; $76FF: $86
     ld   hl, wEntity0PosX                         ; $7700: $21 $00 $C2
     add  hl, de                                   ; $7703: $19
@@ -9377,7 +9377,7 @@ jr_006_76E9:
     add  hl, bc                                   ; $7708: $09
 
 label_006_7709:
-    ldh  a, [hScratchB]                           ; $7709: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7709: $F0 $D8
     add  [hl]                                     ; $770B: $86
     ld   hl, wEntity0PosY                         ; $770C: $21 $10 $C2
     add  hl, de                                   ; $770F: $19
@@ -9397,7 +9397,7 @@ label_006_7709:
 
 jr_006_7725:
     pop  bc                                       ; $7725: $C1
-    ldh  a, [hScratchC]                           ; $7726: $F0 $D9
+    ldh  a, [hScratch2]                           ; $7726: $F0 $D9
     ld   hl, wEntitiesUnknownTableG               ; $7728: $21 $B0 $C3
     add  hl, de                                   ; $772B: $19
     ld   [hl], a                                  ; $772C: $77
@@ -9959,10 +9959,10 @@ jr_006_7982:
     and  $07                                      ; $79DE: $E6 $07
     add  $06                                      ; $79E0: $C6 $06
     call label_3BB5                               ; $79E2: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $79E5: $F0 $D7
+    ldh  a, [hScratch0]                           ; $79E5: $F0 $D7
     ld   hl, wEntity0SpeedY                       ; $79E7: $21 $50 $C2
     call func_006_7A79                            ; $79EA: $CD $79 $7A
-    ldh  a, [hScratchB]                           ; $79ED: $F0 $D8
+    ldh  a, [hScratch1]                           ; $79ED: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $79EF: $21 $40 $C2
 
 jr_006_79F2:
@@ -10028,13 +10028,13 @@ label_006_7A38:
     call label_3B39                               ; $7A4A: $CD $39 $3B
     ld   a, $04                                   ; $7A4D: $3E $04
     call label_3BB5                               ; $7A4F: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $7A52: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7A52: $F0 $D7
     cpl                                           ; $7A54: $2F
     inc  a                                        ; $7A55: $3C
     ld   hl, wEntity0SpeedY                       ; $7A56: $21 $50 $C2
     add  hl, bc                                   ; $7A59: $09
     ld   [hl], a                                  ; $7A5A: $77
-    ldh  a, [hScratchB]                           ; $7A5B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7A5B: $F0 $D8
     cpl                                           ; $7A5D: $2F
     inc  a                                        ; $7A5E: $3C
     ld   hl, wEntity0SpeedX                       ; $7A5F: $21 $40 $C2
@@ -10465,16 +10465,16 @@ jr_006_7C6A:
     ld   hl, $C460                                ; $7C95: $21 $60 $C4
     add  hl, de                                   ; $7C98: $19
     ld   [hl], a                                  ; $7C99: $77
-    ldh  a, [hScratchA]                           ; $7C9A: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7C9A: $F0 $D7
     add  $08                                      ; $7C9C: $C6 $08
     ld   hl, wEntity0PosX                         ; $7C9E: $21 $00 $C2
     add  hl, de                                   ; $7CA1: $19
     ld   [hl], a                                  ; $7CA2: $77
-    ldh  a, [hScratchB]                           ; $7CA3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7CA3: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7CA5: $21 $10 $C2
     add  hl, de                                   ; $7CA8: $19
     ld   [hl], a                                  ; $7CA9: $77
-    ldh  a, [hScratchD]                           ; $7CAA: $F0 $DA
+    ldh  a, [hScratch3]                           ; $7CAA: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $7CAC: $21 $10 $C3
     add  hl, de                                   ; $7CAF: $19
     ld   [hl], a                                  ; $7CB0: $77

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -264,11 +264,11 @@ label_007_4198:
     call label_3B86                               ; $419A: $CD $86 $3B
     ret  c                                        ; $419D: $D8
 
-    ldh  a, [hScratchA]                           ; $419E: $F0 $D7
+    ldh  a, [hScratch0]                           ; $419E: $F0 $D7
     ld   hl, wEntity0PosX                         ; $41A0: $21 $00 $C2
     add  hl, de                                   ; $41A3: $19
     ld   [hl], a                                  ; $41A4: $77
-    ldh  a, [hScratchB]                           ; $41A5: $F0 $D8
+    ldh  a, [hScratch1]                           ; $41A5: $F0 $D8
     ld   hl, wEntity0PosY                         ; $41A7: $21 $10 $C2
     add  hl, de                                   ; $41AA: $19
     ld   [hl], a                                  ; $41AB: $77
@@ -416,12 +416,12 @@ jr_007_4233:
     ld   [hl], a                                  ; $4299: $77
     ld   a, $B8                                   ; $429A: $3E $B8
     call label_3B86                               ; $429C: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $429F: $F0 $D7
+    ldh  a, [hScratch0]                           ; $429F: $F0 $D7
     ld   hl, wEntity0PosX                         ; $42A1: $21 $00 $C2
     add  hl, de                                   ; $42A4: $19
     add  $06                                      ; $42A5: $C6 $06
     ld   [hl], a                                  ; $42A7: $77
-    ldh  a, [hScratchB]                           ; $42A8: $F0 $D8
+    ldh  a, [hScratch1]                           ; $42A8: $F0 $D8
     ld   hl, wEntity0PosY                         ; $42AA: $21 $10 $C2
     add  hl, de                                   ; $42AD: $19
     add  $10                                      ; $42AE: $C6 $10
@@ -660,11 +660,11 @@ func_007_43FD:
     push bc                                       ; $43FD: $C5
     ld   bc, $C010                                ; $43FE: $01 $10 $C0
     ldh  a, [hLinkPositionY]                      ; $4401: $F0 $99
-    ldh  [hScratchA], a                           ; $4403: $E0 $D7
+    ldh  [hScratch0], a                           ; $4403: $E0 $D7
     ldh  a, [hLinkPositionX]                      ; $4405: $F0 $98
-    ldh  [hScratchB], a                           ; $4407: $E0 $D8
+    ldh  [hScratch1], a                           ; $4407: $E0 $D8
     ld   a, $06                                   ; $4409: $3E $06
-    ldh  [hScratchC], a                           ; $440B: $E0 $D9
+    ldh  [hScratch2], a                           ; $440B: $E0 $D9
     ld   h, $F0                                   ; $440D: $26 $F0
     ld   l, $FC                                   ; $440F: $2E $FC
     call label_1819                               ; $4411: $CD $19 $18
@@ -864,13 +864,13 @@ jr_007_4533:
     call IncrementEntityWalkingAttr               ; $4543: $CD $12 $3B
     ld   a, $54                                   ; $4546: $3E $54
     call label_3B86                               ; $4548: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $454B: $F0 $D7
+    ldh  a, [hScratch0]                           ; $454B: $F0 $D7
     sub  $20                                      ; $454D: $D6 $20
     ld   hl, wEntity0PosX                         ; $454F: $21 $00 $C2
     add  hl, de                                   ; $4552: $19
     ld   [hl], a                                  ; $4553: $77
     ldh  [wActiveEntityPosX], a                   ; $4554: $E0 $EE
-    ldh  a, [hScratchB]                           ; $4556: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4556: $F0 $D8
     add  $08                                      ; $4558: $C6 $08
     ld   hl, wEntity0PosY                         ; $455A: $21 $10 $C2
     add  hl, de                                   ; $455D: $19
@@ -1373,9 +1373,9 @@ jr_007_4820:
 
     ldh  a, [hLinkPositionY]                      ; $4824: $F0 $99
     sub  $03                                      ; $4826: $D6 $03
-    ldh  [hScratchB], a                           ; $4828: $E0 $D8
+    ldh  [hScratch1], a                           ; $4828: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $482A: $F0 $98
-    ldh  [hScratchA], a                           ; $482C: $E0 $D7
+    ldh  [hScratch0], a                           ; $482C: $E0 $D7
     ld   a, $0E                                   ; $482E: $3E $0E
     ldh  [hJingle], a                             ; $4830: $E0 $F2
     ld   a, $01                                   ; $4832: $3E $01
@@ -1512,9 +1512,9 @@ jr_007_48F0:
 func_007_48FD:
 label_007_48FD:
     ldh  a, [wActiveEntityPosY]                   ; $48FD: $F0 $EC
-    ldh  [hScratchB], a                           ; $48FF: $E0 $D8
+    ldh  [hScratch1], a                           ; $48FF: $E0 $D8
     ldh  a, [wActiveEntityPosX]                   ; $4901: $F0 $EE
-    ldh  [hScratchA], a                           ; $4903: $E0 $D7
+    ldh  [hScratch0], a                           ; $4903: $E0 $D7
     ld   a, $01                                   ; $4905: $3E $01
     call label_CC7                                ; $4907: $CD $C7 $0C
     ld   a, $0E                                   ; $490A: $3E $0E
@@ -2134,11 +2134,11 @@ func_007_4CEE:
     call label_3B86                               ; $4CF0: $CD $86 $3B
     jr   c, jr_007_4D1D                           ; $4CF3: $38 $28
 
-    ldh  a, [hScratchA]                           ; $4CF5: $F0 $D7
+    ldh  a, [hScratch0]                           ; $4CF5: $F0 $D7
     ld   hl, wEntity0PosX                         ; $4CF7: $21 $00 $C2
     add  hl, de                                   ; $4CFA: $19
     ld   [hl], a                                  ; $4CFB: $77
-    ldh  a, [hScratchB]                           ; $4CFC: $F0 $D8
+    ldh  a, [hScratch1]                           ; $4CFC: $F0 $D8
     ld   hl, wEntity0PosY                         ; $4CFE: $21 $10 $C2
     add  hl, de                                   ; $4D01: $19
     ld   [hl], a                                  ; $4D02: $77
@@ -2309,7 +2309,7 @@ jr_007_4DEA:
 
     ldh  a, [hFFE8]                               ; $4DF5: $F0 $E8
     add  sp, -$20                                 ; $4DF7: $E8 $E0
-    ldh  [hScratchB], a                           ; $4DF9: $E0 $D8
+    ldh  [hScratch1], a                           ; $4DF9: $E0 $D8
     db   $10                                      ; $4DFB: $10
     jr   @+$1A                                    ; $4DFC: $18 $18
 
@@ -3066,9 +3066,9 @@ jr_007_51F2:
     jr   z, jr_007_529F                           ; $525D: $28 $40
 
     ldh  a, [wActiveEntityPosX]                   ; $525F: $F0 $EE
-    ldh  [hScratchA], a                           ; $5261: $E0 $D7
+    ldh  [hScratch0], a                           ; $5261: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $5263: $F0 $EC
-    ldh  [hScratchB], a                           ; $5265: $E0 $D8
+    ldh  [hScratch1], a                           ; $5265: $E0 $D8
     ld   a, $2F                                   ; $5267: $3E $2F
     ldh  [hJingle], a                             ; $5269: $E0 $F2
     ld   a, $02                                   ; $526B: $3E $02
@@ -3163,11 +3163,11 @@ jr_007_529F:
     ld   a, [bc]                                  ; $52DF: $0A
 
 func_007_52E0:
-    ldh  a, [hScratchA]                           ; $52E0: $F0 $D7
+    ldh  a, [hScratch0]                           ; $52E0: $F0 $D7
     rlca                                          ; $52E2: $07
     and  $01                                      ; $52E3: $E6 $01
     ld   e, a                                     ; $52E5: $5F
-    ldh  a, [hScratchB]                           ; $52E6: $F0 $D8
+    ldh  a, [hScratch1]                           ; $52E6: $F0 $D8
     rlca                                          ; $52E8: $07
     rla                                           ; $52E9: $17
     and  $02                                      ; $52EA: $E6 $02
@@ -3177,7 +3177,7 @@ func_007_52E0:
     rla                                           ; $52EF: $17
     and  $18                                      ; $52F0: $E6 $18
     ld   h, a                                     ; $52F2: $67
-    ldh  a, [hScratchB]                           ; $52F3: $F0 $D8
+    ldh  a, [hScratch1]                           ; $52F3: $F0 $D8
     bit  7, a                                     ; $52F5: $CB $7F
     jr   z, jr_007_52FB                           ; $52F7: $28 $02
 
@@ -3186,7 +3186,7 @@ func_007_52E0:
 
 jr_007_52FB:
     ld   d, a                                     ; $52FB: $57
-    ldh  a, [hScratchA]                           ; $52FC: $F0 $D7
+    ldh  a, [hScratch0]                           ; $52FC: $F0 $D7
     bit  7, a                                     ; $52FE: $CB $7F
     jr   z, jr_007_5304                           ; $5300: $28 $02
 
@@ -3429,16 +3429,16 @@ func_007_5453:
     sub  [hl]                                     ; $5464: $96
     sra  a                                        ; $5465: $CB $2F
     sra  a                                        ; $5467: $CB $2F
-    ldh  [hScratchA], a                           ; $5469: $E0 $D7
-    ldh  [hScratchC], a                           ; $546B: $E0 $D9
+    ldh  [hScratch0], a                           ; $5469: $E0 $D7
+    ldh  [hScratch2], a                           ; $546B: $E0 $D9
     ldh  a, [wActiveEntityPosY]                   ; $546D: $F0 $EC
     ld   hl, wEntitiesUnknownTableC               ; $546F: $21 $C0 $C2
     add  hl, bc                                   ; $5472: $09
     sub  [hl]                                     ; $5473: $96
     sra  a                                        ; $5474: $CB $2F
     sra  a                                        ; $5476: $CB $2F
-    ldh  [hScratchB], a                           ; $5478: $E0 $D8
-    ldh  [hScratchD], a                           ; $547A: $E0 $DA
+    ldh  [hScratch1], a                           ; $5478: $E0 $D8
+    ldh  [hScratch3], a                           ; $547A: $E0 $DA
     ld   a, [$C3C0]                               ; $547C: $FA $C0 $C3
     ld   e, a                                     ; $547F: $5F
     ld   d, $00                                   ; $5480: $16 $00
@@ -3452,13 +3452,13 @@ jr_007_548A:
     ldh  [$FFDB], a                               ; $548A: $E0 $DB
     ld   hl, wEntitiesUnknownTableC               ; $548C: $21 $C0 $C2
     add  hl, bc                                   ; $548F: $09
-    ldh  a, [hScratchB]                           ; $5490: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5490: $F0 $D8
     add  [hl]                                     ; $5492: $86
     ld   [de], a                                  ; $5493: $12
     inc  de                                       ; $5494: $13
     ld   hl, wEntitiesUnknownTableB               ; $5495: $21 $B0 $C2
     add  hl, bc                                   ; $5498: $09
-    ldh  a, [hScratchA]                           ; $5499: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5499: $F0 $D7
     add  [hl]                                     ; $549B: $86
 
 jr_007_549C:
@@ -3471,14 +3471,14 @@ jr_007_549C:
     ld   a, $02                                   ; $54A4: $3E $02
     ld   [de], a                                  ; $54A6: $12
     inc  de                                       ; $54A7: $13
-    ldh  a, [hScratchA]                           ; $54A8: $F0 $D7
-    ld   hl, hScratchC                            ; $54AA: $21 $D9 $FF
+    ldh  a, [hScratch0]                           ; $54A8: $F0 $D7
+    ld   hl, hScratch2                            ; $54AA: $21 $D9 $FF
     add  [hl]                                     ; $54AD: $86
-    ldh  [hScratchA], a                           ; $54AE: $E0 $D7
-    ldh  a, [hScratchB]                           ; $54B0: $F0 $D8
-    ld   hl, hScratchD                            ; $54B2: $21 $DA $FF
+    ldh  [hScratch0], a                           ; $54AE: $E0 $D7
+    ldh  a, [hScratch1]                           ; $54B0: $F0 $D8
+    ld   hl, hScratch3                            ; $54B2: $21 $DA $FF
     add  [hl]                                     ; $54B5: $86
-    ldh  [hScratchB], a                           ; $54B6: $E0 $D8
+    ldh  [hScratch1], a                           ; $54B6: $E0 $D8
     ldh  a, [$FFDB]                               ; $54B8: $F0 $DB
     dec  a                                        ; $54BA: $3D
     jr   nz, jr_007_548A                          ; $54BB: $20 $CD
@@ -4021,21 +4021,21 @@ func_007_57B0:
     ld   hl, wEntitiesUnknownTableG               ; $57B8: $21 $B0 $C3
     add  hl, de                                   ; $57BB: $19
     ld   [hl], $01                                ; $57BC: $36 $01
-    ldh  a, [hScratchC]                           ; $57BE: $F0 $D9
+    ldh  a, [hScratch2]                           ; $57BE: $F0 $D9
     ld   hl, $C380                                ; $57C0: $21 $80 $C3
     add  hl, de                                   ; $57C3: $19
     ld   [hl], a                                  ; $57C4: $77
     ld   c, a                                     ; $57C5: $4F
     ld   hl, $57A0                                ; $57C6: $21 $A0 $57
     add  hl, bc                                   ; $57C9: $09
-    ldh  a, [hScratchA]                           ; $57CA: $F0 $D7
+    ldh  a, [hScratch0]                           ; $57CA: $F0 $D7
     add  [hl]                                     ; $57CC: $86
     ld   hl, wEntity0PosX                         ; $57CD: $21 $00 $C2
     add  hl, de                                   ; $57D0: $19
     ld   [hl], a                                  ; $57D1: $77
     ld   hl, $57A4                                ; $57D2: $21 $A4 $57
     add  hl, bc                                   ; $57D5: $09
-    ldh  a, [hScratchB]                           ; $57D6: $F0 $D8
+    ldh  a, [hScratch1]                           ; $57D6: $F0 $D8
     add  [hl]                                     ; $57D8: $86
     ld   hl, wEntity0PosY                         ; $57D9: $21 $10 $C2
     add  hl, de                                   ; $57DC: $19
@@ -4705,12 +4705,12 @@ jr_007_5B94:
     and  a                                        ; $5BA1: $A7
     jr   z, jr_007_5BBE                           ; $5BA2: $28 $1A
 
-    ldh  a, [hScratchA]                           ; $5BA4: $F0 $D7
+    ldh  a, [hScratch0]                           ; $5BA4: $F0 $D7
     call func_007_4005                            ; $5BA6: $CD $05 $40
     cpl                                           ; $5BA9: $2F
     inc  a                                        ; $5BAA: $3C
     ld   [hl], a                                  ; $5BAB: $77
-    ldh  a, [hScratchB]                           ; $5BAC: $F0 $D8
+    ldh  a, [hScratch1]                           ; $5BAC: $F0 $D8
     ld   hl, wEntity0SpeedX                       ; $5BAE: $21 $40 $C2
     add  hl, bc                                   ; $5BB1: $09
     cpl                                           ; $5BB2: $2F
@@ -5261,7 +5261,7 @@ jr_007_5E67:
     call GetRandomByte                            ; $5E74: $CD $0D $28
     and  $07                                      ; $5E77: $E6 $07
     sub  $04                                      ; $5E79: $D6 $04
-    ld   hl, hScratchB                            ; $5E7B: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $5E7B: $21 $D8 $FF
     add  [hl]                                     ; $5E7E: $86
     ld   hl, wEntity0PosY                         ; $5E7F: $21 $10 $C2
     add  hl, de                                   ; $5E82: $19
@@ -5269,7 +5269,7 @@ jr_007_5E67:
     call GetRandomByte                            ; $5E84: $CD $0D $28
     and  $1F                                      ; $5E87: $E6 $1F
     sub  $10                                      ; $5E89: $D6 $10
-    ld   hl, hScratchA                            ; $5E8B: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $5E8B: $21 $D7 $FF
     add  [hl]                                     ; $5E8E: $86
     ld   hl, wEntity0PosX                         ; $5E8F: $21 $00 $C2
     add  hl, de                                   ; $5E92: $19
@@ -5429,7 +5429,7 @@ func_007_5F61:
     call GetRandomByte                            ; $5F7A: $CD $0D $28
     and  $3F                                      ; $5F7D: $E6 $3F
     sub  $20                                      ; $5F7F: $D6 $20
-    ld   hl, hScratchA                            ; $5F81: $21 $D7 $FF
+    ld   hl, hScratch0                            ; $5F81: $21 $D7 $FF
     add  [hl]                                     ; $5F84: $86
     ld   hl, wEntity0PosX                         ; $5F85: $21 $00 $C2
     add  hl, de                                   ; $5F88: $19
@@ -5437,7 +5437,7 @@ func_007_5F61:
     call GetRandomByte                            ; $5F8A: $CD $0D $28
     and  $3F                                      ; $5F8D: $E6 $3F
     sub  $20                                      ; $5F8F: $D6 $20
-    ld   hl, hScratchB                            ; $5F91: $21 $D8 $FF
+    ld   hl, hScratch1                            ; $5F91: $21 $D8 $FF
     add  [hl]                                     ; $5F94: $86
     ld   hl, wEntity0PosY                         ; $5F95: $21 $10 $C2
     add  hl, de                                   ; $5F98: $19
@@ -6067,7 +6067,7 @@ func_007_631C:
     add  hl, bc                                   ; $631F: $09
     ld   a, [hl]                                  ; $6320: $7E
     xor  $01                                      ; $6321: $EE $01
-    ldh  [hScratchA], a                           ; $6323: $E0 $D7
+    ldh  [hScratch0], a                           ; $6323: $E0 $D7
     ld   e, b                                     ; $6325: $58
     ld   d, b                                     ; $6326: $50
 
@@ -6086,7 +6086,7 @@ jr_007_6327:
 
     ld   hl, $C460                                ; $6338: $21 $60 $C4
     add  hl, de                                   ; $633B: $19
-    ldh  a, [hScratchA]                           ; $633C: $F0 $D7
+    ldh  a, [hScratch0]                           ; $633C: $F0 $D7
     cp   [hl]                                     ; $633E: $BE
     jr   z, jr_007_6347                           ; $633F: $28 $06
 
@@ -8482,9 +8482,9 @@ jr_007_70E0:
 
     ld   a, $28                                   ; $70ED: $3E $28
     call label_3BB5                               ; $70EF: $CD $B5 $3B
-    ldh  a, [hScratchA]                           ; $70F2: $F0 $D7
+    ldh  a, [hScratch0]                           ; $70F2: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $70F4: $E0 $9B
-    ldh  a, [hScratchB]                           ; $70F6: $F0 $D8
+    ldh  a, [hScratch1]                           ; $70F6: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $70F8: $E0 $9A
     ld   a, $02                                   ; $70FA: $3E $02
     ld   [$C146], a                               ; $70FC: $EA $46 $C1
@@ -8574,11 +8574,11 @@ jr_007_7168:
     call label_3B86                               ; $716F: $CD $86 $3B
     jr   c, jr_007_7197                           ; $7172: $38 $23
 
-    ldh  a, [hScratchA]                           ; $7174: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7174: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7176: $21 $00 $C2
     add  hl, de                                   ; $7179: $19
     ld   [hl], a                                  ; $717A: $77
-    ldh  a, [hScratchB]                           ; $717B: $F0 $D8
+    ldh  a, [hScratch1]                           ; $717B: $F0 $D8
     ld   hl, wEntity0PosY                         ; $717D: $21 $10 $C2
     add  hl, de                                   ; $7180: $19
     ld   [hl], a                                  ; $7181: $77
@@ -8640,11 +8640,11 @@ jr_007_71B4:
     ld   hl, $C4E0                                ; $71D1: $21 $E0 $C4
     add  hl, de                                   ; $71D4: $19
     ld   [hl], a                                  ; $71D5: $77
-    ldh  a, [hScratchA]                           ; $71D6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $71D6: $F0 $D7
     ld   hl, wEntity0PosX                         ; $71D8: $21 $00 $C2
     add  hl, de                                   ; $71DB: $19
     ld   [hl], a                                  ; $71DC: $77
-    ldh  a, [hScratchB]                           ; $71DD: $F0 $D8
+    ldh  a, [hScratch1]                           ; $71DD: $F0 $D8
     ld   hl, wEntity0PosY                         ; $71DF: $21 $10 $C2
     add  hl, de                                   ; $71E2: $19
     add  $08                                      ; $71E3: $C6 $08
@@ -10281,9 +10281,9 @@ jr_007_7ACB:
 jr_007_7AD1:
     push bc                                       ; $7AD1: $C5
     ldh  a, [wActiveEntityPosY]                   ; $7AD2: $F0 $EC
-    ldh  [hScratchA], a                           ; $7AD4: $E0 $D7
+    ldh  [hScratch0], a                           ; $7AD4: $E0 $D7
     ldh  a, [wActiveEntityPosX]                   ; $7AD6: $F0 $EE
-    ldh  [hScratchB], a                           ; $7AD8: $E0 $D8
+    ldh  [hScratch1], a                           ; $7AD8: $E0 $D8
     ldh  a, [hActiveEntityUnknownG]               ; $7ADA: $F0 $F1
     ld   e, a                                     ; $7ADC: $5F
     ld   d, b                                     ; $7ADD: $50
@@ -10301,7 +10301,7 @@ jr_007_7AD1:
     ld   hl, $7A7D                                ; $7AF6: $21 $7D $7A
     add  hl, de                                   ; $7AF9: $19
     ld   a, [hl]                                  ; $7AFA: $7E
-    ldh  [hScratchC], a                           ; $7AFB: $E0 $D9
+    ldh  [hScratch2], a                           ; $7AFB: $E0 $D9
     ld   hl, $7A75                                ; $7AFD: $21 $75 $7A
     add  hl, de                                   ; $7B00: $19
     ld   a, [hl]                                  ; $7B01: $7E
@@ -10318,7 +10318,7 @@ jr_007_7AD1:
     ld   c, l                                     ; $7B13: $4D
     ld   b, h                                     ; $7B14: $44
     xor  a                                        ; $7B15: $AF
-    ldh  [hScratchD], a                           ; $7B16: $E0 $DA
+    ldh  [hScratch3], a                           ; $7B16: $E0 $DA
     pop  hl                                       ; $7B18: $E1
     call label_1819                               ; $7B19: $CD $19 $18
     ld   a, $02                                   ; $7B1C: $3E $02
@@ -10398,11 +10398,11 @@ ChestWithItemEntityHandler::
     call label_3B86                               ; $7BF0: $CD $86 $3B
     jp   c, label_007_7EA4                        ; $7BF3: $DA $A4 $7E
 
-    ldh  a, [hScratchA]                           ; $7BF6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7BF6: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7BF8: $21 $00 $C2
     add  hl, de                                   ; $7BFB: $19
     ld   [hl], a                                  ; $7BFC: $77
-    ldh  a, [hScratchB]                           ; $7BFD: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7BFD: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7BFF: $21 $10 $C2
     add  hl, de                                   ; $7C02: $19
     ld   [hl], a                                  ; $7C03: $77
@@ -10890,7 +10890,7 @@ jr_007_7E7B:
 func_007_7E7D:
     call func_007_7E5D                            ; $7E7D: $CD $5D $7E
     ld   a, e                                     ; $7E80: $7B
-    ldh  [hScratchA], a                           ; $7E81: $E0 $D7
+    ldh  [hScratch0], a                           ; $7E81: $E0 $D7
     ld   a, d                                     ; $7E83: $7A
     bit  7, a                                     ; $7E84: $CB $7F
     jr   z, jr_007_7E8A                           ; $7E86: $28 $02
@@ -10902,7 +10902,7 @@ jr_007_7E8A:
     push af                                       ; $7E8A: $F5
     call func_007_7E6D                            ; $7E8B: $CD $6D $7E
     ld   a, e                                     ; $7E8E: $7B
-    ldh  [hScratchB], a                           ; $7E8F: $E0 $D8
+    ldh  [hScratch1], a                           ; $7E8F: $E0 $D8
     ld   a, d                                     ; $7E91: $7A
     bit  7, a                                     ; $7E92: $CB $7F
     jr   z, jr_007_7E98                           ; $7E94: $28 $02
@@ -10915,11 +10915,11 @@ jr_007_7E98:
     cp   d                                        ; $7E99: $BA
     jr   nc, jr_007_7EA0                          ; $7E9A: $30 $04
 
-    ldh  a, [hScratchA]                           ; $7E9C: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7E9C: $F0 $D7
     jr   jr_007_7EA2                              ; $7E9E: $18 $02
 
 jr_007_7EA0:
-    ldh  a, [hScratchB]                           ; $7EA0: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7EA0: $F0 $D8
 
 jr_007_7EA2:
     ld   e, a                                     ; $7EA2: $5F
@@ -10972,11 +10972,11 @@ label_007_7EC1:
 
     ld   a, $30                                   ; $7EE1: $3E $30
     call label_3B86                               ; $7EE3: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $7EE6: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7EE6: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7EE8: $21 $00 $C2
     add  hl, de                                   ; $7EEB: $19
     ld   [hl], a                                  ; $7EEC: $77
-    ldh  a, [hScratchB]                           ; $7EED: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7EED: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7EEF: $21 $10 $C2
     add  hl, de                                   ; $7EF2: $19
     ld   [hl], a                                  ; $7EF3: $77
@@ -11023,9 +11023,9 @@ label_007_7F16:
 label_007_7F36:
     call func_007_7D9C                            ; $7F36: $CD $9C $7D
     ldh  a, [wActiveEntityPosX]                   ; $7F39: $F0 $EE
-    ldh  [hScratchA], a                           ; $7F3B: $E0 $D7
+    ldh  [hScratch0], a                           ; $7F3B: $E0 $D7
     ldh  a, [wActiveEntityPosY]                   ; $7F3D: $F0 $EC
-    ldh  [hScratchB], a                           ; $7F3F: $E0 $D8
+    ldh  [hScratch1], a                           ; $7F3F: $E0 $D8
     ld   a, $02                                   ; $7F41: $3E $02
     call label_CC7                                ; $7F43: $CD $C7 $0C
     ld   a, $13                                   ; $7F46: $3E $13
@@ -11034,11 +11034,11 @@ label_007_7F36:
 
     ld   a, $36                                   ; $7F4B: $3E $36
     call label_3B86                               ; $7F4D: $CD $86 $3B
-    ldh  a, [hScratchA]                           ; $7F50: $F0 $D7
+    ldh  a, [hScratch0]                           ; $7F50: $F0 $D7
     ld   hl, wEntity0PosX                         ; $7F52: $21 $00 $C2
     add  hl, de                                   ; $7F55: $19
     ld   [hl], a                                  ; $7F56: $77
-    ldh  a, [hScratchB]                           ; $7F57: $F0 $D8
+    ldh  a, [hScratch1]                           ; $7F57: $F0 $D8
     ld   hl, wEntity0PosY                         ; $7F59: $21 $10 $C2
     add  hl, de                                   ; $7F5C: $19
     ld   [hl], a                                  ; $7F5D: $77

--- a/src/code/file_creation.asm
+++ b/src/code/file_creation.asm
@@ -337,11 +337,11 @@ label_4BF5::
     ldh  a, [$FFCC]
 
 label_4BF7::
-    ldh  [hScratchA], a
-    ldh  a, [hScratchA]
+    ldh  [hScratch0], a
+    ldh  a, [hScratch0]
     and  $0C
     jr   nz, label_4C41
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     and  $03
     jr   nz, label_4C21
     ldh  a, [$FFCB]

--- a/src/code/file_deletion.asm
+++ b/src/code/file_deletion.asm
@@ -105,9 +105,9 @@ label_4DA6::
     xor  a
     ldh  [$FFDB], a
     ld   a, [$DC06]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ld   a, [$DC09]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     jp   label_5D53
 
 label_4DBD::
@@ -120,9 +120,9 @@ label_4DBE::
     ld   a, $01
     ldh  [$FFDB], a
     ld   a, [$DC07]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ld   a, [$DC0A]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     jp   label_5D53
 
 label_4DD6::
@@ -132,9 +132,9 @@ label_4DD6::
     ld   a, $02
     ldh  [$FFDB], a
     ld   a, [$DC08]
-    ldh  [hScratchC], a
+    ldh  [hScratch2], a
     ld   a, [$DC0B]
-    ldh  [hScratchD], a
+    ldh  [hScratch3], a
     jp   label_5D53
 
 label_4DEE::

--- a/src/code/home/animated_tiles.asm
+++ b/src/code/home/animated_tiles.asm
@@ -36,7 +36,7 @@ AnimateMarinBeachTiles::
     jp   CopyData
     jr   nz, AnimateTiles.doWorldAnimations
     and  b
-    ldh  [hScratchE], a
+    ldh  [hScratch9], a
     ldh  [hLinkFinalPositionY], a
     ld   h, b
 

--- a/src/code/home/dialog.asm
+++ b/src/code/home/dialog.asm
@@ -172,13 +172,13 @@ label_23EF::
     ld   a, [wBGOriginLow]
     add  a, [hl]
     ld   l, a
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, data_23D6
     add  hl, de
     ld   a, [wBGOriginHigh]
     add  a, [hl]
     ld   h, a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ld   l, a
     xor  a
     ld   e, a
@@ -205,9 +205,9 @@ label_242B::
     cp   $12
     jr   nz, label_241E
     ld   e, $00
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     add  a, $20
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     jr   nc, label_243C
     inc  h
 
@@ -252,9 +252,9 @@ label_2464::
     cp   $12
     jr   nz, label_2444
     ld   e, $00
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     add  a, $20
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     jr   nc, label_2475
     inc  h
 
@@ -446,7 +446,7 @@ DialogDrawNextCharacterHandler::
     ld   [$C3C3], a ; upcoming character, used in code for the arrow
     call ReloadSavedBank
     ld   a, e
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     cp   "<ask>" ; $fe
     jr   nz, .notChoice
     pop  hl
@@ -531,7 +531,7 @@ DialogDrawNextCharacterHandler::
 .handleNameChar
 
 .notName
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     ld   e, a
     ld   a, BANK(AsciiToTileMap)
     ld   [MBC3SelectBank], a
@@ -567,7 +567,7 @@ DialogDrawNextCharacterHandler::
      ; stubbed out bit of code accessing a table for (han)dakutens
     ld   a, $1C ; BANK(DakutenTable)
     ld   [MBC3SelectBank], a ; current character
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     ld   e, a
     ld   d, $00
     xor  a

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -486,8 +486,8 @@ label_7148::
     db 0, 0, 0, 0, $40, $40, $40, $40, $90, $90, $90, $90
 
 label_7154::
-    ldh  [hScratchE], a
-    ldh  [hScratchE], a
+    ldh  [hScratch9], a
+    ldh  [hScratch9], a
 
 label_7158::
     call label_71C7
@@ -986,11 +986,11 @@ RenderRain::
     call GetRandomByte
     and  $18
     add  a, $10
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
     call GetRandomByte
     and  $18
     add  a, $10
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     ld   hl, $C04C
     ; On the sea, limit the rain to the top section of the screen ($10)
     ld   c, $10
@@ -1001,9 +1001,9 @@ RenderRain::
     ld   c, $15
 
 .loop
-    ldh  a, [hScratchB]
+    ldh  a, [hScratch1]
     ldi  [hl], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     ldi  [hl], a
     call GetRandomByte
     and  $01       ; if random(0,1) == 0
@@ -1017,16 +1017,16 @@ RenderRain::
     ldi  [hl], a
     ld   a, $00
     ldi  [hl], a
-    ldh  a, [hScratchA]
+    ldh  a, [hScratch0]
     add  a, $1C
-    ldh  [hScratchA], a
+    ldh  [hScratch0], a
     cp   $A0
     jr   c, .continue
     sub  a, $98
-    ldh  [hScratchA], a
-    ldh  a, [hScratchB]
+    ldh  [hScratch0], a
+    ldh  a, [hScratch1]
     add  a, $25
-    ldh  [hScratchB], a
+    ldh  [hScratch1], a
 
 .continue
     dec  c

--- a/src/code/overworld_macros.asm
+++ b/src/code/overworld_macros.asm
@@ -40,7 +40,7 @@ jr_024_75A9:
     ld   d, $00                                   ; $75A9: $16 $00
     ld   hl, wRoomObjectsArea                     ; $75AB: $21 $00 $D7
     add  hl, de                                   ; $75AE: $19
-    ldh  a, [hScratchA]                           ; $75AF: $F0 $D7
+    ldh  a, [hScratch0]                           ; $75AF: $F0 $D7
     and  a                                        ; $75B1: $A7
     jr   z, jr_024_75CD                           ; $75B2: $28 $19
 
@@ -50,7 +50,7 @@ jr_024_75A9:
 jr_024_75B7:
     call func_024_75CD                            ; $75B7: $CD $CD $75
     dec  bc                                       ; $75BA: $0B
-    ldh  a, [hScratchA]                           ; $75BB: $F0 $D7
+    ldh  a, [hScratch0]                           ; $75BB: $F0 $D7
     and  $40                                      ; $75BD: $E6 $40
     ld   d, $F1                                   ; $75BF: $16 $F1
     jr   z, jr_024_75C5                           ; $75C1: $28 $02

--- a/src/code/palettes.asm
+++ b/src/code/palettes.asm
@@ -1388,7 +1388,7 @@ jr_021_5491:
     ld   a, e                                     ; $5491: $7B
     and  $1F                                      ; $5492: $E6 $1F
     call func_021_54F9                            ; $5494: $CD $F9 $54
-    ldh  [hBGAttributesBank], a                    ; $5497: $E0 $DF
+    ldh  [hScratch8], a                           ; $5497: $E0 $DF
     ld   a, e                                     ; $5499: $7B
     and  $E0                                      ; $549A: $E6 $E0
     swap a                                        ; $549C: $CB $37
@@ -1420,7 +1420,7 @@ jr_021_5491:
     swap a                                        ; $54CB: $CB $37
     sla  a                                        ; $54CD: $CB $27
     ld   e, a                                     ; $54CF: $5F
-    ldh  a, [hBGAttributesBank]                    ; $54D0: $F0 $DF
+    ldh  a, [hScratch8]                    ; $54D0: $F0 $DF
     or   e                                        ; $54D2: $B3
     ld   e, a                                     ; $54D3: $5F
     pop  hl                                       ; $54D4: $E1

--- a/src/code/photos.asm
+++ b/src/code/photos.asm
@@ -1433,9 +1433,9 @@ Func_037_4972::
     ld   h, [hl]                                ; $4984: $66
     ld   l, a                                   ; $4985: $6F
     ld   a, [$C212]                             ; $4986: $FA $12 $C2
-    ldh  [hScratchA], a                         ; $4989: $E0 $D7
+    ldh  [hScratch0], a                         ; $4989: $E0 $D7
     ld   a, [$C211]                             ; $498B: $FA $11 $C2
-    ldh  [hScratchB], a                         ; $498E: $E0 $D8
+    ldh  [hScratch1], a                         ; $498E: $E0 $D8
     call Func_037_4AB8                          ; $4990: $CD $B8 $4A
     ret                                         ; $4993: $C9
 
@@ -1505,9 +1505,9 @@ Func_037_49D3::
     ld   h, [hl]                                ; $49EB: $66
     ld   l, a                                   ; $49EC: $6F
     ld   a, [$C203]                             ; $49ED: $FA $03 $C2
-    ldh  [hScratchA], a                         ; $49F0: $E0 $D7
+    ldh  [hScratch0], a                         ; $49F0: $E0 $D7
     ld   a, [$C202]                             ; $49F2: $FA $02 $C2
-    ldh  [hScratchB], a                         ; $49F5: $E0 $D8
+    ldh  [hScratch1], a                         ; $49F5: $E0 $D8
     call Func_037_4AB8                          ; $49F7: $CD $B8 $4A
     ret                                         ; $49FA: $C9
 
@@ -1569,9 +1569,9 @@ Func_037_4A37::
     ld   h, [hl]                                ; $4A4F: $66
     ld   l, a                                   ; $4A50: $6F
     ld   a, [$C209]                             ; $4A51: $FA $09 $C2
-    ldh  [hScratchA], a                         ; $4A54: $E0 $D7
+    ldh  [hScratch0], a                         ; $4A54: $E0 $D7
     ld   a, [$C208]                             ; $4A56: $FA $08 $C2
-    ldh  [hScratchB], a                         ; $4A59: $E0 $D8
+    ldh  [hScratch1], a                         ; $4A59: $E0 $D8
     call Func_037_4AB8                          ; $4A5B: $CD $B8 $4A
     ret                                         ; $4A5E: $C9
 
@@ -1588,9 +1588,9 @@ Func_037_4A64::
     ld   h, [hl]                                ; $4A6E: $66
     ld   l, a                                   ; $4A6F: $6F
     ld   a, [$C21D]                             ; $4A70: $FA $1D $C2
-    ldh  [hScratchA], a                         ; $4A73: $E0 $D7
+    ldh  [hScratch0], a                         ; $4A73: $E0 $D7
     ld   a, [$C21C]                             ; $4A75: $FA $1C $C2
-    ldh  [hScratchB], a                         ; $4A78: $E0 $D8
+    ldh  [hScratch1], a                         ; $4A78: $E0 $D8
     call Func_037_4AB8                          ; $4A7A: $CD $B8 $4A
     ret                                         ; $4A7D: $C9
 
@@ -1619,8 +1619,8 @@ Func_037_4A8E::
     ld   hl, $4A86                              ; $4AAA: $21 $86 $4A
 .else_4AAD_37:
     xor  a                                      ; $4AAD: $AF
-    ldh  [hScratchA], a                         ; $4AAE: $E0 $D7
-    ldh  [hScratchB], a                         ; $4AB0: $E0 $D8
+    ldh  [hScratch0], a                         ; $4AAE: $E0 $D7
+    ldh  [hScratch1], a                         ; $4AB0: $E0 $D8
     ld   c, $08                                 ; $4AB2: $0E $08
     call Func_037_4AB8                          ; $4AB4: $CD $B8 $4A
     ret                                         ; $4AB7: $C9
@@ -1641,12 +1641,12 @@ Func_037_4AB8::
     srl  c                                      ; $4ACA: $CB $39
     srl  c                                      ; $4ACC: $CB $39
 .loop_4ACE_37:
-    ldh  a, [hScratchA]                         ; $4ACE: $F0 $D7
+    ldh  a, [hScratch0]                         ; $4ACE: $F0 $D7
     add  [hl]                                   ; $4AD0: $86
     ld   [de], a                                ; $4AD1: $12
     inc  de                                     ; $4AD2: $13
     inc  hl                                     ; $4AD3: $23
-    ldh  a, [hScratchB]                         ; $4AD4: $F0 $D8
+    ldh  a, [hScratch1]                         ; $4AD4: $F0 $D8
     add  [hl]                                   ; $4AD6: $86
     ld   [de], a                                ; $4AD7: $12
     inc  de                                     ; $4AD8: $13
@@ -1727,9 +1727,9 @@ Func_037_4B31::
     ld   h, [hl]                                ; $4B45: $66
     ld   l, a                                   ; $4B46: $6F
     ld   a, [$C203]                             ; $4B47: $FA $03 $C2
-    ldh  [hScratchA], a                         ; $4B4A: $E0 $D7
+    ldh  [hScratch0], a                         ; $4B4A: $E0 $D7
     ld   a, [$C202]                             ; $4B4C: $FA $02 $C2
-    ldh  [hScratchB], a                         ; $4B4F: $E0 $D8
+    ldh  [hScratch1], a                         ; $4B4F: $E0 $D8
     call Func_037_4AB8                          ; $4B51: $CD $B8 $4A
     ret                                         ; $4B54: $C9
 
@@ -2346,9 +2346,9 @@ Func_037_4F1B::
     ld   [$C225], a                             ; $4F21: $EA $25 $C2
     ld   hl, $4F13                              ; $4F24: $21 $13 $4F
     ld   a, [$C279]                             ; $4F27: $FA $79 $C2
-    ldh  [hScratchA], a                         ; $4F2A: $E0 $D7
+    ldh  [hScratch0], a                         ; $4F2A: $E0 $D7
     ld   a, [$C278]                             ; $4F2C: $FA $78 $C2
-    ldh  [hScratchB], a                         ; $4F2F: $E0 $D8
+    ldh  [hScratch1], a                         ; $4F2F: $E0 $D8
     ld   c, $08                                 ; $4F31: $0E $08
     call Func_037_4AB8                          ; $4F33: $CD $B8 $4A
     ret                                         ; $4F36: $C9
@@ -2369,9 +2369,9 @@ Func_037_4F37::
     ld   h, [hl]                                ; $4F4B: $66
     ld   l, a                                   ; $4F4C: $6F
     ld   a, [$C222]                             ; $4F4D: $FA $22 $C2
-    ldh  [hScratchA], a                         ; $4F50: $E0 $D7
+    ldh  [hScratch0], a                         ; $4F50: $E0 $D7
     ld   a, [$C223]                             ; $4F52: $FA $23 $C2
-    ldh  [hScratchB], a                         ; $4F55: $E0 $D8
+    ldh  [hScratch1], a                         ; $4F55: $E0 $D8
     call Func_037_4AB8                          ; $4F57: $CD $B8 $4A
     ret                                         ; $4F5A: $C9
 
@@ -2470,9 +2470,9 @@ JumpTable_037_4FD0::
     ld   h, [hl]                                ; $4FE2: $66
     ld   l, a                                   ; $4FE3: $6F
     ld   a, [$C216]                             ; $4FE4: $FA $16 $C2
-    ldh  [hScratchA], a                         ; $4FE7: $E0 $D7
+    ldh  [hScratch0], a                         ; $4FE7: $E0 $D7
     ld   a, [$C217]                             ; $4FE9: $FA $17 $C2
-    ldh  [hScratchB], a                         ; $4FEC: $E0 $D8
+    ldh  [hScratch1], a                         ; $4FEC: $E0 $D8
     call Func_037_4AB8                          ; $4FEE: $CD $B8 $4A
     ld   hl, $5941                              ; $4FF1: $21 $41 $59
     ld   a, [$C201]                             ; $4FF4: $FA $01 $C2
@@ -3024,9 +3024,9 @@ Func_037_533F::
     ld   h, [hl]                                ; $534E: $66
     ld   l, a                                   ; $534F: $6F
     ld   a, [$C24F]                             ; $5350: $FA $4F $C2
-    ldh  [hScratchA], a                         ; $5353: $E0 $D7
+    ldh  [hScratch0], a                         ; $5353: $E0 $D7
     ld   a, [$C250]                             ; $5355: $FA $50 $C2
-    ldh  [hScratchB], a                         ; $5358: $E0 $D8
+    ldh  [hScratch1], a                         ; $5358: $E0 $D8
     call Func_037_4AB8                          ; $535A: $CD $B8 $4A
     ret                                         ; $535D: $C9
 

--- a/src/constants/hram.asm
+++ b/src/constants/hram.asm
@@ -176,44 +176,40 @@ hFFD2:: ; FFD2
   ds 5
 
 ; Scratch values, used for many different uses
-hScratchA:: ; FFD7
-  ds 1
-hScratchB:: ; FFD8
-  ds 1
-hScratchC:: ; FFD9
-  ds 1
-hScratchD:: ; FFDA
-  ds 1
 
-; Unlabeled
-ds 4
-
-hBGAttributesBank ; FFDF
+hScratch0:: ; FFD7
   ds 1
-
-; Scratch hram address with different uses
-hScratchE          ; FFE0
+hScratch1:: ; FFD8
+  ds 1
+hScratch2:: ; FFD9
+  ds 1
+hScratch3:: ; FFDA
+  ds 1
+hScratch4:: ; FFDB
+  ds 1
+hScratch5:: ; FFDC
+  ds 1
+hScratch6:: ; FFDD
+  ds 1
+hScratch7:: ; FFDE
+  ds 1
+hScratch8 ; FFDF
+  ds 1
+hScratch9          ; FFE0
 hBGMapOffsetHigh:: ; FFE0
   ds 1
-
-; This location has different uses
-hScratchF          ; FFE1
+hScratchA          ; FFE1
 hBGMapOffsetLow::  ; FFE1
   ds 1
-
-hScratchG:: ; FFE2
+hScratchB:: ; FFE2
   ds 1
-
-hScratchH:: ; FFE3
+hScratchC:: ; FFE3
   ds 1
-
-hScratchI:: ; FFE4
+hScratchD:: ; FFE4
   ds 1
-
-hScratchJ:: ; FFE5
+hScratchE:: ; FFE5
   ds 1
-
-hScratchK:: ; FFE6
+hScratchF:: ; FFE6
 hFreeWarpDataAddress ; FFE6
   ; Address of the first free warp data slot
   ds 1


### PR DESCRIPTION
They now go from hScratch0 to hScratchF.