### PR TITLE
Merge pull request #164 from kemenaran/remove-ld-long-macro

### DIFF
--- a/src/code/audio/sfx.asm
+++ b/src/code/audio/sfx.asm
@@ -9256,7 +9256,7 @@ jr_01F_7499:
     ldh  a, [$FF74]                               ; $74AB: $F0 $74
     push af                                       ; $74AD: $F5
     ld   [hl], h                                  ; $74AE: $74
-    ld_long a, $FF74                              ; $74AF: $FA $74 $FF
+    db   $FA, $74, $FF
     ld   [hl], h                                  ; $74B2: $74
     inc  b                                        ; $74B3: $04
     ld   [hl], l                                  ; $74B4: $75

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -9477,7 +9477,7 @@ Func_020_7679:
     rst  $38                                      ; $77F5: $FF
     db   $f4                                      ; $77F6: $F4
     add  sp, -$17                                 ; $77F7: $E8 $E9
-    ld_long hActiveEntityType, a                              ; $77F9: $EA $EB $FF
+    db   $EA, $EB, $FF
     rst  $38                                      ; $77FC: $FF
     rst  $38                                      ; $77FD: $FF
     rst  $38                                      ; $77FE: $FF

--- a/src/code/macros.asm
+++ b/src/code/macros.asm
@@ -84,21 +84,3 @@ jp_open_dialog: macro
         jp   OpenDialog
     endc
 endm
-
-; mgbdis macro
-; RGBDS optimises instructions like `ld [$FF40],a` to `LDH [$FF00+40],a`,
-; so these are encoded as data bytes using a macro to ensure exact
-; reproduction of the original ROM.
-ld_long: MACRO
-    IF STRLWR("\1") == "a"
-        ; ld a, [$ff40]
-        db $FA
-        dw \2
-    ELSE
-        IF STRLWR("\2") == "a"
-            ; ld [$ff40], a
-            db $EA
-            dw \1
-        ENDC
-    ENDC
-ENDM


### PR DESCRIPTION
This macro is used by mgbdis – but most of the time it's actually
data being interpreted as code.

Replace the macro uses by actual bytes.