### PR TITLE
wram: rename "Entities substate" to "Entities private state"

### DIFF
--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -6447,7 +6447,7 @@ jr_002_6FD7:
     ld   a, ENTITY_MIMIC                          ; $6FD7: $3E $28
     call SpawnNewEntity_trampoline                ; $6FD9: $CD $86 $3B
 
-    ld   hl, wEntitiesSubstate2Table              ; $6FDC: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6FDC: $21 $C0 $C2
     add  hl, de                                   ; $6FDF: $19
     inc  [hl]                                     ; $6FE0: $34
     jr   jr_002_702C                              ; $6FE1: $18 $49

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -1143,7 +1143,7 @@ CreditsStairsPrepare2Handler::
     ld   a, ENTITY_ENDING_OWL_STAIR_CLIMBING      ; $4CF4: $3E $E8
     call SpawnNewEntity_trampoline                ; $4CF6: $CD $86 $3B
 
-    ld   hl, wEntitiesSubstate1Table              ; $4CF9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4CF9: $21 $B0 $C2
     add  hl, de                                   ; $4CFC: $19
     inc  [hl]                                     ; $4CFD: $34
     ld   a, $50                                   ; $4CFE: $3E $50

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -25,10 +25,10 @@ ResetEntity::
     ld   hl, wEntitiesCollisionsTable             ; $401C: $21 $A0 $C2
     add  hl, bc                                   ; $401F: $09
     ld   [hl], b                                  ; $4020: $70
-    ld   hl, wEntitiesSubstate1Table              ; $4021: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4021: $21 $B0 $C2
     add  hl, bc                                   ; $4024: $09
     ld   [hl], b                                  ; $4025: $70
-    ld   hl, wEntitiesSubstate2Table              ; $4026: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4026: $21 $C0 $C2
     add  hl, bc                                   ; $4029: $09
     ld   [hl], b                                  ; $402A: $70
     ld   hl, wEntitiesUnknownTableD               ; $402B: $21 $D0 $C2
@@ -659,7 +659,7 @@ jr_015_463A:
     ret  nz                                       ; $4655: $C0
 
     call IncrementEntityState                     ; $4656: $CD $12 $3B
-    ld   hl, wEntitiesSubstate1Table              ; $4659: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4659: $21 $B0 $C2
     add  hl, bc                                   ; $465C: $09
     ld   [hl], $30                                ; $465D: $36 $30
 
@@ -669,7 +669,7 @@ jr_015_465F:
     ld   a, $02                                   ; $4660: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $4662: $E0 $A1
     ld   [wC167], a                               ; $4664: $EA $67 $C1
-    ld   hl, wEntitiesSubstate1Table              ; $4667: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4667: $21 $B0 $C2
     add  hl, bc                                   ; $466A: $09
     ld   a, [hl]                                  ; $466B: $7E
     ldh  [hLinkPositionY], a                      ; $466C: $E0 $99
@@ -692,7 +692,7 @@ jr_015_4682:
     and  $03                                      ; $4684: $E6 $03
     jr   nz, jr_015_469C                          ; $4686: $20 $14
 
-    ld   hl, wEntitiesSubstate1Table              ; $4688: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4688: $21 $B0 $C2
     add  hl, bc                                   ; $468B: $09
     dec  [hl]                                     ; $468C: $35
     ld   a, [hl]                                  ; $468D: $7E
@@ -1714,7 +1714,7 @@ PokeyEntityHandler::
     ld   hl, wEntitiesPosYTable                         ; $4C1E: $21 $10 $C2
     add  hl, de                                   ; $4C21: $19
     ld   [hl], a                                  ; $4C22: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4C23: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4C23: $21 $B0 $C2
     add  hl, de                                   ; $4C26: $19
     inc  [hl]                                     ; $4C27: $34
     push bc                                       ; $4C28: $C5
@@ -1909,7 +1909,7 @@ jr_015_4D39:
     inc  hl                                       ; $4D42: $23
 
 FlameShooterEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $4D43: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4D43: $21 $B0 $C2
     add  hl, bc                                   ; $4D46: $09
     ld   a, [hl]                                  ; $4D47: $7E
     and  a                                        ; $4D48: $A7
@@ -1953,7 +1953,7 @@ jr_015_4D5B:
     add  hl, de                                   ; $4D87: $19
     add  $04                                      ; $4D88: $C6 $04
     ld   [hl], a                                  ; $4D8A: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4D8B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4D8B: $21 $B0 $C2
     add  hl, de                                   ; $4D8E: $19
     inc  [hl]                                     ; $4D8F: $34
     ld   hl, wEntitiesSpeedYTable                       ; $4D90: $21 $50 $C2
@@ -2038,7 +2038,7 @@ jr_015_4DFB:
     call SpawnNewEntity_trampoline                ; $4DFF: $CD $86 $3B
     jr   c, jr_015_4E46                           ; $4E02: $38 $42
 
-    ld   hl, wEntitiesSubstate1Table              ; $4E04: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4E04: $21 $B0 $C2
     add  hl, de                                   ; $4E07: $19
     ld   [hl], $02                                ; $4E08: $36 $02
     push bc                                       ; $4E0A: $C5
@@ -2233,7 +2233,7 @@ jr_015_4F02:
     ld   hl, wEntitiesPosZTable                   ; $4F3D: $21 $10 $C3
     add  hl, de                                   ; $4F40: $19
     ld   [hl], a                                  ; $4F41: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4F42: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4F42: $21 $B0 $C2
     add  hl, de                                   ; $4F45: $19
     inc  [hl]                                     ; $4F46: $34
     push bc                                       ; $4F47: $C5
@@ -2837,7 +2837,7 @@ func_015_52BB:
     call SetEntitySpriteVariant                   ; $52E8: $CD $0C $3B
     call GetEntityTransitionCountdown             ; $52EB: $CD $05 $0C
     ld   [hl], $40                                ; $52EE: $36 $40
-    ld   hl, wEntitiesSubstate1Table              ; $52F0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $52F0: $21 $B0 $C2
     add  hl, bc                                   ; $52F3: $09
     ld   [hl], b                                  ; $52F4: $70
     call IncrementEntityState                     ; $52F5: $CD $12 $3B
@@ -3823,7 +3823,7 @@ label_015_582B:
     ld   hl, wEntitiesDirectionTable              ; $582B: $21 $80 $C3
     add  hl, bc                                   ; $582E: $09
     ld   a, [hl]                                  ; $582F: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $5830: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5830: $21 $B0 $C2
     add  hl, bc                                   ; $5833: $09
     add  [hl]                                     ; $5834: $86
     jp   SetEntitySpriteVariant                   ; $5835: $C3 $0C $3B
@@ -3916,7 +3916,7 @@ jr_015_58C0:
     rra                                           ; $58C1: $1F
     rra                                           ; $58C2: $1F
     and  $03                                      ; $58C3: $E6 $03
-    ld   hl, wEntitiesSubstate1Table              ; $58C5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $58C5: $21 $B0 $C2
     add  hl, bc                                   ; $58C8: $09
     ld   [hl], a                                  ; $58C9: $77
     call GetEntityTransitionCountdown             ; $58CA: $CD $05 $0C
@@ -3956,7 +3956,7 @@ jr_015_58C0:
     jp   IncrementEntityState                     ; $5905: $C3 $12 $3B
 
 jr_015_5908:
-    ld   hl, wEntitiesSubstate1Table              ; $5908: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5908: $21 $B0 $C2
     add  hl, bc                                   ; $590B: $09
     ld   [hl], $04                                ; $590C: $36 $04
     jp   label_015_582B                           ; $590E: $C3 $2B $58
@@ -4113,7 +4113,7 @@ jr_015_59EC:
     ld   hl, wEntitiesDirectionTable              ; $59F8: $21 $80 $C3
     add  hl, bc                                   ; $59FB: $09
     ld   [hl], a                                  ; $59FC: $77
-    ld   hl, wEntitiesSubstate1Table              ; $59FD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $59FD: $21 $B0 $C2
     add  hl, bc                                   ; $5A00: $09
     ld   [hl], b                                  ; $5A01: $70
     jp   label_015_582B                           ; $5A02: $C3 $2B $58
@@ -5157,7 +5157,7 @@ jr_015_5F4C:
     ld   hl, wEntitiesPosYTable                         ; $5F5E: $21 $10 $C2
     add  hl, de                                   ; $5F61: $19
     ld   [hl], a                                  ; $5F62: $77
-    ld   hl, wEntitiesSubstate1Table              ; $5F63: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F63: $21 $B0 $C2
     add  hl, de                                   ; $5F66: $19
     inc  [hl]                                     ; $5F67: $34
     push bc                                       ; $5F68: $C5
@@ -5485,7 +5485,7 @@ jr_015_6109:
     ldh  a, [wActiveEntityPosY]                   ; $611F: $F0 $EC
     ld   [hl], a                                  ; $6121: $77
     call func_015_6331                            ; $6122: $CD $31 $63
-    ld   hl, wEntitiesSubstate1Table              ; $6125: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6125: $21 $B0 $C2
     add  hl, bc                                   ; $6128: $09
     ld   e, [hl]                                  ; $6129: $5E
     srl  e                                        ; $612A: $CB $3B
@@ -5864,14 +5864,14 @@ jr_015_6342:
     ld   e, $0C                                   ; $635F: $1E $0C
 
 jr_015_6361:
-    ld   hl, wEntitiesSubstate1Table              ; $6361: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6361: $21 $B0 $C2
     add  hl, bc                                   ; $6364: $09
     ld   [hl], e                                  ; $6365: $73
     call GetRandomByte                            ; $6366: $CD $0D $28
     rra                                           ; $6369: $1F
     jr   c, jr_015_6374                           ; $636A: $38 $08
 
-    ld   hl, wEntitiesSubstate2Table              ; $636C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $636C: $21 $C0 $C2
     add  hl, bc                                   ; $636F: $09
     ld   a, [hl]                                  ; $6370: $7E
     cpl                                           ; $6371: $2F
@@ -5887,15 +5887,15 @@ jr_015_6379:
     jr   nz, jr_015_63AF                          ; $637C: $20 $31
 
     ld   [hl], $06                                ; $637E: $36 $06
-    ld   hl, wEntitiesSubstate2Table              ; $6380: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6380: $21 $C0 $C2
     add  hl, bc                                   ; $6383: $09
     ld   a, [hl]                                  ; $6384: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $6385: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6385: $21 $B0 $C2
     add  hl, bc                                   ; $6388: $09
     add  [hl]                                     ; $6389: $86
     and  $0F                                      ; $638A: $E6 $0F
     ld   [hl], a                                  ; $638C: $77
-    ld   hl, wEntitiesSubstate1Table              ; $638D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $638D: $21 $B0 $C2
     add  hl, bc                                   ; $6390: $09
     ld   e, [hl]                                  ; $6391: $5E
     ld   d, b                                     ; $6392: $50
@@ -5927,7 +5927,7 @@ jr_015_63AF:
     call GetRandomByte                            ; $63BC: $CD $0D $28
     and  $02                                      ; $63BF: $E6 $02
     dec  a                                        ; $63C1: $3D
-    ld   hl, wEntitiesSubstate2Table              ; $63C2: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $63C2: $21 $C0 $C2
     add  hl, bc                                   ; $63C5: $09
     ld   [hl], a                                  ; $63C6: $77
 
@@ -5935,7 +5935,7 @@ jr_015_63C7:
     ret                                           ; $63C7: $C9
 
 FinalNightmareForm5Handler::
-    ld   hl, wEntitiesSubstate1Table              ; $63C8: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $63C8: $21 $B0 $C2
     add  hl, bc                                   ; $63CB: $09
     ld   a, [hl]                                  ; $63CC: $7E
     cp   $03                                      ; $63CD: $FE $03
@@ -6443,7 +6443,7 @@ jr_015_6651:
     ld   hl, wEntitiesTransitionCountdownTable    ; $6675: $21 $E0 $C2
     add  hl, de                                   ; $6678: $19
     ld   [hl], $30                                ; $6679: $36 $30
-    ld   hl, wEntitiesSubstate1Table              ; $667B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $667B: $21 $B0 $C2
     add  hl, de                                   ; $667E: $19
     ld   [hl], $02                                ; $667F: $36 $02
     push bc                                       ; $6681: $C5
@@ -6532,7 +6532,7 @@ jr_015_66D6:
     call SpawnNewEntity_trampoline                ; $6702: $CD $86 $3B
     jr   c, jr_015_674E                           ; $6705: $38 $47
 
-    ld   hl, wEntitiesSubstate1Table              ; $6707: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6707: $21 $B0 $C2
     add  hl, de                                   ; $670A: $19
     inc  [hl]                                     ; $670B: $34
     ldh  a, [hScratch1]                           ; $670C: $F0 $D8
@@ -6584,7 +6584,7 @@ jr_015_674E:
     ld   [hl], $1F                                ; $6758: $36 $1F
     call GetRandomByte                            ; $675A: $CD $0D $28
     and  $07                                      ; $675D: $E6 $07
-    ld   hl, wEntitiesSubstate2Table              ; $675F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $675F: $21 $C0 $C2
     add  hl, bc                                   ; $6762: $09
     ld   [hl], a                                  ; $6763: $77
     call func_015_5128                            ; $6764: $CD $28 $51
@@ -6629,7 +6629,7 @@ jr_015_676A:
     push af                                       ; $6796: $F5
     ldh  a, [hLinkPositionY]                      ; $6797: $F0 $99
     push af                                       ; $6799: $F5
-    ld   hl, wEntitiesSubstate2Table              ; $679A: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $679A: $21 $C0 $C2
     add  hl, bc                                   ; $679D: $09
     ld   e, [hl]                                  ; $679E: $5E
 
@@ -6782,7 +6782,7 @@ jr_015_685F:
     ld   hl, wEntitiesPosYTable                         ; $6878: $21 $10 $C2
     add  hl, de                                   ; $687B: $19
     ld   [hl], a                                  ; $687C: $77
-    ld   hl, wEntitiesSubstate1Table              ; $687D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $687D: $21 $B0 $C2
     add  hl, de                                   ; $6880: $19
     ld   [hl], $03                                ; $6881: $36 $03
     ld   hl, wEntitiesTransitionCountdownTable    ; $6883: $21 $E0 $C2
@@ -8061,13 +8061,13 @@ jr_015_6EC4:
     ld   hl, $6DDB                                ; $6EC6: $21 $DB $6D
     add  hl, de                                   ; $6EC9: $19
     ld   a, [hl]                                  ; $6ECA: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $6ECB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6ECB: $21 $B0 $C2
     add  hl, bc                                   ; $6ECE: $09
     ld   [hl], a                                  ; $6ECF: $77
     ld   hl, $6DF3                                ; $6ED0: $21 $F3 $6D
     add  hl, de                                   ; $6ED3: $19
     ld   a, [hl]                                  ; $6ED4: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $6ED5: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6ED5: $21 $C0 $C2
     add  hl, bc                                   ; $6ED8: $09
     ld   [hl], a                                  ; $6ED9: $77
     ld   hl, $6E0B                                ; $6EDA: $21 $0B $6E
@@ -8176,7 +8176,7 @@ jr_015_6F6C:
 jr_015_6F70:
     call func_015_7B88                            ; $6F70: $CD $88 $7B
     call label_3B23                               ; $6F73: $CD $23 $3B
-    ld   hl, wEntitiesSubstate1Table              ; $6F76: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F76: $21 $B0 $C2
     add  hl, bc                                   ; $6F79: $09
     ld   e, [hl]                                  ; $6F7A: $5E
     ld   hl, wEntitiesUnknowTableY                ; $6F7B: $21 $D0 $C3
@@ -8191,7 +8191,7 @@ jr_015_6F70:
     ld   [$D221], a                               ; $6F88: $EA $21 $D2
 
 jr_015_6F8B:
-    ld   hl, wEntitiesSubstate2Table              ; $6F8B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6F8B: $21 $C0 $C2
     add  hl, bc                                   ; $6F8E: $09
     ld   e, [hl]                                  ; $6F8F: $5E
     ld   hl, wEntitiesUnknownTableD               ; $6F90: $21 $D0 $C2
@@ -9415,7 +9415,7 @@ jr_015_7639:
     ld   [bc], a                                  ; $767A: $02
 
 MonkeyEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $767B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $767B: $21 $B0 $C2
     add  hl, bc                                   ; $767E: $09
     ld   a, [hl]                                  ; $767F: $7E
     and  a                                        ; $7680: $A7
@@ -9554,7 +9554,7 @@ jr_015_773A:
     ld   hl, wEntitiesPosZTable                   ; $7750: $21 $10 $C3
     add  hl, de                                   ; $7753: $19
     ld   [hl], $18                                ; $7754: $36 $18
-    ld   hl, wEntitiesSubstate1Table              ; $7756: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7756: $21 $B0 $C2
     add  hl, de                                   ; $7759: $19
     inc  [hl]                                     ; $775A: $34
     ld   hl, wEntitiesSpeedZTable                 ; $775B: $21 $20 $C3
@@ -10454,7 +10454,7 @@ ClearEntityStatusAndReturn::
     ret                                           ; $7C36: $C9
 
 label_015_7C37:
-    ld   hl, wEntitiesSubstate2Table              ; $7C37: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7C37: $21 $C0 $C2
     add  hl, bc                                   ; $7C3A: $09
     ld   a, [hl]                                  ; $7C3B: $7E
     rst  $00                                      ; $7C3C: $C7
@@ -10471,7 +10471,7 @@ label_015_7C37:
     ld   [hl], $FF                                ; $7C4C: $36 $FF
 
 label_015_7C4E:
-    ld   hl, wEntitiesSubstate2Table              ; $7C4E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7C4E: $21 $C0 $C2
     add  hl, bc                                   ; $7C51: $09
     inc  [hl]                                     ; $7C52: $34
     ret                                           ; $7C53: $C9
@@ -10710,7 +10710,7 @@ jr_015_7DAF:
     and  $0F                                      ; $7DB0: $E6 $0F
     jr   nz, jr_015_7DEC                          ; $7DB2: $20 $38
 
-    ld   hl, wEntitiesSubstate2Table              ; $7DB4: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7DB4: $21 $C0 $C2
     add  hl, bc                                   ; $7DB7: $09
     ld   a, [hl]                                  ; $7DB8: $7E
     cp   $04                                      ; $7DB9: $FE $04
@@ -10724,7 +10724,7 @@ jr_015_7DAF:
     ld   hl, wRequestDestinationHigh              ; $7DC7: $21 $01 $D6
     add  hl, de                                   ; $7DCA: $19
     push hl                                       ; $7DCB: $E5
-    ld   hl, wEntitiesSubstate2Table              ; $7DCC: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7DCC: $21 $C0 $C2
     add  hl, bc                                   ; $7DCF: $09
     ld   a, [hl]                                  ; $7DD0: $7E
     inc  [hl]                                     ; $7DD1: $34
@@ -10953,7 +10953,7 @@ jr_015_7EF3:
     ld   hl, $7EB0                                ; $7EF4: $21 $B0 $7E
     add  hl, de                                   ; $7EF7: $19
     ld   a, [hl]                                  ; $7EF8: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $7EF9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7EF9: $21 $B0 $C2
     add  hl, bc                                   ; $7EFC: $09
     ld   [hl], a                                  ; $7EFD: $77
     call OpenDialogInTable2                       ; $7EFE: $CD $7C $23
@@ -10971,7 +10971,7 @@ jr_015_7EF3:
     and  a                                        ; $7F15: $A7
     jr   nz, jr_015_7F82                          ; $7F16: $20 $6A
 
-    ld   hl, wEntitiesSubstate1Table              ; $7F18: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7F18: $21 $B0 $C2
     add  hl, bc                                   ; $7F1B: $09
     ld   a, [hl]                                  ; $7F1C: $7E
     inc  a                                        ; $7F1D: $3C

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -1059,7 +1059,7 @@ jr_018_46DF:
     ld   hl, $45B7                                ; $46EF: $21 $B7 $45
     add  hl, de                                   ; $46F2: $19
     ld   a, [hl]                                  ; $46F3: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $46F4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $46F4: $21 $B0 $C2
     add  hl, bc                                   ; $46F7: $09
     ld   [hl], a                                  ; $46F8: $77
     ld   hl, $4653                                ; $46F9: $21 $53 $46
@@ -1768,7 +1768,7 @@ jr_018_4ADC:
     ld   hl, wEntitiesPosYTable                         ; $4AF0: $21 $10 $C2
     add  hl, de                                   ; $4AF3: $19
     ld   [hl], a                                  ; $4AF4: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4AF5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4AF5: $21 $B0 $C2
     add  hl, de                                   ; $4AF8: $19
     inc  [hl]                                     ; $4AF9: $34
     push bc                                       ; $4AFA: $C5
@@ -2527,7 +2527,7 @@ jr_018_4F4E:
     ret  nz                                       ; $4F9D: $C0
 
 jr_018_4F9E:
-    ld   hl, wEntitiesSubstate1Table              ; $4F9E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4F9E: $21 $B0 $C2
     add  hl, bc                                   ; $4FA1: $09
     ld   e, [hl]                                  ; $4FA2: $5E
     ld   d, $00                                   ; $4FA3: $16 $00
@@ -3403,7 +3403,7 @@ func_018_548A:
 jr_018_5492:
     ld   de, $547A                                ; $5492: $11 $7A $54
     call RenderAnimatedActiveEntity                               ; $5495: $CD $C0 $3B
-    ld   hl, wEntitiesSubstate2Table              ; $5498: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5498: $21 $C0 $C2
     add  hl, bc                                   ; $549B: $09
     ld   a, [hl]                                  ; $549C: $7E
     add  $FC                                      ; $549D: $C6 $FC
@@ -3475,7 +3475,7 @@ jr_018_54EE:
     jp   label_018_7E5F                           ; $54FE: $C3 $5F $7E
 
 WalrusEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $5501: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5501: $21 $B0 $C2
     add  hl, bc                                   ; $5504: $09
     ld   a, [hl]                                  ; $5505: $7E
     and  a                                        ; $5506: $A7
@@ -3549,7 +3549,7 @@ jr_018_552F:
     ld   hl, wEntitiesPhysicsFlagsTable           ; $5570: $21 $40 $C3
     add  hl, de                                   ; $5573: $19
     ld   [hl], $C1                                ; $5574: $36 $C1
-    ld   hl, wEntitiesSubstate1Table              ; $5576: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5576: $21 $B0 $C2
     add  hl, de                                   ; $5579: $19
     inc  [hl]                                     ; $557A: $34
 
@@ -4746,7 +4746,7 @@ label_018_5C6A:
     add  hl, de                                   ; $5CB9: $19
     ldh  a, [hLinkDirection]                      ; $5CBA: $F0 $9E
     ld   [hl], a                                  ; $5CBC: $77
-    ld   hl, wEntitiesSubstate1Table              ; $5CBD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5CBD: $21 $B0 $C2
     add  hl, bc                                   ; $5CC0: $09
     ld   a, [hl]                                  ; $5CC1: $7E
     ldh  [hDungeonFloorTile], a                   ; $5CC2: $E0 $E9
@@ -4780,7 +4780,7 @@ jr_018_5CEA:
     inc  [hl]                                     ; $5CEE: $34
 
 jr_018_5CEF:
-    ld   hl, wEntitiesSubstate1Table              ; $5CEF: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5CEF: $21 $B0 $C2
     add  hl, bc                                   ; $5CF2: $09
     inc  [hl]                                     ; $5CF3: $34
     ldh  a, [hFFE8]                               ; $5CF4: $F0 $E8
@@ -5114,7 +5114,7 @@ MarinAtTalTalHeightsEntityHandler::
     and  $10                                      ; $5EE8: $E6 $10
     jp   nz, label_018_7F08                       ; $5EEA: $C2 $08 $7F
 
-    ld   hl, wEntitiesSubstate2Table              ; $5EED: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5EED: $21 $C0 $C2
     add  hl, bc                                   ; $5EF0: $09
     ld   a, [hl]                                  ; $5EF1: $7E
     and  a                                        ; $5EF2: $A7
@@ -5288,7 +5288,7 @@ jr_018_5FBF:
     ldh  [hLinkInteractiveMotionBlocked], a       ; $6004: $E0 $A1
     call func_018_7DE8                            ; $6006: $CD $E8 $7D
     call_open_dialog $239                         ; $6009
-    ld   hl, wEntitiesSubstate1Table              ; $600E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $600E: $21 $B0 $C2
     add  hl, bc                                   ; $6011: $09
     ld   [hl], b                                  ; $6012: $70
     jp   IncrementEntityState                     ; $6013: $C3 $12 $3B
@@ -5297,7 +5297,7 @@ jr_018_5FBF:
     ld   a, $02                                   ; $6019: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $601B: $E0 $A1
     call func_018_7DE8                            ; $601D: $CD $E8 $7D
-    ld   hl, wEntitiesSubstate1Table              ; $6020: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6020: $21 $B0 $C2
     add  hl, bc                                   ; $6023: $09
     inc  [hl]                                     ; $6024: $34
     ld   a, [hl]                                  ; $6025: $7E
@@ -5318,7 +5318,7 @@ jr_018_5FBF:
     ld   hl, wEntitiesPosYTable                         ; $6041: $21 $10 $C2
     add  hl, de                                   ; $6044: $19
     ld   [hl], $88                                ; $6045: $36 $88
-    ld   hl, wEntitiesSubstate2Table              ; $6047: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6047: $21 $C0 $C2
     add  hl, de                                   ; $604A: $19
     inc  [hl]                                     ; $604B: $34
     jp   IncrementEntityState                     ; $604C: $C3 $12 $3B
@@ -5853,7 +5853,7 @@ jr_018_632D:
     adc  b                                        ; $638C: $88
 
 ZombieEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $638D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $638D: $21 $B0 $C2
     add  hl, bc                                   ; $6390: $09
     ld   a, [hl]                                  ; $6391: $7E
     and  a                                        ; $6392: $A7
@@ -5913,7 +5913,7 @@ jr_018_63D1:
     ld   hl, wEntitiesPosYTable                         ; $63E6: $21 $10 $C2
     add  hl, de                                   ; $63E9: $19
     ld   [hl], a                                  ; $63EA: $77
-    ld   hl, wEntitiesSubstate1Table              ; $63EB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $63EB: $21 $B0 $C2
     add  hl, de                                   ; $63EE: $19
     ld   [hl], $01                                ; $63EF: $36 $01
     ld   hl, wEntitiesPhysicsFlagsTable           ; $63F1: $21 $40 $C3
@@ -6076,7 +6076,7 @@ BlainoEntityHandler::
 
     call func_018_7DE8                            ; $64D6: $CD $E8 $7D
     call label_3EE8                               ; $64D9: $CD $E8 $3E
-    ld   hl, wEntitiesSubstate1Table              ; $64DC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $64DC: $21 $B0 $C2
     add  hl, bc                                   ; $64DF: $09
     ld   a, [hl]                                  ; $64E0: $7E
     and  a                                        ; $64E1: $A7
@@ -6206,7 +6206,7 @@ jr_018_659F:
     call label_BFB                                ; $659F: $CD $FB $0B
     jr   nz, jr_018_65CE                          ; $65A2: $20 $2A
 
-    ld   hl, wEntitiesSubstate1Table              ; $65A4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $65A4: $21 $B0 $C2
     add  hl, bc                                   ; $65A7: $09
     ld   a, [hl]                                  ; $65A8: $7E
     cp   $05                                      ; $65A9: $FE $05
@@ -7046,7 +7046,7 @@ func_018_69D8:
     ret                                           ; $69FB: $C9
 
 VireEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $69FC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $69FC: $21 $B0 $C2
     add  hl, bc                                   ; $69FF: $09
     ld   a, [hl]                                  ; $6A00: $7E
     cp   $02                                      ; $6A01: $FE $02
@@ -7097,7 +7097,7 @@ func_018_6A31:
     ld   hl, wEntitiesPosZTable                   ; $6A52: $21 $10 $C3
     add  hl, de                                   ; $6A55: $19
     ld   [hl], a                                  ; $6A56: $77
-    ld   hl, wEntitiesSubstate1Table              ; $6A57: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6A57: $21 $B0 $C2
     add  hl, de                                   ; $6A5A: $19
     ld   [hl], $01                                ; $6A5B: $36 $01
     ldh  a, [hFFE8]                               ; $6A5D: $F0 $E8
@@ -7194,7 +7194,7 @@ jr_018_6A8B:
     ld   [hl], a                                  ; $6AF6: $77
     call IncrementEntityState                     ; $6AF7: $CD $12 $3B
     ld   [hl], $03                                ; $6AFA: $36 $03
-    ld   hl, wEntitiesSubstate2Table              ; $6AFC: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6AFC: $21 $C0 $C2
     add  hl, bc                                   ; $6AFF: $09
     ld   [hl], $FF                                ; $6B00: $36 $FF
 
@@ -7332,7 +7332,7 @@ label_018_6B92:
     ld   [hl], $30                                ; $6BBF: $36 $30
     call GetRandomByte                            ; $6BC1: $CD $0D $28
     and  $03                                      ; $6BC4: $E6 $03
-    ld   hl, wEntitiesSubstate2Table              ; $6BC6: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6BC6: $21 $C0 $C2
     add  hl, bc                                   ; $6BC9: $09
     ld   [hl], a                                  ; $6BCA: $77
     and  a                                        ; $6BCB: $A7
@@ -7349,7 +7349,7 @@ jr_018_6BD4:
     ld   a, $02                                   ; $6BD7: $3E $02
     jp   SetEntitySpriteVariant                   ; $6BD9: $C3 $0C $3B
 
-    ld   hl, wEntitiesSubstate2Table              ; $6BDC: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6BDC: $21 $C0 $C2
     add  hl, bc                                   ; $6BDF: $09
     ld   a, [hl]                                  ; $6BE0: $7E
     cp   $FF                                      ; $6BE1: $FE $FF
@@ -7396,7 +7396,7 @@ jr_018_6BD4:
     ret                                           ; $6C26: $C9
 
 jr_018_6C27:
-    ld   hl, wEntitiesSubstate2Table              ; $6C27: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6C27: $21 $C0 $C2
     add  hl, bc                                   ; $6C2A: $09
     ld   a, [hl]                                  ; $6C2B: $7E
     cp   $FF                                      ; $6C2C: $FE $FF
@@ -7516,7 +7516,7 @@ jr_018_6CB8:
     jr   z, jr_018_6CCD                           ; $6CC1: $28 $0A
 
     call ClearEntitySpeed                         ; $6CC3: $CD $7F $3D
-    ld   hl, wEntitiesSubstate2Table              ; $6CC6: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6CC6: $21 $C0 $C2
     add  hl, bc                                   ; $6CC9: $09
     ld   [hl], $FF                                ; $6CCA: $36 $FF
     ret                                           ; $6CCC: $C9
@@ -7654,7 +7654,7 @@ jr_018_6D7F:
     call GetEntityTransitionCountdown             ; $6D82: $CD $05 $0C
     jr   nz, jr_018_6D93                          ; $6D85: $20 $0C
 
-    ld   hl, wEntitiesSubstate2Table              ; $6D87: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6D87: $21 $C0 $C2
     add  hl, bc                                   ; $6D8A: $09
     ld   [hl], $FF                                ; $6D8B: $36 $FF
     call IncrementEntityState                     ; $6D8D: $CD $12 $3B
@@ -7704,7 +7704,7 @@ jr_018_6DC3:
     cp   $BD                                      ; $6DD0: $FE $BD
     jr   nz, jr_018_6DDE                          ; $6DD2: $20 $0A
 
-    ld   hl, wEntitiesSubstate1Table              ; $6DD4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6DD4: $21 $B0 $C2
     add  hl, de                                   ; $6DD7: $19
     ld   a, [hl]                                  ; $6DD8: $7E
     cp   $02                                      ; $6DD9: $FE $02
@@ -7737,7 +7737,7 @@ jr_018_6DDE:
     ld   hl, wEntitiesPosYTable                         ; $6DFF: $21 $10 $C2
     add  hl, de                                   ; $6E02: $19
     ld   [hl], a                                  ; $6E03: $77
-    ld   hl, wEntitiesSubstate1Table              ; $6E04: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6E04: $21 $B0 $C2
     add  hl, de                                   ; $6E07: $19
     ld   [hl], $02                                ; $6E08: $36 $02
     ld   hl, wEntitiesPhysicsFlagsTable           ; $6E0A: $21 $40 $C3
@@ -7871,7 +7871,7 @@ jr_018_6EBA:
     ldh  [hLinkPositionY], a                      ; $6EC3: $E0 $99
     call IncrementEntityState                     ; $6EC5: $CD $12 $3B
     ld   [hl], $03                                ; $6EC8: $36 $03
-    ld   hl, wEntitiesSubstate2Table              ; $6ECA: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6ECA: $21 $C0 $C2
     add  hl, bc                                   ; $6ECD: $09
     ld   [hl], $01                                ; $6ECE: $36 $01
 
@@ -8068,7 +8068,7 @@ jr_018_6F95:
     ret                                           ; $6FD5: $C9
 
 GrimCreeperEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $6FD6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6FD6: $21 $B0 $C2
     add  hl, bc                                   ; $6FD9: $09
     ld   a, [hl]                                  ; $6FDA: $7E
 
@@ -8167,7 +8167,7 @@ jr_018_7069:
     cp   $BC                                      ; $706E: $FE $BC
     jr   nz, jr_018_707F                          ; $7070: $20 $0D
 
-    ld   hl, wEntitiesSubstate1Table              ; $7072: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7072: $21 $B0 $C2
     add  hl, de                                   ; $7075: $19
     ld   a, [hl]                                  ; $7076: $7E
     and  a                                        ; $7077: $A7
@@ -8256,7 +8256,7 @@ jr_018_70A4:
     ld   hl, wEntitiesHealthTable                 ; $70EA: $21 $60 $C3
     add  hl, de                                   ; $70ED: $19
     ld   [hl], $01                                ; $70EE: $36 $01
-    ld   hl, wEntitiesSubstate1Table              ; $70F0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $70F0: $21 $B0 $C2
     add  hl, de                                   ; $70F3: $19
     ld   [hl], $01                                ; $70F4: $36 $01
     ld   hl, wEntitiesPhysicsFlagsTable           ; $70F6: $21 $40 $C3
@@ -8311,7 +8311,7 @@ jr_018_7121:
     and  a                                        ; $7141: $A7
     jr   nz, jr_018_7152                          ; $7142: $20 $0E
 
-    ld   hl, wEntitiesSubstate2Table              ; $7144: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7144: $21 $C0 $C2
     add  hl, bc                                   ; $7147: $09
     ld   a, [hl]                                  ; $7148: $7E
     and  a                                        ; $7149: $A7
@@ -8910,7 +8910,7 @@ jr_018_7416:
     ld   hl, wEntitiesSpeedZTable                 ; $7463: $21 $20 $C3
     add  hl, de                                   ; $7466: $19
     ld   [hl], a                                  ; $7467: $77
-    ld   hl, wEntitiesSubstate1Table              ; $7468: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7468: $21 $B0 $C2
     add  hl, de                                   ; $746B: $19
     ld   [hl], a                                  ; $746C: $77
     pop  bc                                       ; $746D: $C1
@@ -9478,7 +9478,7 @@ jr_018_7764:
 jr_018_77A9:
     call func_018_7E5F                            ; $77A9: $CD $5F $7E
     call label_3B23                               ; $77AC: $CD $23 $3B
-    ld   hl, wEntitiesSubstate1Table              ; $77AF: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $77AF: $21 $B0 $C2
     add  hl, bc                                   ; $77B2: $09
     ld   a, [hl]                                  ; $77B3: $7E
     ld   hl, $774D                                ; $77B4: $21 $4D $77
@@ -9490,7 +9490,7 @@ jr_018_77B8:
     call func_018_7D95                            ; $77BA: $CD $95 $7D
     jr   nc, jr_018_77CC                          ; $77BD: $30 $0D
 
-    ld   hl, wEntitiesSubstate2Table              ; $77BF: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $77BF: $21 $C0 $C2
     add  hl, bc                                   ; $77C2: $09
     ld   a, [hl]                                  ; $77C3: $7E
     and  $03                                      ; $77C4: $E6 $03
@@ -9646,7 +9646,7 @@ BomberEntityHandler::
     ld   hl, wEntitiesSpeedYTable                       ; $788F: $21 $50 $C2
     add  hl, bc                                   ; $7892: $09
     ld   [hl], a                                  ; $7893: $77
-    ld   hl, wEntitiesSubstate1Table              ; $7894: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7894: $21 $B0 $C2
     add  hl, bc                                   ; $7897: $09
     inc  [hl]                                     ; $7898: $34
     ld   a, [hl]                                  ; $7899: $7E
@@ -9880,10 +9880,10 @@ jr_018_79F0:
     ld   [$DDD8], a                               ; $79F3: $EA $D8 $DD
     ld   d, h                                     ; $79F6: $54
     ld   e, l                                     ; $79F7: $5D
-    ld   hl, wEntitiesSubstate1Table              ; $79F8: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $79F8: $21 $B0 $C2
     add  hl, bc                                   ; $79FB: $09
     ld   [hl], d                                  ; $79FC: $72
-    ld   hl, wEntitiesSubstate2Table              ; $79FD: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $79FD: $21 $C0 $C2
     add  hl, bc                                   ; $7A00: $09
     ld   [hl], e                                  ; $7A01: $73
     ld   hl, wEntitiesStateTable                  ; $7A02: $21 $90 $C2
@@ -9955,10 +9955,10 @@ label_018_7A5D:
     add  hl, bc                                   ; $7A6C: $09
     ld   a, [hl]                                  ; $7A6D: $7E
     ldh  [hSwordIntersectedAreaY], a              ; $7A6E: $E0 $CD
-    ld   hl, wEntitiesSubstate1Table              ; $7A70: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7A70: $21 $B0 $C2
     add  hl, bc                                   ; $7A73: $09
     ld   d, [hl]                                  ; $7A74: $56
-    ld   hl, wEntitiesSubstate2Table              ; $7A75: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7A75: $21 $C0 $C2
     add  hl, bc                                   ; $7A78: $09
     ld   e, [hl]                                  ; $7A79: $5E
     ld   a, $AB                                   ; $7A7A: $3E $AB
@@ -10690,7 +10690,7 @@ label_018_7F08:
 
 func_018_7F0F:
 label_018_7F0F:
-    ld   hl, wEntitiesSubstate2Table              ; $7F0F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7F0F: $21 $C0 $C2
     add  hl, bc                                   ; $7F12: $09
     ld   a, [hl]                                  ; $7F13: $7E
     rst  $00                                      ; $7F14: $C7
@@ -10707,7 +10707,7 @@ label_018_7F0F:
     ld   [hl], $FF                                ; $7F24: $36 $FF
 
 label_018_7F26:
-    ld   hl, wEntitiesSubstate2Table              ; $7F26: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7F26: $21 $C0 $C2
     add  hl, bc                                   ; $7F29: $09
     inc  [hl]                                     ; $7F2A: $34
     ret                                           ; $7F2B: $C9

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -14,7 +14,7 @@ Data_019_4020::
     ld   d, $01                                   ; $4020: $16 $01
 
 LiftableStatueEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $4022: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4022: $21 $B0 $C2
     add  hl, bc                                   ; $4025: $09
     ld   a, [hl]                                  ; $4026: $7E
     and  a                                        ; $4027: $A7
@@ -244,7 +244,7 @@ jr_019_4185:
     call SpawnNewEntity_trampoline                ; $4189: $CD $86 $3B
     jr   c, jr_019_41E2                           ; $418C: $38 $54
 
-    ld   hl, wEntitiesSubstate1Table              ; $418E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $418E: $21 $B0 $C2
     add  hl, de                                   ; $4191: $19
     inc  [hl]                                     ; $4192: $34
 
@@ -982,7 +982,7 @@ jr_019_46A2:
     ld   [$DB7D], a                               ; $46BE: $EA $7D $DB
     ld   a, $0D                                   ; $46C1: $3E $0D
     ld   [wAButtonSlot], a                        ; $46C3: $EA $00 $DB
-    ld   hl, wEntitiesSubstate1Table              ; $46C6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $46C6: $21 $B0 $C2
     add  hl, bc                                   ; $46C9: $09
     ld   [hl], a                                  ; $46CA: $77
     call GetEntityTransitionCountdown             ; $46CB: $CD $05 $0C
@@ -1025,7 +1025,7 @@ jr_019_46FB:
 jr_019_4707:
     ld   a, [$DB7D]                               ; $4707: $FA $7D $DB
     ld   [hl], a                                  ; $470A: $77
-    ld   hl, wEntitiesSubstate1Table              ; $470B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $470B: $21 $B0 $C2
     add  hl, bc                                   ; $470E: $09
     ld   [hl], a                                  ; $470F: $77
     ld   a, $0D                                   ; $4710: $3E $0D
@@ -1084,7 +1084,7 @@ jr_019_4755:
     jr   nz, jr_019_476A                          ; $4757: $20 $11
 
     dec  [hl]                                     ; $4759: $35
-    ld   hl, wEntitiesSubstate1Table              ; $475A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $475A: $21 $B0 $C2
     add  hl, bc                                   ; $475D: $09
     ld   a, [hl]                                  ; $475E: $7E
     cp   $0D                                      ; $475F: $FE $0D
@@ -1111,7 +1111,7 @@ jr_019_476A:
     ld   a, $02                                   ; $477F: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $4781: $E0 $A1
     call ResetSpinAttack                                ; $4783: $CD $AF $0C
-    ld   hl, wEntitiesSubstate1Table              ; $4786: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4786: $21 $B0 $C2
     add  hl, bc                                   ; $4789: $09
     ld   a, [hl]                                  ; $478A: $7E
     ldh  [hActiveEntitySpriteVariant], a               ; $478B: $E0 $F1
@@ -1695,7 +1695,7 @@ jr_019_4AAD:
     jr   c, jr_019_4AEB                           ; $4AC9: $38 $20
 
 EggSongEventEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $4ACB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4ACB: $21 $B0 $C2
     add  hl, bc                                   ; $4ACE: $09
     ld   a, [hl]                                  ; $4ACF: $7E
     and  a                                        ; $4AD0: $A7
@@ -1842,7 +1842,7 @@ func_019_4B6E:
     ld   hl, wEntitiesSpriteVariantTable               ; $4BA0: $21 $B0 $C3
     add  hl, de                                   ; $4BA3: $19
     ld   [hl], a                                  ; $4BA4: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4BA5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4BA5: $21 $B0 $C2
     add  hl, de                                   ; $4BA8: $19
     inc  [hl]                                     ; $4BA9: $34
     pop  bc                                       ; $4BAA: $C1
@@ -2103,7 +2103,7 @@ jr_019_4D1A:
     dec  sp                                       ; $4D4C: $3B
     ret  c                                        ; $4D4D: $D8
 
-    ld   hl, wEntitiesSubstate1Table              ; $4D4E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4D4E: $21 $B0 $C2
     add  hl, de                                   ; $4D51: $19
     ld   [hl], $02                                ; $4D52: $36 $02
     call GetRandomByte                            ; $4D54: $CD $0D $28
@@ -2155,7 +2155,7 @@ label_019_4D9B:
     and  $20                                      ; $4D9D: $E6 $20
     jp   nz, label_019_7E61                       ; $4D9F: $C2 $61 $7E
 
-    ld   hl, wEntitiesSubstate1Table              ; $4DA2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4DA2: $21 $B0 $C2
     add  hl, bc                                   ; $4DA5: $09
     ld   a, [hl]                                  ; $4DA6: $7E
     and  a                                        ; $4DA7: $A7
@@ -2203,7 +2203,7 @@ label_019_4D9B:
     ld   hl, wEntitiesPosYTable                         ; $4DE6: $21 $10 $C2
     add  hl, de                                   ; $4DE9: $19
     ld   [hl], $D8                                ; $4DEA: $36 $D8
-    ld   hl, wEntitiesSubstate1Table              ; $4DEC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4DEC: $21 $B0 $C2
     add  hl, de                                   ; $4DEF: $19
     inc  [hl]                                     ; $4DF0: $34
     ld   hl, wEntitiesPhysicsFlagsTable           ; $4DF1: $21 $40 $C3
@@ -2453,7 +2453,7 @@ jr_019_4F5A:
     and  $07                                      ; $4F68: $E6 $07
     jr   nz, jr_019_4F8F                          ; $4F6A: $20 $23
 
-    ld   hl, wEntitiesSubstate2Table              ; $4F6C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4F6C: $21 $C0 $C2
     add  hl, bc                                   ; $4F6F: $09
     inc  [hl]                                     ; $4F70: $34
     ld   a, [hl]                                  ; $4F71: $7E
@@ -2475,7 +2475,7 @@ jr_019_4F5A:
     jp   label_019_7E61                           ; $4F8C: $C3 $61 $7E
 
 jr_019_4F8F:
-    ld   hl, wEntitiesSubstate2Table              ; $4F8F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4F8F: $21 $C0 $C2
     add  hl, bc                                   ; $4F92: $09
     ld   e, [hl]                                  ; $4F93: $5E
     ld   d, b                                     ; $4F94: $50
@@ -2513,7 +2513,7 @@ jr_019_4F8F:
     ld   hl, wEntitiesPosYTable                         ; $4FC9: $21 $10 $C2
     add  hl, de                                   ; $4FCC: $19
     ld   [hl], a                                  ; $4FCD: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4FCE: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4FCE: $21 $B0 $C2
     add  hl, de                                   ; $4FD1: $19
     ld   [hl], $01                                ; $4FD2: $36 $01
     ld   hl, wEntitiesTransitionCountdownTable    ; $4FD4: $21 $E0 $C2
@@ -3224,7 +3224,7 @@ jr_019_53DF:
     inc  [hl]                                     ; $53EF: $34
 
 PodobooEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $53F0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $53F0: $21 $B0 $C2
     add  hl, bc                                   ; $53F3: $09
     ld   a, [hl]                                  ; $53F4: $7E
     and  a                                        ; $53F5: $A7
@@ -3273,7 +3273,7 @@ jr_019_542C:
     ld   hl, wEntitiesPosYTable                         ; $5436: $21 $10 $C2
     add  hl, de                                   ; $5439: $19
     ld   [hl], a                                  ; $543A: $77
-    ld   hl, wEntitiesSubstate1Table              ; $543B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $543B: $21 $B0 $C2
     add  hl, de                                   ; $543E: $19
     ld   [hl], $02                                ; $543F: $36 $02
     push bc                                       ; $5441: $C5
@@ -3365,7 +3365,7 @@ jr_019_54AC:
     ld   hl, wEntitiesTransitionCountdownTable    ; $54C6: $21 $E0 $C2
     add  hl, de                                   ; $54C9: $19
     ld   [hl], $18                                ; $54CA: $36 $18
-    ld   hl, wEntitiesSubstate1Table              ; $54CC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $54CC: $21 $B0 $C2
     add  hl, de                                   ; $54CF: $19
     ld   [hl], $01                                ; $54D0: $36 $01
     ldh  a, [hActiveEntitySpriteVariant]               ; $54D2: $F0 $F1
@@ -3770,7 +3770,7 @@ ThwimpEntityHandler::
     ld   c, b                                     ; $56E1: $48
     ld   d, a                                     ; $56E2: $57
     ldh  a, [wActiveEntityPosY]                   ; $56E3: $F0 $EC
-    ld   hl, wEntitiesSubstate1Table              ; $56E5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $56E5: $21 $B0 $C2
     add  hl, bc                                   ; $56E8: $09
     ld   [hl], a                                  ; $56E9: $77
     call IncrementEntityState                     ; $56EA: $CD $12 $3B
@@ -3835,7 +3835,7 @@ jr_019_5732:
     call GetEntityTransitionCountdown             ; $5748: $CD $05 $0C
     ret  nz                                       ; $574B: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $574C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $574C: $21 $B0 $C2
     add  hl, bc                                   ; $574F: $09
     ldh  a, [wActiveEntityPosY]                   ; $5750: $F0 $EC
     cp   [hl]                                     ; $5752: $BE
@@ -3954,7 +3954,7 @@ jr_019_57E7:
     add  c                                        ; $57EB: $81
     ld   e, b                                     ; $57EC: $58
     ldh  a, [wActiveEntityPosY]                   ; $57ED: $F0 $EC
-    ld   hl, wEntitiesSubstate1Table              ; $57EF: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $57EF: $21 $B0 $C2
     add  hl, bc                                   ; $57F2: $09
     ld   [hl], a                                  ; $57F3: $77
     call IncrementEntityState                     ; $57F4: $CD $12 $3B
@@ -4044,7 +4044,7 @@ jr_019_5846:
     call GetEntityTransitionCountdown             ; $5881: $CD $05 $0C
     ret  nz                                       ; $5884: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $5885: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5885: $21 $B0 $C2
     add  hl, bc                                   ; $5888: $09
     ldh  a, [wActiveEntityPosY]                   ; $5889: $F0 $EC
     cp   [hl]                                     ; $588B: $BE
@@ -5166,7 +5166,7 @@ GhostEntityHandler::
     call RenderAnimatedActiveEntity                               ; $5E3B: $CD $C0 $3B
 
 jr_019_5E3E:
-    ld   hl, wEntitiesSubstate2Table              ; $5E3E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5E3E: $21 $C0 $C2
     add  hl, bc                                   ; $5E41: $09
     ld   a, [hl]                                  ; $5E42: $7E
     and  a                                        ; $5E43: $A7
@@ -5317,7 +5317,7 @@ jr_019_5EAF:
     ld   a, $2D                                   ; $5F23: $3E $2D
     ldh  [hJingle], a                             ; $5F25: $E0 $F2
     call IncrementEntityState                     ; $5F27: $CD $12 $3B
-    ld   hl, wEntitiesSubstate2Table              ; $5F2A: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5F2A: $21 $C0 $C2
     add  hl, bc                                   ; $5F2D: $09
     inc  [hl]                                     ; $5F2E: $34
     ret                                           ; $5F2F: $C9
@@ -5874,7 +5874,7 @@ func_019_6262:
 jr_019_6262:
     push bc                                       ; $6262: $C5
     push hl                                       ; $6263: $E5
-    ld   hl, wEntitiesSubstate1Table              ; $6264: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6264: $21 $B0 $C2
     add  hl, bc                                   ; $6267: $09
     ld   a, [hl]                                  ; $6268: $7E
     rla                                           ; $6269: $17
@@ -5918,7 +5918,7 @@ jr_019_6288:
     call func_019_6262                            ; $6296: $CD $62 $62
     call GetEntityTransitionCountdown             ; $6299: $CD $05 $0C
     ld   [hl], $18                                ; $629C: $36 $18
-    ld   hl, wEntitiesSubstate1Table              ; $629E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $629E: $21 $B0 $C2
     add  hl, bc                                   ; $62A1: $09
     inc  [hl]                                     ; $62A2: $34
     ld   hl, wEntitiesUnknowTableY                ; $62A3: $21 $D0 $C3
@@ -7080,7 +7080,7 @@ jr_019_6889:
 
     jp   label_019_6A4F                           ; $6891: $C3 $4F $6A
 
-    ld   hl, wEntitiesSubstate1Table              ; $6894: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6894: $21 $B0 $C2
     add  hl, bc                                   ; $6897: $09
     ld   a, [hl]                                  ; $6898: $7E
     push af                                       ; $6899: $F5
@@ -7163,7 +7163,7 @@ jr_019_68F6:
     jp   IncrementEntityState                     ; $68F6: $C3 $12 $3B
 
     push bc                                       ; $68F9: $C5
-    ld   hl, wEntitiesSubstate1Table              ; $68FA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $68FA: $21 $B0 $C2
     add  hl, bc                                   ; $68FD: $09
     ld   a, [hl]                                  ; $68FE: $7E
     rla                                           ; $68FF: $17
@@ -7199,7 +7199,7 @@ jr_019_691E:
     ld   [hl], $00                                ; $6923: $36 $00
     pop  bc                                       ; $6925: $C1
     push bc                                       ; $6926: $C5
-    ld   hl, wEntitiesSubstate1Table              ; $6927: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6927: $21 $B0 $C2
     add  hl, bc                                   ; $692A: $09
     ld   a, [hl]                                  ; $692B: $7E
     rla                                           ; $692C: $17
@@ -7234,7 +7234,7 @@ jr_019_694B:
 
     ld   [hl], $00                                ; $6950: $36 $00
     pop  bc                                       ; $6952: $C1
-    ld   hl, wEntitiesSubstate1Table              ; $6953: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6953: $21 $B0 $C2
     add  hl, bc                                   ; $6956: $09
     ld   a, [hl]                                  ; $6957: $7E
     inc  a                                        ; $6958: $3C
@@ -7408,7 +7408,7 @@ jr_019_6A6D:
     ld   hl, wEntitiesTransitionCountdownTable    ; $6A80: $21 $E0 $C2
     add  hl, de                                   ; $6A83: $19
     ld   [hl], $10                                ; $6A84: $36 $10
-    ld   hl, wEntitiesSubstate1Table              ; $6A86: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6A86: $21 $B0 $C2
     add  hl, de                                   ; $6A89: $19
     ld   [hl], $01                                ; $6A8A: $36 $01
 
@@ -7436,7 +7436,7 @@ jr_019_6AA1:
     ldh  a, [rNR10]                               ; $6AAD: $F0 $10
 
 MimicEntityHandler::
-    ld   hl, wEntitiesSubstate2Table              ; $6AAF: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6AAF: $21 $C0 $C2
     add  hl, bc                                   ; $6AB2: $09
     ld   a, [hl]                                  ; $6AB3: $7E
     and  a                                        ; $6AB4: $A7
@@ -7682,7 +7682,7 @@ jr_019_6BFD:
     add  hl, bc                                   ; $6C0F: $09
     ld   [hl], $03                                ; $6C10: $36 $03
     ldh  a, [$FFEF]                               ; $6C12: $F0 $EF
-    ld   hl, wEntitiesSubstate1Table              ; $6C14: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6C14: $21 $B0 $C2
     add  hl, bc                                   ; $6C17: $09
     ld   [hl], a                                  ; $6C18: $77
     jp   IncrementEntityState                     ; $6C19: $C3 $12 $3B
@@ -7751,7 +7751,7 @@ jr_019_6C68:
 
     jp   IncrementEntityState                     ; $6C81: $C3 $12 $3B
 
-    ld   hl, wEntitiesSubstate1Table              ; $6C84: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6C84: $21 $B0 $C2
     add  hl, bc                                   ; $6C87: $09
     ld   a, [hl]                                  ; $6C88: $7E
     ld   hl, wEntitiesPosYTable                         ; $6C89: $21 $10 $C2
@@ -7852,7 +7852,7 @@ label_019_6D00:
     ld   a, $0B                                   ; $6D12: $3E $0B
     ld   [hl], a                                  ; $6D14: $77
     pop  bc                                       ; $6D15: $C1
-    ld   hl, wEntitiesSubstate1Table              ; $6D16: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6D16: $21 $B0 $C2
     add  hl, bc                                   ; $6D19: $09
     ld   a, [hl]                                  ; $6D1A: $7E
     and  a                                        ; $6D1B: $A7
@@ -7941,7 +7941,7 @@ jr_019_6D86:
     ld   hl, wEntitiesPosYTable                         ; $6DA0: $21 $10 $C2
     add  hl, de                                   ; $6DA3: $19
     ld   [hl], a                                  ; $6DA4: $77
-    ld   hl, wEntitiesSubstate1Table              ; $6DA5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6DA5: $21 $B0 $C2
     add  hl, de                                   ; $6DA8: $19
     ld   [hl], $01                                ; $6DA9: $36 $01
     ld   hl, wEntitiesSpeedZTable                 ; $6DAB: $21 $20 $C3
@@ -8244,7 +8244,7 @@ jr_019_6F25:
     ld   hl, wEntitiesPosYTable                         ; $6F54: $21 $10 $C2
     add  hl, de                                   ; $6F57: $19
     ld   [hl], $28                                ; $6F58: $36 $28
-    ld   hl, wEntitiesSubstate1Table              ; $6F5A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F5A: $21 $B0 $C2
     add  hl, de                                   ; $6F5D: $19
     ld   [hl], $01                                ; $6F5E: $36 $01
     ld   hl, wEntitiesTransitionCountdownTable    ; $6F60: $21 $E0 $C2
@@ -8671,7 +8671,7 @@ func_019_717C:
     ld   h, b                                     ; $71BB: $60
 
 SeashellMansionEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $71BC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $71BC: $21 $B0 $C2
     add  hl, bc                                   ; $71BF: $09
 
 jr_019_71C0:
@@ -8850,7 +8850,7 @@ jr_019_72AC:
     ld   [hl], $40                                ; $72AC: $36 $40
     call IncrementEntityState                     ; $72AE: $CD $12 $3B
     call func_019_7921                            ; $72B1: $CD $21 $79
-    ld   hl, wEntitiesSubstate2Table              ; $72B4: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $72B4: $21 $C0 $C2
     add  hl, bc                                   ; $72B7: $09
     ld   [hl], $01                                ; $72B8: $36 $01
     ld   a, $56                                   ; $72BA: $3E $56
@@ -8942,7 +8942,7 @@ jr_019_7327:
     ld   hl, wEntitiesPosYTable                         ; $734A: $21 $10 $C2
     add  hl, de                                   ; $734D: $19
     ld   [hl], $48                                ; $734E: $36 $48
-    ld   hl, wEntitiesSubstate1Table              ; $7350: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7350: $21 $B0 $C2
     add  hl, de                                   ; $7353: $19
     ld   [hl], $02                                ; $7354: $36 $02
     ld   hl, wEntitiesTransitionCountdownTable    ; $7356: $21 $E0 $C2
@@ -8984,7 +8984,7 @@ jr_019_7373:
     ld   hl, wEntitiesPosYTable                         ; $7391: $21 $10 $C2
     add  hl, de                                   ; $7394: $19
     ld   [hl], $48                                ; $7395: $36 $48
-    ld   hl, wEntitiesSubstate1Table              ; $7397: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7397: $21 $B0 $C2
     add  hl, de                                   ; $739A: $19
     ld   [hl], $01                                ; $739B: $36 $01
     ld   hl, wEntitiesTransitionCountdownTable    ; $739D: $21 $E0 $C2
@@ -9013,7 +9013,7 @@ jr_019_7373:
     ld   e, $70                                   ; $73BB: $1E $70
 
 func_019_73BD:
-    ld   hl, wEntitiesSubstate2Table              ; $73BD: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $73BD: $21 $C0 $C2
     add  hl, bc                                   ; $73C0: $09
     ld   a, [hl]                                  ; $73C1: $7E
     and  a                                        ; $73C2: $A7
@@ -10295,12 +10295,12 @@ jr_019_7A5D:
     jr   nz, jr_019_7A5D                          ; $7A62: $20 $F9
 
 jr_019_7A64:
-    ld   hl, wEntitiesSubstate1Table              ; $7A64: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7A64: $21 $B0 $C2
     add  hl, bc                                   ; $7A67: $09
     ldh  a, [hScratch0]                           ; $7A68: $F0 $D7
     add  [hl]                                     ; $7A6A: $86
     ld   [hl], a                                  ; $7A6B: $77
-    ld   hl, wEntitiesSubstate2Table              ; $7A6C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7A6C: $21 $C0 $C2
     add  hl, bc                                   ; $7A6F: $09
     ldh  a, [hScratch2]                           ; $7A70: $F0 $D9
     add  [hl]                                     ; $7A72: $86
@@ -11149,7 +11149,7 @@ label_019_7E61:
     ld   [hl], b                                  ; $7E65: $70
     ret                                           ; $7E66: $C9
 
-    ld   hl, wEntitiesSubstate2Table              ; $7E67: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7E67: $21 $C0 $C2
     add  hl, bc                                   ; $7E6A: $09
     ld   a, [hl]                                  ; $7E6B: $7E
     rst  $00                                      ; $7E6C: $C7
@@ -11166,7 +11166,7 @@ label_019_7E61:
     ld   [hl], $FF                                ; $7E7C: $36 $FF
 
 label_019_7E7E:
-    ld   hl, wEntitiesSubstate2Table              ; $7E7E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7E7E: $21 $C0 $C2
     add  hl, bc                                   ; $7E81: $09
     inc  [hl]                                     ; $7E82: $34
     ret                                           ; $7E83: $C9

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -316,7 +316,7 @@ Data_003_4924::
     cp   $50                                      ; $494A: $FE $50
     ret  c                                        ; $494C: $D8
 
-    ld   hl, wEntitiesSubstate1Table              ; $494D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $494D: $21 $B0 $C2
     add  hl, bc                                   ; $4950: $09
     inc  [hl]                                     ; $4951: $34
     ret                                           ; $4952: $C9
@@ -414,7 +414,7 @@ jr_003_499C:
     ld   a, [hl]                                  ; $49D8: $7E
     add  $0A                                      ; $49D9: $C6 $0A
     ld   [hl], a                                  ; $49DB: $77
-    ld   hl, wEntitiesSubstate2Table              ; $49DC: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $49DC: $21 $C0 $C2
     add  hl, bc                                   ; $49DF: $09
     ld   [hl], a                                  ; $49E0: $77
     ret                                           ; $49E1: $C9
@@ -1240,7 +1240,7 @@ jr_003_4E85:
     ld   [hl], a                                  ; $4EC2: $77
     ret                                           ; $4EC3: $C9
 
-    ld   hl, wEntitiesSubstate2Table              ; $4EC4: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4EC4: $21 $C0 $C2
     add  hl, bc                                   ; $4EC7: $09
     ld   [hl], $04                                ; $4EC8: $36 $04
     ld   a, $03                                   ; $4ECA: $3E $03
@@ -1479,7 +1479,7 @@ Data_003_4FF7::
     db   $00, $00, $F4, $0C
 
 IronMaskEntityHandler::
-    ld   hl, wEntitiesSubstate2Table              ; $4FFB: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4FFB: $21 $C0 $C2
     add  hl, bc                                   ; $4FFE: $09
     ld   a, [hl]                                  ; $4FFF: $7E
     and  a                                        ; $5000: $A7
@@ -2333,7 +2333,7 @@ SpawnEnemyDrop::
     cp   ENTITY_LIKE_LIKE                         ; $55D1: $FE $23
     jr   nz, .likeLikeEnd                         ; $55D3: $20 $0D
 
-    ld   hl, wEntitiesSubstate1Table              ; $55D5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $55D5: $21 $B0 $C2
     add  hl, bc                                   ; $55D8: $09
     ld   a, [hl]                                  ; $55D9: $7E
     and  a                                        ; $55DA: $A7
@@ -2446,10 +2446,10 @@ SpawnEnemyDrop::
     ret  c                                        ; $5673: $D8
 
     ; Configure the dropped item entity
-    ld   hl, wEntitiesSubstate1Table              ; $5674: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5674: $21 $B0 $C2
     add  hl, bc                                   ; $5677: $09
     ld   a, [hl]                                  ; $5678: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $5679: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5679: $21 $B0 $C2
     add  hl, de                                   ; $567C: $19
     ld   [hl], a                                  ; $567D: $77
 
@@ -2854,7 +2854,7 @@ jr_003_5896:
     ld   hl, wEntitiesStateTable                  ; $589E: $21 $90 $C2
     add  hl, bc                                   ; $58A1: $09
     ld   [hl], $00                                ; $58A2: $36 $00
-    ld   hl, wEntitiesSubstate1Table              ; $58A4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $58A4: $21 $B0 $C2
     add  hl, bc                                   ; $58A7: $09
     ld   a, [hl]                                  ; $58A8: $7E
     inc  a                                        ; $58A9: $3C
@@ -3703,7 +3703,7 @@ jr_003_5D80:
     ld   bc, $17E                                 ; $5D90: $01 $7E $01
 
 SirensInstrumentEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $5D93: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5D93: $21 $B0 $C2
     add  hl, bc                                   ; $5D96: $09
     ld   a, [hl]                                  ; $5D97: $7E
     rst  $00                                      ; $5D98: $C7
@@ -3826,7 +3826,7 @@ jr_003_5E29:
     cp   $50                                      ; $5E29: $FE $50
     jr   nc, jr_003_5E8A                          ; $5E2B: $30 $5D
 
-    ld   hl, wEntitiesSubstate2Table              ; $5E2D: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5E2D: $21 $C0 $C2
     add  hl, bc                                   ; $5E30: $09
     ld   a, [hl]                                  ; $5E31: $7E
     cp   $19                                      ; $5E32: $FE $19
@@ -3851,7 +3851,7 @@ jr_003_5E45:
 
     ld   a, ENTITY_GOOMBA                         ; $5E4A: $3E $9F
     call SpawnNewEntity                           ; $5E4C: $CD $CA $64
-    ld   hl, wEntitiesSubstate1Table              ; $5E4F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5E4F: $21 $B0 $C2
     add  hl, de                                   ; $5E52: $19
     ld   [hl], $01                                ; $5E53: $36 $01
     ld   hl, wEntitiesTransitionCountdownTable           ; $5E55: $21 $E0 $C2
@@ -3861,7 +3861,7 @@ jr_003_5E45:
 jr_003_5E5B:
     ldh  a, [hFrameCounter]                       ; $5E5B: $F0 $E7
     and  $03                                      ; $5E5D: $E6 $03
-    ld   hl, wEntitiesSubstate2Table              ; $5E5F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5E5F: $21 $C0 $C2
     add  hl, bc                                   ; $5E62: $09
     add  [hl]                                     ; $5E63: $86
     ld   e, a                                     ; $5E64: $5F
@@ -4023,7 +4023,7 @@ jr_003_5F2C:
     ld   hl, wEntitiesPosYTable                         ; $5F4B: $21 $10 $C2
     add  hl, de                                   ; $5F4E: $19
     ld   [hl], a                                  ; $5F4F: $77
-    ld   hl, wEntitiesSubstate1Table              ; $5F50: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F50: $21 $B0 $C2
     add  hl, de                                   ; $5F53: $19
     ld   [hl], $02                                ; $5F54: $36 $02
     ld   hl, wEntitiesDropTimerTable                                ; $5F56: $21 $50 $C4
@@ -4049,7 +4049,7 @@ jr_003_5F5F:
     ld   a, $39                                   ; $5F75: $3E $39
     call SpawnNewEntity                           ; $5F77: $CD $CA $64
     push bc                                       ; $5F7A: $C5
-    ld   hl, wEntitiesSubstate1Table              ; $5F7B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F7B: $21 $B0 $C2
     add  hl, de                                   ; $5F7E: $19
     inc  [hl]                                     ; $5F7F: $34
     ldh  a, [hFFE8]                               ; $5F80: $F0 $E8
@@ -4859,7 +4859,7 @@ jr_003_6422:
     ret                                           ; $6467: $C9
 
 jr_003_6468:
-    ld   hl, wEntitiesSubstate1Table              ; $6468: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6468: $21 $B0 $C2
     add  hl, bc                                   ; $646B: $09
     ld   a, [hl]                                  ; $646C: $7E
     ld   [wShieldLevel], a                        ; $646D: $EA $44 $DB
@@ -6700,7 +6700,7 @@ jr_003_6EF7:
     jp   z, label_003_6F93                        ; $6F01: $CA $93 $6F
 
 label_003_6F04:
-    ld   hl, wEntitiesSubstate1Table              ; $6F04: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F04: $21 $B0 $C2
     add  hl, bc                                   ; $6F07: $09
     ld   a, [hl]                                  ; $6F08: $7E
     cpl                                           ; $6F09: $2F
@@ -6967,7 +6967,7 @@ jr_003_707D:
     and  a                                        ; $7083: $A7
     jr   nz, jr_003_70A9                          ; $7084: $20 $23
 
-    ld   hl, wEntitiesSubstate1Table              ; $7086: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7086: $21 $B0 $C2
     add  hl, bc                                   ; $7089: $09
     ld   a, [hl]                                  ; $708A: $7E
     cp   $04                                      ; $708B: $FE $04
@@ -7061,7 +7061,7 @@ jr_003_710D:
     cp   $24                                      ; $710D: $FE $24
     jr   nz, jr_003_7146                          ; $710F: $20 $35
 
-    ld   hl, wEntitiesSubstate2Table              ; $7111: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7111: $21 $C0 $C2
     add  hl, bc                                   ; $7114: $09
     ld   a, [hl]                                  ; $7115: $7E
     and  a                                        ; $7116: $A7
@@ -7311,7 +7311,7 @@ jr_003_7279:
     jr   nz, jr_003_7293                          ; $7287: $20 $0A
 
 jr_003_7289:
-    ld   hl, wEntitiesSubstate1Table              ; $7289: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7289: $21 $B0 $C2
     add  hl, bc                                   ; $728C: $09
     ld   a, [hl]                                  ; $728D: $7E
     and  a                                        ; $728E: $A7
@@ -7402,7 +7402,7 @@ jr_003_72EE:
 jr_003_7304:
     ld   a, $03                                   ; $7304: $3E $03
     ld   [wBossAgonySFXCountdown], a              ; $7306: $EA $A7 $C5
-    ld   hl, wEntitiesSubstate2Table              ; $7309: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7309: $21 $C0 $C2
     add  hl, bc                                   ; $730C: $09
     ld   [hl], b                                  ; $730D: $70
     ld   hl, wEntitiesTypeTable                   ; $730E: $21 $A0 $C3
@@ -8087,7 +8087,7 @@ jr_003_76AC:
     cp   [hl]                                     ; $76D3: $BE
     jr   nz, jr_003_7710                          ; $76D4: $20 $3A
 
-    ld   hl, wEntitiesSubstate2Table              ; $76D6: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $76D6: $21 $C0 $C2
     add  hl, de                                   ; $76D9: $19
     ld   a, [hl]                                  ; $76DA: $7E
     and  a                                        ; $76DB: $A7
@@ -9242,10 +9242,10 @@ jr_003_7CFD:
     ld   b, d                                     ; $7D1E: $42
     ld   d, h                                     ; $7D1F: $54
     ld   e, l                                     ; $7D20: $5D
-    ld   hl, wEntitiesSubstate1Table              ; $7D21: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7D21: $21 $B0 $C2
     add  hl, bc                                   ; $7D24: $09
     ld   [hl], d                                  ; $7D25: $72
-    ld   hl, wEntitiesSubstate2Table              ; $7D26: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7D26: $21 $C0 $C2
     add  hl, bc                                   ; $7D29: $09
     ld   [hl], e                                  ; $7D2A: $73
     ldh  a, [hSwordIntersectedAreaX]              ; $7D2B: $F0 $CE

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -121,7 +121,7 @@ jr_036_406E:
     ld   a, a                                     ; $409A: $7F
     ld   a, l                                     ; $409B: $7D
     call func_036_4365                            ; $409C: $CD $65 $43
-    ld   hl, wEntitiesSubstate1Table              ; $409F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $409F: $21 $B0 $C2
     add  hl, bc                                   ; $40A2: $09
     inc  [hl]                                     ; $40A3: $34
     ld   a, [hl]                                  ; $40A4: $7E
@@ -201,7 +201,7 @@ jr_036_40F7:
     ld   [hl], a                                  ; $4116: $77
 
 jr_036_4117:
-    ld   hl, wEntitiesSubstate1Table              ; $4117: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4117: $21 $B0 $C2
     add  hl, bc                                   ; $411A: $09
     inc  [hl]                                     ; $411B: $34
     ld   a, [hl]                                  ; $411C: $7E
@@ -232,7 +232,7 @@ jr_036_4117:
     ld   [hl], a                                  ; $4143: $77
 
 jr_036_4144:
-    ld   hl, wEntitiesSubstate1Table              ; $4144: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4144: $21 $B0 $C2
     add  hl, bc                                   ; $4147: $09
     inc  [hl]                                     ; $4148: $34
     ld   a, [hl]                                  ; $4149: $7E
@@ -682,7 +682,7 @@ jr_036_4405:
     call_open_dialog $294                         ; $4408
     call func_036_6C23                            ; $440D: $CD $23 $6C
     ld   a, [hl]                                  ; $4410: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $4411: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4411: $21 $C0 $C2
     add  hl, bc                                   ; $4414: $09
     ld   [hl], a                                  ; $4415: $77
     ld   a, $07                                   ; $4416: $3E $07
@@ -801,7 +801,7 @@ jr_036_449C:
     call func_036_4365                            ; $44B3: $CD $65 $43
     ld   a, $0C                                   ; $44B6: $3E $0C
     call func_036_6C07                            ; $44B8: $CD $07 $6C
-    ld   hl, wEntitiesSubstate1Table              ; $44BB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $44BB: $21 $B0 $C2
     add  hl, bc                                   ; $44BE: $09
     xor  a                                        ; $44BF: $AF
     ld   [hl], a                                  ; $44C0: $77
@@ -820,12 +820,12 @@ jr_036_449C:
     ret                                           ; $44D9: $C9
 
 jr_036_44DA:
-    ld   hl, wEntitiesSubstate2Table              ; $44DA: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $44DA: $21 $C0 $C2
     add  hl, bc                                   ; $44DD: $09
     ld   a, [hl]                                  ; $44DE: $7E
     sub  $10                                      ; $44DF: $D6 $10
     ld   [hl], a                                  ; $44E1: $77
-    ld   hl, wEntitiesSubstate1Table              ; $44E2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $44E2: $21 $B0 $C2
     add  hl, bc                                   ; $44E5: $09
     inc  [hl]                                     ; $44E6: $34
     ld   a, [hl]                                  ; $44E7: $7E
@@ -843,7 +843,7 @@ jr_036_44F6:
     ret                                           ; $44FB: $C9
 
     call func_036_4365                            ; $44FC: $CD $65 $43
-    ld   hl, wEntitiesSubstate2Table              ; $44FF: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $44FF: $21 $C0 $C2
     add  hl, bc                                   ; $4502: $09
     ld   a, [hl]                                  ; $4503: $7E
     call func_036_6C23                            ; $4504: $CD $23 $6C
@@ -889,7 +889,7 @@ jr_036_452D:
     ret                                           ; $4541: $C9
 
 jr_036_4542:
-    ld   hl, wEntitiesSubstate2Table              ; $4542: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4542: $21 $C0 $C2
     add  hl, bc                                   ; $4545: $09
     ld   a, [hl]                                  ; $4546: $7E
     call func_036_6C23                            ; $4547: $CD $23 $6C
@@ -930,13 +930,13 @@ jr_036_457C:
     call func_036_6C28                            ; $457D: $CD $28 $6C
     inc  [hl]                                     ; $4580: $34
     ldh  a, [hLinkPositionY]                      ; $4581: $F0 $99
-    ld   hl, wEntitiesSubstate2Table              ; $4583: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4583: $21 $C0 $C2
     add  hl, bc                                   ; $4586: $09
     ld   [hl], a                                  ; $4587: $77
     ret                                           ; $4588: $C9
 
     call func_036_4365                            ; $4589: $CD $65 $43
-    ld   hl, wEntitiesSubstate2Table              ; $458C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $458C: $21 $C0 $C2
     add  hl, bc                                   ; $458F: $09
     ld   a, [hl]                                  ; $4590: $7E
     call func_036_6C28                            ; $4591: $CD $28 $6C
@@ -953,7 +953,7 @@ jr_036_457C:
     ld   [hl], a                                  ; $45A3: $77
 
 jr_036_45A4:
-    ld   hl, wEntitiesSubstate1Table              ; $45A4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $45A4: $21 $B0 $C2
     add  hl, bc                                   ; $45A7: $09
     ld   a, [hl]                                  ; $45A8: $7E
     cp   $05                                      ; $45A9: $FE $05
@@ -1011,14 +1011,14 @@ jr_036_45E6:
     ret                                           ; $45FA: $C9
 
 jr_036_45FB:
-    ld   hl, wEntitiesSubstate2Table              ; $45FB: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $45FB: $21 $C0 $C2
     add  hl, bc                                   ; $45FE: $09
     ld   a, [hl]                                  ; $45FF: $7E
     call func_036_6C28                            ; $4600: $CD $28 $6C
     cp   [hl]                                     ; $4603: $BE
     ret  nz                                       ; $4604: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $4605: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4605: $21 $B0 $C2
     add  hl, bc                                   ; $4608: $09
     ld   a, [hl]                                  ; $4609: $7E
     cp   $05                                      ; $460A: $FE $05
@@ -1050,7 +1050,7 @@ jr_036_4627:
     ret                                           ; $462A: $C9
 
     call func_036_4365                            ; $462B: $CD $65 $43
-    ld   hl, wEntitiesSubstate1Table              ; $462E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $462E: $21 $B0 $C2
     add  hl, bc                                   ; $4631: $09
     inc  [hl]                                     ; $4632: $34
     ld   a, [hl]                                  ; $4633: $7E
@@ -1110,7 +1110,7 @@ jr_036_466C:
 
 label_036_467F:
     call func_036_4365                            ; $467F: $CD $65 $43
-    ld   hl, wEntitiesSubstate1Table              ; $4682: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4682: $21 $B0 $C2
     add  hl, bc                                   ; $4685: $09
     ld   a, [hl]                                  ; $4686: $7E
     inc  [hl]                                     ; $4687: $34
@@ -1357,7 +1357,7 @@ jr_036_47B1:
     ld   [hl], $6A                                ; $47ED: $36 $6A
     jp   IncrementEntityState                     ; $47EF: $C3 $12 $3B
 
-    ld   hl, wEntitiesSubstate1Table              ; $47F2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $47F2: $21 $B0 $C2
     add  hl, bc                                   ; $47F5: $09
     inc  [hl]                                     ; $47F6: $34
     ld   a, [hl]                                  ; $47F7: $7E
@@ -1625,7 +1625,7 @@ func_036_496E:
     ret                                           ; $497A: $C9
 
     call func_036_496E                            ; $497B: $CD $6E $49
-    ld   hl, wEntitiesSubstate1Table              ; $497E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $497E: $21 $B0 $C2
     add  hl, bc                                   ; $4981: $09
     ld   a, [hl]                                  ; $4982: $7E
     and  a                                        ; $4983: $A7
@@ -1693,7 +1693,7 @@ jr_036_49C6:
 
     jp   IncrementEntityState                     ; $49D7: $C3 $12 $3B
 
-    ld   hl, wEntitiesSubstate1Table              ; $49DA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $49DA: $21 $B0 $C2
     add  hl, bc                                   ; $49DD: $09
     ld   a, [hl]                                  ; $49DE: $7E
     and  a                                        ; $49DF: $A7
@@ -2259,7 +2259,7 @@ func_036_4D03:
     cp   $10                                      ; $4D08: $FE $10
     jr   nz, jr_036_4D13                          ; $4D0A: $20 $07
 
-    ld   hl, wEntitiesSubstate1Table              ; $4D0C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4D0C: $21 $B0 $C2
     add  hl, bc                                   ; $4D0F: $09
     ld   [hl], $00                                ; $4D10: $36 $00
     ret                                           ; $4D12: $C9
@@ -2274,7 +2274,7 @@ jr_036_4D13:
     call IsEntityUnknownFZero                     ; $4D1A: $CD $00 $0C
     ret  nz                                       ; $4D1D: $C0
 
-    ld   hl, wEntitiesSubstate2Table              ; $4D1E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4D1E: $21 $C0 $C2
     add  hl, bc                                   ; $4D21: $09
     ld   a, [hl]                                  ; $4D22: $7E
     and  a                                        ; $4D23: $A7
@@ -2374,7 +2374,7 @@ jr_036_4D89:
     ld   hl, wEntitiesUnknowTableF                ; $4DAA: $21 $F0 $C2
     add  hl, bc                                   ; $4DAD: $09
     ld   [hl], $60                                ; $4DAE: $36 $60
-    ld   hl, wEntitiesSubstate2Table              ; $4DB0: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4DB0: $21 $C0 $C2
     add  hl, bc                                   ; $4DB3: $09
     ld   [hl], $04                                ; $4DB4: $36 $04
     ret                                           ; $4DB6: $C9
@@ -2460,7 +2460,7 @@ jr_036_4E1B:
     and  a                                        ; $4E2F: $A7
     jr   z, jr_036_4E5C                           ; $4E30: $28 $2A
 
-    ld   hl, wEntitiesSubstate1Table              ; $4E32: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4E32: $21 $B0 $C2
     add  hl, bc                                   ; $4E35: $09
     cp   $02                                      ; $4E36: $FE $02
     jr   nc, jr_036_4E42                          ; $4E38: $30 $08
@@ -2682,7 +2682,7 @@ Func_036_4F68::
     push af                                       ; $4F6B: $F5
     ld   a, $36                                   ; $4F6C: $3E $36
     ld   [wCurrentBank], a                        ; $4F6E: $EA $AF $DB
-    ld   hl, wEntitiesSubstate2Table              ; $4F71: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4F71: $21 $C0 $C2
     add  hl, bc                                   ; $4F74: $09
     ld   a, [hl]                                  ; $4F75: $7E
     ld   hl, $6A20                                ; $4F76: $21 $20 $6A
@@ -2697,7 +2697,7 @@ jr_036_4F7F:
     call label_A5F                                ; $4F83: $CD $5F $0A
     ld   a, $02                                   ; $4F86: $3E $02
     call label_3DA0                               ; $4F88: $CD $A0 $3D
-    ld   hl, wEntitiesSubstate1Table              ; $4F8B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4F8B: $21 $B0 $C2
     add  hl, bc                                   ; $4F8E: $09
     ld   a, [hl]                                  ; $4F8F: $7E
     and  a                                        ; $4F90: $A7
@@ -2939,7 +2939,7 @@ func_036_50C9:
     ld   [wC16C], a                               ; $5105: $EA $6C $C1
     ld   [wTransitionSequenceCounter], a          ; $5108: $EA $6B $C1
     ld   [wActivePowerUp], a                      ; $510B: $EA $7C $D4
-    ld   hl, wEntitiesSubstate1Table              ; $510E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $510E: $21 $B0 $C2
     add  hl, bc                                   ; $5111: $09
     ld   [hl], a                                  ; $5112: $77
     call IncrementEntityState                     ; $5113: $CD $12 $3B
@@ -2951,7 +2951,7 @@ func_036_50C9:
 
     ld   a, [wC177]                               ; $511C: $FA $77 $C1
     and  a                                        ; $511F: $A7
-    ld   hl, wEntitiesSubstate2Table              ; $5120: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5120: $21 $C0 $C2
     add  hl, bc                                   ; $5123: $09
     ld   [hl], a                                  ; $5124: $77
     ld   e, $5D                                   ; $5125: $1E $5D
@@ -2974,7 +2974,7 @@ jr_036_512C:
     and  a                                        ; $513C: $A7
     jr   nz, jr_036_5148                          ; $513D: $20 $09
 
-    ld   hl, wEntitiesSubstate2Table              ; $513F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $513F: $21 $C0 $C2
     add  hl, bc                                   ; $5142: $09
     ld   a, [hl]                                  ; $5143: $7E
     call IncrementEntityState                     ; $5144: $CD $12 $3B
@@ -3010,10 +3010,10 @@ func_036_5153:
     ld   hl, wEntitiesPosYTable                         ; $5176: $21 $10 $C2
     add  hl, de                                   ; $5179: $19
     ld   [hl], a                                  ; $517A: $77
-    ld   hl, wEntitiesSubstate2Table              ; $517B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $517B: $21 $C0 $C2
     add  hl, bc                                   ; $517E: $09
     ld   a, [hl]                                  ; $517F: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $5180: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5180: $21 $C0 $C2
     add  hl, de                                   ; $5183: $19
     ld   [hl], a                                  ; $5184: $77
     call func_036_5153                            ; $5185: $CD $53 $51
@@ -3199,7 +3199,7 @@ jr_036_526E:
     ld   a, [hl]                                  ; $5282: $7E
     and  $7C                                      ; $5283: $E6 $7C
     ldh  [hScratch2], a                           ; $5285: $E0 $D9
-    ld   hl, wEntitiesSubstate2Table              ; $5287: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5287: $21 $C0 $C2
     add  hl, bc                                   ; $528A: $09
     ld   a, [hl]                                  ; $528B: $7E
     and  a                                        ; $528C: $A7
@@ -3236,7 +3236,7 @@ jr_036_5297:
     cp   $20                                      ; $52BB: $FE $20
     ret  nz                                       ; $52BD: $C0
 
-    ld   hl, wEntitiesSubstate2Table              ; $52BE: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $52BE: $21 $C0 $C2
     add  hl, bc                                   ; $52C1: $09
     ld   a, [hl]                                  ; $52C2: $7E
     inc  a                                        ; $52C3: $3C
@@ -3245,7 +3245,7 @@ jr_036_5297:
     add  hl, bc                                   ; $52CA: $09
     ld   e, [hl]                                  ; $52CB: $5E
     ld   d, $00                                   ; $52CC: $16 $00
-    ld   hl, wEntitiesSubstate1Table              ; $52CE: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $52CE: $21 $B0 $C2
     add  hl, de                                   ; $52D1: $19
     ld   [hl], $01                                ; $52D2: $36 $01
     call IncrementEntityState                     ; $52D4: $CD $12 $3B
@@ -3284,7 +3284,7 @@ jr_036_52F2:
     and  $03                                      ; $5308: $E6 $03
     ret  nz                                       ; $530A: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $530B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $530B: $21 $B0 $C2
     add  hl, bc                                   ; $530E: $09
     push hl                                       ; $530F: $E5
     ld   a, $36                                   ; $5310: $3E $36
@@ -3456,7 +3456,7 @@ jr_036_53AA:
     nop                                           ; $53BF: $00
     call func_036_5153                            ; $53C0: $CD $53 $51
     push bc                                       ; $53C3: $C5
-    ld   hl, wEntitiesSubstate1Table              ; $53C4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $53C4: $21 $B0 $C2
     add  hl, bc                                   ; $53C7: $09
     ld   c, [hl]                                  ; $53C8: $4E
     sla  c                                        ; $53C9: $CB $21
@@ -3487,7 +3487,7 @@ jr_036_53E6:
     ld   [hl], $00                                ; $53EC: $36 $00
     pop  bc                                       ; $53EE: $C1
     push bc                                       ; $53EF: $C5
-    ld   hl, wEntitiesSubstate1Table              ; $53F0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $53F0: $21 $B0 $C2
     add  hl, bc                                   ; $53F3: $09
     ld   c, [hl]                                  ; $53F4: $4E
     sla  c                                        ; $53F5: $CB $21
@@ -3515,7 +3515,7 @@ jr_036_5412:
 
     ld   [hl], $00                                ; $5418: $36 $00
     pop  bc                                       ; $541A: $C1
-    ld   hl, wEntitiesSubstate1Table              ; $541B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $541B: $21 $B0 $C2
     add  hl, bc                                   ; $541E: $09
     inc  [hl]                                     ; $541F: $34
     ld   a, [hl]                                  ; $5420: $7E
@@ -3723,7 +3723,7 @@ jr_036_5510:
     ret  z                                        ; $553B: $C8
 
     xor  a                                        ; $553C: $AF
-    ld   hl, wEntitiesSubstate1Table              ; $553D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $553D: $21 $B0 $C2
     add  hl, bc                                   ; $5540: $09
     ld   [hl], a                                  ; $5541: $77
     ld   a, $02                                   ; $5542: $3E $02
@@ -3798,7 +3798,7 @@ jr_036_5510:
     and  a                                        ; $55B4: $A7
     ret  nz                                       ; $55B5: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $55B6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $55B6: $21 $B0 $C2
     add  hl, bc                                   ; $55B9: $09
     ld   a, [hl]                                  ; $55BA: $7E
     and  a                                        ; $55BB: $A7
@@ -3887,7 +3887,7 @@ jr_036_5603:
     and  a                                        ; $5647: $A7
     jr   nz, jr_036_5652                          ; $5648: $20 $08
 
-    ld   hl, wEntitiesSubstate1Table              ; $564A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $564A: $21 $B0 $C2
     add  hl, bc                                   ; $564D: $09
     ld   [hl], $01                                ; $564E: $36 $01
     jr   jr_036_5673                              ; $5650: $18 $21
@@ -3967,7 +3967,7 @@ jr_036_5673:
     inc  b                                        ; $56B3: $04
 
 func_036_56B4:
-    ld   hl, wEntitiesSubstate2Table              ; $56B4: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $56B4: $21 $C0 $C2
     add  hl, bc                                   ; $56B7: $09
     inc  [hl]                                     ; $56B8: $34
     ld   a, [hl]                                  ; $56B9: $7E
@@ -4029,7 +4029,7 @@ func_036_56CD:
     ld   hl, wEntitiesSpriteVariantTable               ; $5709: $21 $B0 $C3
     add  hl, de                                   ; $570C: $19
     ld   [hl], a                                  ; $570D: $77
-    ld   hl, wEntitiesSubstate1Table              ; $570E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $570E: $21 $B0 $C2
     add  hl, de                                   ; $5711: $19
     ld   [hl], a                                  ; $5712: $77
     ld   hl, wEntitiesPhysicsFlagsTable                ; $5713: $21 $40 $C3
@@ -4112,7 +4112,7 @@ func_036_5779:
     ld   hl, wEntitiesUnknowTableT                ; $577A: $21 $10 $C4
     add  hl, bc                                   ; $577D: $09
     ld   [hl], a                                  ; $577E: $77
-    ld   hl, wEntitiesSubstate1Table              ; $577F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $577F: $21 $B0 $C2
     add  hl, bc                                   ; $5782: $09
     ld   [hl], a                                  ; $5783: $77
     ld   a, $20                                   ; $5784: $3E $20
@@ -4560,7 +4560,7 @@ jr_036_59B3:
     and  $10                                      ; $59E0: $E6 $10
     jr   z, jr_036_5A00                           ; $59E2: $28 $1C
 
-    ld   hl, wEntitiesSubstate1Table              ; $59E4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $59E4: $21 $B0 $C2
     add  hl, bc                                   ; $59E7: $09
     ld   a, $01                                   ; $59E8: $3E $01
     ld   [hl], a                                  ; $59EA: $77
@@ -4785,7 +4785,7 @@ jr_036_5B1C:
     call label_C56                                ; $5B25: $CD $56 $0C
     call label_3B39                               ; $5B28: $CD $39 $3B
     call func_036_6A62                            ; $5B2B: $CD $62 $6A
-    ld   hl, wEntitiesSubstate1Table              ; $5B2E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5B2E: $21 $B0 $C2
     add  hl, bc                                   ; $5B31: $09
     ldh  a, [hFrameCounter]                       ; $5B32: $F0 $E7
     and  $04                                      ; $5B34: $E6 $04
@@ -5073,7 +5073,7 @@ func_036_5CBD:
     ldh  [hLinkPositionXIncrement], a             ; $5CD7: $E0 $9A
     ld   a, $30                                   ; $5CD9: $3E $30
     call func_036_6C83                            ; $5CDB: $CD $83 $6C
-    ld   hl, wEntitiesSubstate2Table              ; $5CDE: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5CDE: $21 $C0 $C2
     add  hl, bc                                   ; $5CE1: $09
     ld   [hl], $06                                ; $5CE2: $36 $06
     ld   a, $08                                   ; $5CE4: $3E $08
@@ -5119,7 +5119,7 @@ func_036_5CBD:
     ld   [hl], $01                                ; $5D26: $36 $01
     call func_036_6BF8                            ; $5D28: $CD $F8 $6B
     ld   [hl], $18                                ; $5D2B: $36 $18
-    ld   hl, wEntitiesSubstate2Table              ; $5D2D: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5D2D: $21 $C0 $C2
     add  hl, bc                                   ; $5D30: $09
     ld   [hl], $00                                ; $5D31: $36 $00
     ld   a, $09                                   ; $5D33: $3E $09
@@ -5129,7 +5129,7 @@ func_036_5CBD:
 jr_036_5D39:
     ld   a, $20                                   ; $5D39: $3E $20
     call func_036_6C83                            ; $5D3B: $CD $83 $6C
-    ld   hl, wEntitiesSubstate1Table              ; $5D3E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5D3E: $21 $B0 $C2
     add  hl, bc                                   ; $5D41: $09
     ld   [hl], $06                                ; $5D42: $36 $06
     call func_036_6BFD                            ; $5D44: $CD $FD $6B
@@ -5166,7 +5166,7 @@ jr_036_5D65:
     call func_036_6C0D                            ; $5D77: $CD $0D $6C
     ld   a, $20                                   ; $5D7A: $3E $20
     call func_036_6C83                            ; $5D7C: $CD $83 $6C
-    ld   hl, wEntitiesSubstate1Table              ; $5D7F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5D7F: $21 $B0 $C2
     add  hl, bc                                   ; $5D82: $09
     dec  [hl]                                     ; $5D83: $35
     ld   a, [hl]                                  ; $5D84: $7E
@@ -5194,7 +5194,7 @@ jr_036_5D97:
     call func_036_6C0D                            ; $5DA7: $CD $0D $6C
     ld   a, $20                                   ; $5DAA: $3E $20
     call func_036_6C83                            ; $5DAC: $CD $83 $6C
-    ld   hl, wEntitiesSubstate1Table              ; $5DAF: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5DAF: $21 $B0 $C2
     add  hl, bc                                   ; $5DB2: $09
     dec  [hl]                                     ; $5DB3: $35
     ld   a, [hl]                                  ; $5DB4: $7E
@@ -5220,7 +5220,7 @@ jr_036_5DC2:
     call func_036_6C0D                            ; $5DD1: $CD $0D $6C
     ld   a, $20                                   ; $5DD4: $3E $20
     call func_036_6C83                            ; $5DD6: $CD $83 $6C
-    ld   hl, wEntitiesSubstate1Table              ; $5DD9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5DD9: $21 $B0 $C2
     add  hl, bc                                   ; $5DDC: $09
     dec  [hl]                                     ; $5DDD: $35
     ld   a, [hl]                                  ; $5DDE: $7E
@@ -5249,7 +5249,7 @@ jr_036_5DC2:
     call func_036_6C0D                            ; $5E01: $CD $0D $6C
     ld   a, $20                                   ; $5E04: $3E $20
     call func_036_6C83                            ; $5E06: $CD $83 $6C
-    ld   hl, wEntitiesSubstate1Table              ; $5E09: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5E09: $21 $B0 $C2
     add  hl, bc                                   ; $5E0C: $09
     dec  [hl]                                     ; $5E0D: $35
     ld   a, [hl]                                  ; $5E0E: $7E
@@ -5268,7 +5268,7 @@ jr_036_5DC2:
     call func_036_6C0D                            ; $5E20: $CD $0D $6C
     ld   a, $08                                   ; $5E23: $3E $08
     call func_036_6C83                            ; $5E25: $CD $83 $6C
-    ld   hl, wEntitiesSubstate2Table              ; $5E28: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5E28: $21 $C0 $C2
     add  hl, bc                                   ; $5E2B: $09
     dec  [hl]                                     ; $5E2C: $35
     ld   a, [hl]                                  ; $5E2D: $7E
@@ -5349,7 +5349,7 @@ jr_036_5E81:
     ld   a, $04                                   ; $5E99: $3E $04
     ld   [$C158], a                               ; $5E9B: $EA $58 $C1
     call func_036_5EC2                            ; $5E9E: $CD $C2 $5E
-    ld   hl, wEntitiesSubstate2Table              ; $5EA1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5EA1: $21 $C0 $C2
     add  hl, bc                                   ; $5EA4: $09
     ld   a, [hl]                                  ; $5EA5: $7E
     and  a                                        ; $5EA6: $A7
@@ -5744,13 +5744,13 @@ jr_036_60B2:
     ld   hl, $60B3                                ; $60C6: $21 $B3 $60
     add  hl, de                                   ; $60C9: $19
     ld   a, [hl]                                  ; $60CA: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $60CB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $60CB: $21 $B0 $C2
     add  hl, bc                                   ; $60CE: $09
     ld   [hl], a                                  ; $60CF: $77
     call func_036_6C23                            ; $60D0: $CD $23 $6C
     ld   a, [hl]                                  ; $60D3: $7E
     sub  $40                                      ; $60D4: $D6 $40
-    ld   hl, wEntitiesSubstate1Table              ; $60D6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $60D6: $21 $B0 $C2
     add  hl, bc                                   ; $60D9: $09
     bit  7, a                                     ; $60DA: $CB $7F
     jr   z, jr_036_60EC                           ; $60DC: $28 $0E
@@ -5796,13 +5796,13 @@ jr_036_6103:
     ld   hl, $60B3                                ; $610B: $21 $B3 $60
     add  hl, de                                   ; $610E: $19
     ld   a, [hl]                                  ; $610F: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $6110: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6110: $21 $C0 $C2
     add  hl, bc                                   ; $6113: $09
     ld   [hl], a                                  ; $6114: $77
     call func_036_6C28                            ; $6115: $CD $28 $6C
     ld   a, [hl]                                  ; $6118: $7E
     sub  $40                                      ; $6119: $D6 $40
-    ld   hl, wEntitiesSubstate2Table              ; $611B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $611B: $21 $C0 $C2
     add  hl, bc                                   ; $611E: $09
     bit  7, a                                     ; $611F: $CB $7F
     jr   z, jr_036_6131                           ; $6121: $28 $0E
@@ -5841,7 +5841,7 @@ jr_036_613D:
     and  $01                                      ; $6149: $E6 $01
     jr   z, jr_036_6181                           ; $614B: $28 $34
 
-    ld   hl, wEntitiesSubstate1Table              ; $614D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $614D: $21 $B0 $C2
     add  hl, bc                                   ; $6150: $09
     ld   a, [hl]                                  ; $6151: $7E
     ld   e, a                                     ; $6152: $5F
@@ -5857,7 +5857,7 @@ jr_036_613D:
     inc  [hl]                                     ; $615F: $34
 
 jr_036_6160:
-    ld   hl, wEntitiesSubstate2Table              ; $6160: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6160: $21 $C0 $C2
     add  hl, bc                                   ; $6163: $09
     ld   a, [hl]                                  ; $6164: $7E
     ld   d, a                                     ; $6165: $57
@@ -8402,7 +8402,7 @@ jr_036_6E57:
     add  hl, bc                                   ; $6E78: $09
     ld   [hl], a                                  ; $6E79: $77
     call label_3D8A                               ; $6E7A: $CD $8A $3D
-    ld   hl, wEntitiesSubstate1Table              ; $6E7D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6E7D: $21 $B0 $C2
     add  hl, bc                                   ; $6E80: $09
     ldh  a, [$FFB8]                               ; $6E81: $F0 $B8
     cp   [hl]                                     ; $6E83: $BE
@@ -8458,7 +8458,7 @@ jr_036_6EC8:
 
 jr_036_6ECD:
     ldh  a, [$FFB8]                               ; $6ECD: $F0 $B8
-    ld   hl, wEntitiesSubstate1Table              ; $6ECF: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6ECF: $21 $B0 $C2
     add  hl, bc                                   ; $6ED2: $09
     ld   [hl], a                                  ; $6ED3: $77
     ret                                           ; $6ED4: $C9
@@ -8480,7 +8480,7 @@ PiranhaPlantEntityHandler::
     ret  nz                                       ; $6EED: $C0
 
     call func_036_6A40                            ; $6EEE: $CD $40 $6A
-    ld   hl, wEntitiesSubstate2Table              ; $6EF1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6EF1: $21 $C0 $C2
     add  hl, bc                                   ; $6EF4: $09
     ld   a, [hl]                                  ; $6EF5: $7E
     and  a                                        ; $6EF6: $A7
@@ -8488,7 +8488,7 @@ PiranhaPlantEntityHandler::
 
     inc  [hl]                                     ; $6EF9: $34
     ldh  a, [$FFEF]                               ; $6EFA: $F0 $EF
-    ld   hl, wEntitiesSubstate1Table              ; $6EFC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6EFC: $21 $B0 $C2
     add  hl, bc                                   ; $6EFF: $09
     ld   [hl], a                                  ; $6F00: $77
 
@@ -8561,7 +8561,7 @@ jr_036_6F4C:
     ld   hl, $6F36                                ; $6F5B: $21 $36 $6F
     add  hl, de                                   ; $6F5E: $19
     ld   a, [hl]                                  ; $6F5F: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $6F60: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F60: $21 $B0 $C2
     add  hl, bc                                   ; $6F63: $09
     add  [hl]                                     ; $6F64: $86
     ld   hl, wEntitiesPosYTable                         ; $6F65: $21 $10 $C2
@@ -8625,7 +8625,7 @@ jr_036_6FA3:
     ld   hl, $6F8C                                ; $6FB2: $21 $8C $6F
     add  hl, de                                   ; $6FB5: $19
     ld   a, [hl]                                  ; $6FB6: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $6FB7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6FB7: $21 $B0 $C2
     add  hl, bc                                   ; $6FBA: $09
     add  [hl]                                     ; $6FBB: $86
     ld   hl, wEntitiesPosYTable                         ; $6FBC: $21 $10 $C2

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -16,7 +16,7 @@ Data_004_4B12::
   db   $08, $0C, $02, $0C                         ; $4B2A
 
 func_004_4B2E:
-    ld   hl, wEntitiesSubstate1Table              ; $4B2E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4B2E: $21 $B0 $C2
     add  hl, bc                                   ; $4B31: $09
     ld   a, [hl]                                  ; $4B32: $7E
     sla  a                                        ; $4B33: $CB $27
@@ -336,7 +336,7 @@ label_004_4E60:
     cp   $02                                      ; $4E68: $FE $02
     jr   nz, jr_004_4E83                          ; $4E6A: $20 $17
 
-    ld   hl, wEntitiesSubstate1Table              ; $4E6C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4E6C: $21 $B0 $C2
     add  hl, bc                                   ; $4E6F: $09
     ld   a, [hl]                                  ; $4E70: $7E
     and  a                                        ; $4E71: $A7
@@ -611,7 +611,7 @@ func_004_5067:
     jp   SetEntitySpriteVariant                   ; $506D: $C3 $0C $3B
 
 FacadeEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $5070: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5070: $21 $B0 $C2
     add  hl, bc                                   ; $5073: $09
     ld   a, [hl]                                  ; $5074: $7E
     JP_TABLE                                      ; $5075
@@ -846,14 +846,14 @@ jr_004_5202:
     call SpawnNewEntity_trampoline                ; $522C: $CD $86 $3B
     jr   c, jr_004_5273                           ; $522F: $38 $42
 
-    ld   hl, wEntitiesSubstate1Table              ; $5231: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5231: $21 $B0 $C2
     add  hl, de                                   ; $5234: $19
     ld   [hl], $01                                ; $5235: $36 $01
 
 jr_004_5237:
     call GetRandomByte                            ; $5237: $CD $0D $28
     and  $0F                                      ; $523A: $E6 $0F
-    ld   hl, wEntitiesSubstate2Table              ; $523C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $523C: $21 $C0 $C2
     add  hl, bc                                   ; $523F: $09
     cp   [hl]                                     ; $5240: $BE
     jr   z, jr_004_5237                           ; $5241: $28 $F4
@@ -904,7 +904,7 @@ jr_004_5273:
     call SpawnNewEntity_trampoline                ; $5285: $CD $86 $3B
     jr   c, jr_004_52C9                           ; $5288: $38 $3F
 
-    ld   hl, wEntitiesSubstate1Table              ; $528A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $528A: $21 $B0 $C2
     add  hl, de                                   ; $528D: $19
     ld   [hl], $02                                ; $528E: $36 $02
     push bc                                       ; $5290: $C5
@@ -965,7 +965,7 @@ jr_004_52C9:
     call SpawnNewEntity_trampoline                ; $52E7: $CD $86 $3B
     jr   c, jr_004_5340                           ; $52EA: $38 $54
 
-    ld   hl, wEntitiesSubstate1Table              ; $52EC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $52EC: $21 $B0 $C2
     add  hl, de                                   ; $52EF: $19
     ld   [hl], $03                                ; $52F0: $36 $03
     push bc                                       ; $52F2: $C5
@@ -1698,7 +1698,7 @@ jr_004_57C6:
     ldh  a, [wActiveEntityPosY]                   ; $57DC: $F0 $EC
     ld   [hl], a                                  ; $57DE: $77
     call func_004_5AE6                            ; $57DF: $CD $E6 $5A
-    ld   hl, wEntitiesSubstate1Table              ; $57E2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $57E2: $21 $B0 $C2
     add  hl, bc                                   ; $57E5: $09
     ld   e, [hl]                                  ; $57E6: $5E
     srl  e                                        ; $57E7: $CB $3B
@@ -2025,14 +2025,14 @@ jr_004_5AF1:
     ld   e, $0C                                   ; $5B0E: $1E $0C
 
 jr_004_5B10:
-    ld   hl, wEntitiesSubstate1Table              ; $5B10: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5B10: $21 $B0 $C2
     add  hl, bc                                   ; $5B13: $09
     ld   [hl], e                                  ; $5B14: $73
     call GetRandomByte                            ; $5B15: $CD $0D $28
     rra                                           ; $5B18: $1F
     jr   c, jr_004_5B23                           ; $5B19: $38 $08
 
-    ld   hl, wEntitiesSubstate2Table              ; $5B1B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5B1B: $21 $C0 $C2
     add  hl, bc                                   ; $5B1E: $09
     ld   a, [hl]                                  ; $5B1F: $7E
     cpl                                           ; $5B20: $2F
@@ -2055,15 +2055,15 @@ jr_004_5B28:
     ld   [hl], $06                                ; $5B35: $36 $06
 
 jr_004_5B37:
-    ld   hl, wEntitiesSubstate2Table              ; $5B37: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5B37: $21 $C0 $C2
     add  hl, bc                                   ; $5B3A: $09
     ld   a, [hl]                                  ; $5B3B: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $5B3C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5B3C: $21 $B0 $C2
     add  hl, bc                                   ; $5B3F: $09
     add  [hl]                                     ; $5B40: $86
     and  $0F                                      ; $5B41: $E6 $0F
     ld   [hl], a                                  ; $5B43: $77
-    ld   hl, wEntitiesSubstate1Table              ; $5B44: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5B44: $21 $B0 $C2
     add  hl, bc                                   ; $5B47: $09
     ld   e, [hl]                                  ; $5B48: $5E
     ld   d, b                                     ; $5B49: $50
@@ -2095,7 +2095,7 @@ jr_004_5B66:
     call GetRandomByte                            ; $5B73: $CD $0D $28
     and  $02                                      ; $5B76: $E6 $02
     dec  a                                        ; $5B78: $3D
-    ld   hl, wEntitiesSubstate2Table              ; $5B79: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5B79: $21 $C0 $C2
     add  hl, bc                                   ; $5B7C: $09
     ld   [hl], a                                  ; $5B7D: $77
 
@@ -2268,7 +2268,7 @@ func_004_5C63::
     add  $20                                      ; $5C82: $C6 $20
     ld   [hl], a                                  ; $5C84: $77
     and  $01                                      ; $5C85: $E6 $01
-    ld   hl, wEntitiesSubstate1Table              ; $5C87: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5C87: $21 $B0 $C2
     add  hl, bc                                   ; $5C8A: $09
     ld   [hl], a                                  ; $5C8B: $77
 
@@ -2281,7 +2281,7 @@ jr_004_5C8C:
     add  $18                                      ; $5C96: $C6 $18
     ld   [hl], a                                  ; $5C98: $77
     and  $01                                      ; $5C99: $E6 $01
-    ld   hl, wEntitiesSubstate2Table              ; $5C9B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5C9B: $21 $C0 $C2
     add  hl, bc                                   ; $5C9E: $09
     ld   [hl], a                                  ; $5C9F: $77
 
@@ -2291,7 +2291,7 @@ jr_004_5CA0:
     and  $03                                      ; $5CA3: $E6 $03
     jr   nz, jr_004_5D07                          ; $5CA5: $20 $60
 
-    ld   hl, wEntitiesSubstate1Table              ; $5CA7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5CA7: $21 $B0 $C2
     add  hl, bc                                   ; $5CAA: $09
     ldh  a, [wActiveEntityPosX]                               ; $5CAB: $F0 $EE
     cp   $28                                      ; $5CAD: $FE $28
@@ -2311,7 +2311,7 @@ jr_004_5CBB:
     ld   [hl], $20                                ; $5CBE: $36 $20
 
 jr_004_5CC0:
-    ld   hl, wEntitiesSubstate2Table              ; $5CC0: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5CC0: $21 $C0 $C2
     add  hl, bc                                   ; $5CC3: $09
     ldh  a, [wActiveEntityPosY]                               ; $5CC4: $F0 $EC
     cp   $28                                      ; $5CC6: $FE $28
@@ -2331,7 +2331,7 @@ jr_004_5CD4:
     ld   [hl], $20                                ; $5CD7: $36 $20
 
 jr_004_5CD9:
-    ld   hl, wEntitiesSubstate1Table              ; $5CD9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5CD9: $21 $B0 $C2
     add  hl, bc                                   ; $5CDC: $09
     ld   e, [hl]                                  ; $5CDD: $5E
     ld   d, b                                     ; $5CDE: $50
@@ -2349,7 +2349,7 @@ jr_004_5CD9:
 
 jr_004_5CEF:
     dec  [hl]                                     ; $5CEF: $35
-    ld   hl, wEntitiesSubstate2Table              ; $5CF0: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5CF0: $21 $C0 $C2
     add  hl, bc                                   ; $5CF3: $09
     ld   e, [hl]                                  ; $5CF4: $5E
     ld   d, b                                     ; $5CF5: $50
@@ -2831,7 +2831,7 @@ Data_004_604C::
     ldh  a, [$FF3E]                               ; $60A3: $F0 $3E
     ld   bc, $67EA                                ; $60A5: $01 $EA $67
     pop  bc                                       ; $60A8: $C1
-    ld   hl, wEntitiesSubstate1Table              ; $60A9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $60A9: $21 $B0 $C2
     add  hl, bc                                   ; $60AC: $09
     ld   a, [hl]                                  ; $60AD: $7E
     JP_TABLE                                      ; $60AE: $C7
@@ -2865,7 +2865,7 @@ Data_004_604C::
 
     ld   [bc], a                                  ; $60D1: $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $60D2: $E0 $A1
-    ld   hl, wEntitiesSubstate2Table              ; $60D4: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $60D4: $21 $C0 $C2
     add  hl, bc                                   ; $60D7: $09
     ld   a, [hl]                                  ; $60D8: $7E
     and  a                                        ; $60D9: $A7
@@ -2899,7 +2899,7 @@ jr_004_60E0:
     ld   hl, $60C5                                ; $6103: $21 $C5 $60
     add  hl, bc                                   ; $6106: $09
     ld   a, [hl]                                  ; $6107: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $6108: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6108: $21 $B0 $C2
     add  hl, de                                   ; $610B: $19
     ld   [hl], a                                  ; $610C: $77
     ld   hl, $60CA                                ; $610D: $21 $CA $60
@@ -2994,7 +2994,7 @@ jr_004_616C:
     ld   hl, wEntitiesSpeedYTable                                ; $619F: $21 $50 $C2
     add  hl, de                                   ; $61A2: $19
     ld   [hl], $FA                                ; $61A3: $36 $FA
-    ld   hl, wEntitiesSubstate1Table              ; $61A5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $61A5: $21 $B0 $C2
     add  hl, de                                   ; $61A8: $19
     ld   [hl], $01                                ; $61A9: $36 $01
     ld   hl, wEntitiesTransitionCountdownTable           ; $61AB: $21 $E0 $C2
@@ -3333,7 +3333,7 @@ jr_004_638A:
     and  a                                        ; $638F: $A7
     jr   z, jr_004_63A7                           ; $6390: $28 $15
 
-    ld   hl, wEntitiesSubstate1Table              ; $6392: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6392: $21 $B0 $C2
     add  hl, de                                   ; $6395: $19
     ld   a, [hl]                                  ; $6396: $7E
     cp   $02                                      ; $6397: $FE $02
@@ -3474,7 +3474,7 @@ label_004_644E:
     adc  c                                        ; $6461: $89
     ld   h, [hl]                                  ; $6462: $66
     call func_004_679B                            ; $6463: $CD $9B $67
-    ld   hl, wEntitiesSubstate1Table              ; $6466: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6466: $21 $B0 $C2
     add  hl, bc                                   ; $6469: $09
     ld   a, [hl]                                  ; $646A: $7E
     cp   $03                                      ; $646B: $FE $03
@@ -3518,7 +3518,7 @@ jr_004_6497:
     ldh  a, [hSwordIntersectedAreaY]                               ; $649A: $F0 $CD
     sbc  e                                        ; $649C: $9B
     ld   h, a                                     ; $649D: $67
-    ld   hl, wEntitiesSubstate1Table              ; $649E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $649E: $21 $B0 $C2
     add  hl, bc                                   ; $64A1: $09
     ld   a, [hl]                                  ; $64A2: $7E
     cp   $03                                      ; $64A3: $FE $03
@@ -3730,7 +3730,7 @@ jr_004_65DB:
     and  $30                                      ; $65DD: $E6 $30
     jr   z, jr_004_6631                           ; $65DF: $28 $50
 
-    ld   hl, wEntitiesSubstate1Table              ; $65E1: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $65E1: $21 $B0 $C2
     add  hl, bc                                   ; $65E4: $09
     ld   a, [hl]                                  ; $65E5: $7E
     cp   $03                                      ; $65E6: $FE $03
@@ -3900,7 +3900,7 @@ jr_004_66DC:
     jr   jr_004_66FE                              ; $66E4: $18 $18
 
 jr_004_66E6:
-    ld   hl, wEntitiesSubstate1Table              ; $66E6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $66E6: $21 $B0 $C2
     add  hl, bc                                   ; $66E9: $09
     ld   a, [hl]                                  ; $66EA: $7E
     cp   $03                                      ; $66EB: $FE $03
@@ -4498,7 +4498,7 @@ label_004_6A2B:
     cp   [hl]                                     ; $6A56: $BE
     jr   nz, jr_004_6A67                          ; $6A57: $20 $0E
 
-    ld   hl, wEntitiesSubstate1Table              ; $6A59: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6A59: $21 $B0 $C2
     add  hl, bc                                   ; $6A5C: $09
     ld   [hl], $38                                ; $6A5D: $36 $38
     ld   hl, wEntitiesUnknowTableP                ; $6A5F: $21 $40 $C4
@@ -4510,7 +4510,7 @@ jr_004_6A67:
     jp   label_004_6A2B                           ; $6A67: $C3 $2B $6A
 
     call func_004_6E1D                            ; $6A6A: $CD $1D $6E
-    ld   hl, wEntitiesSubstate1Table              ; $6A6D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6A6D: $21 $B0 $C2
     add  hl, bc                                   ; $6A70: $09
     dec  [hl]                                     ; $6A71: $35
     dec  [hl]                                     ; $6A72: $35
@@ -4687,7 +4687,7 @@ jr_004_6B51:
     and  a                                        ; $6B60: $A7
     ret  z                                        ; $6B61: $C8
 
-    ld   hl, wEntitiesSubstate1Table              ; $6B62: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6B62: $21 $B0 $C2
     add  hl, bc                                   ; $6B65: $09
     ld   a, [hl]                                  ; $6B66: $7E
     and  $80                                      ; $6B67: $E6 $80
@@ -4793,7 +4793,7 @@ func_004_6BE1:
     cp   $01                                      ; $6C0C: $FE $01
     ret  nz                                       ; $6C0E: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $6C0F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6C0F: $21 $B0 $C2
     add  hl, bc                                   ; $6C12: $09
     ld   a, [hl]                                  ; $6C13: $7E
     cpl                                           ; $6C14: $2F
@@ -4940,7 +4940,7 @@ jr_004_6CB4:
     ld   hl, wEntitiesStateTable                  ; $6CE4: $21 $90 $C2
     add  hl, de                                   ; $6CE7: $19
     ld   [hl], $01                                ; $6CE8: $36 $01
-    ld   hl, wEntitiesSubstate1Table              ; $6CEA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6CEA: $21 $B0 $C2
     add  hl, de                                   ; $6CED: $19
     ld   [hl], c                                  ; $6CEE: $71
     ld   hl, wEntitiesPhysicsFlagsTable                ; $6CEF: $21 $40 $C3
@@ -4993,7 +4993,7 @@ label_004_6D0F:
     and  a                                        ; $6D39: $A7
     jr   nz, jr_004_6D5C                          ; $6D3A: $20 $20
 
-    ld   hl, wEntitiesSubstate1Table              ; $6D3C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6D3C: $21 $B0 $C2
     add  hl, bc                                   ; $6D3F: $09
     ld   e, [hl]                                  ; $6D40: $5E
     ld   d, b                                     ; $6D41: $50
@@ -5166,13 +5166,13 @@ func_004_6E03:
     jr   jr_004_6DEF                              ; $6E1B: $18 $D2
 
 func_004_6E1D:
-    ld   hl, wEntitiesSubstate1Table              ; $6E1D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6E1D: $21 $B0 $C2
     add  hl, bc                                   ; $6E20: $09
     ld   a, [hl]                                  ; $6E21: $7E
     push af                                       ; $6E22: $F5
     swap a                                        ; $6E23: $CB $37
     and  $F0                                      ; $6E25: $E6 $F0
-    ld   hl, wEntitiesSubstate2Table              ; $6E27: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6E27: $21 $C0 $C2
     add  hl, bc                                   ; $6E2A: $09
     add  [hl]                                     ; $6E2B: $86
     ld   [hl], a                                  ; $6E2C: $77
@@ -5265,7 +5265,7 @@ jr_004_6E8A:
     ret                                           ; $6E91: $C9
 
 func_004_6E92:
-    ld   hl, wEntitiesSubstate1Table              ; $6E92: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6E92: $21 $B0 $C2
     add  hl, bc                                   ; $6E95: $09
     ld   a, [hl]                                  ; $6E96: $7E
     and  a                                        ; $6E97: $A7
@@ -5395,7 +5395,7 @@ jr_004_6F3C:
     ld   a, $4F                                   ; $6F3D: $3E $4F
     ld   e, $0E                                   ; $6F3F: $1E $0E
     call SpawnNewEntityInRange_trampoline         ; $6F41: $CD $98 $3B
-    ld   hl, wEntitiesSubstate1Table              ; $6F44: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F44: $21 $B0 $C2
     add  hl, de                                   ; $6F47: $19
     ld   [hl], $01                                ; $6F48: $36 $01
     ld   hl, $6F09                                ; $6F4A: $21 $09 $6F
@@ -6023,7 +6023,7 @@ jr_004_7274:
 
     ld   hl, $D201                                ; $7300: $21 $01 $D2
     ld   [hl], $02                                ; $7303: $36 $02
-    ld   hl, wEntitiesSubstate2Table              ; $7305: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7305: $21 $C0 $C2
     add  hl, bc                                   ; $7308: $09
     ld   a, [hl]                                  ; $7309: $7E
     and  a                                        ; $730A: $A7
@@ -6078,7 +6078,7 @@ label_004_7332:
     ld   hl, $C3B0                                ; $7354: $21 $B0 $C3
     add  hl, de                                   ; $7357: $19
     ld   [hl], $06                                ; $7358: $36 $06
-    ld   hl, wEntitiesSubstate1Table              ; $735A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $735A: $21 $B0 $C2
     add  hl, de                                   ; $735D: $19
     inc  [hl]                                     ; $735E: $34
 
@@ -6127,7 +6127,7 @@ jr_004_7362:
     ld   [hl], $01                                ; $739D: $36 $01
     ld   a, e                                     ; $739F: $7B
     inc  a                                        ; $73A0: $3C
-    ld   hl, wEntitiesSubstate2Table              ; $73A1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $73A1: $21 $C0 $C2
     add  hl, bc                                   ; $73A4: $09
     ld   [hl], a                                  ; $73A5: $77
     call IsEntityUnknownFZero                                ; $73A6: $CD $00 $0C
@@ -6145,7 +6145,7 @@ jr_004_73B0:
     ret                                           ; $73B6: $C9
 
 func_004_73B7:
-    ld   hl, wEntitiesSubstate2Table              ; $73B7: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $73B7: $21 $C0 $C2
     add  hl, bc                                   ; $73BA: $09
     ld   a, [hl]                                  ; $73BB: $7E
     and  a                                        ; $73BC: $A7

--- a/src/code/entities/bank5.asm
+++ b/src/code/entities/bank5.asm
@@ -94,7 +94,7 @@ func_005_40AF:
     ld   a, [hl]                                  ; $40B3: $7E
     add  $04                                      ; $40B4: $C6 $04
     ld   [hl], a                                  ; $40B6: $77
-    ld   hl, wEntitiesSubstate1Table              ; $40B7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $40B7: $21 $B0 $C2
     add  hl, bc                                   ; $40BA: $09
     ld   [hl], a                                  ; $40BB: $77
     ld   e, $10                                   ; $40BC: $1E $10
@@ -110,7 +110,7 @@ jr_005_40C1:
     ld   a, [hl]                                  ; $40C9: $7E
     add  $08                                      ; $40CA: $C6 $08
     ld   [hl], a                                  ; $40CC: $77
-    ld   hl, wEntitiesSubstate2Table              ; $40CD: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $40CD: $21 $C0 $C2
     add  hl, bc                                   ; $40D0: $09
     ld   [hl], a                                  ; $40D1: $77
     ld   hl, wEntitiesPosZTable                   ; $40D2: $21 $10 $C3
@@ -173,20 +173,20 @@ jr_005_4127:
 
 jr_005_4129:
     ldh  a, [hScratch0]                           ; $4129: $F0 $D7
-    ld   hl, wEntitiesSubstate1Table              ; $412B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $412B: $21 $B0 $C2
     add  hl, bc                                   ; $412E: $09
     ld   [hl], a                                  ; $412F: $77
     ldh  a, [hScratch1]                           ; $4130: $F0 $D8
-    ld   hl, wEntitiesSubstate2Table              ; $4132: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4132: $21 $C0 $C2
     add  hl, bc                                   ; $4135: $09
     ld   [hl], a                                  ; $4136: $77
 
 jr_005_4137:
-    ld   hl, wEntitiesSubstate1Table              ; $4137: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4137: $21 $B0 $C2
     add  hl, bc                                   ; $413A: $09
     ld   a, [hl]                                  ; $413B: $7E
     ld   [$D150], a                               ; $413C: $EA $50 $D1
-    ld   hl, wEntitiesSubstate2Table              ; $413F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $413F: $21 $C0 $C2
     add  hl, bc                                   ; $4142: $09
     ld   a, [hl]                                  ; $4143: $7E
     ld   [$D151], a                               ; $4144: $EA $51 $D1
@@ -341,7 +341,7 @@ jr_005_4227:
 
 func_005_4228:
     ld   e, $01                                   ; $4228: $1E $01
-    ld   hl, wEntitiesSubstate1Table              ; $422A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $422A: $21 $B0 $C2
     add  hl, bc                                   ; $422D: $09
     ld   a, [hl]                                  ; $422E: $7E
     ld   hl, wEntitiesPosXTable                   ; $422F: $21 $00 $C2
@@ -356,7 +356,7 @@ func_005_4228:
     inc  e                                        ; $423D: $1C
 
 jr_005_423E:
-    ld   hl, wEntitiesSubstate2Table              ; $423E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $423E: $21 $C0 $C2
     add  hl, bc                                   ; $4241: $09
     ld   a, [hl]                                  ; $4242: $7E
     ld   hl, wEntitiesPosYTable                   ; $4243: $21 $10 $C2
@@ -706,11 +706,11 @@ func_005_43FE:
     or   [hl]                                     ; $440F: $B6
     jp   z, jr_005_44CA                           ; $4410: $CA $CA $44
 
-    ld   hl, wEntitiesSubstate1Table              ; $4413: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4413: $21 $B0 $C2
     add  hl, bc                                   ; $4416: $09
     ld   a, [hl]                                  ; $4417: $7E
     ld   [$D106], a                               ; $4418: $EA $06 $D1
-    ld   hl, wEntitiesSubstate2Table              ; $441B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $441B: $21 $C0 $C2
     add  hl, bc                                   ; $441E: $09
     ld   a, [hl]                                  ; $441F: $7E
     ld   [$D116], a                               ; $4420: $EA $16 $D1
@@ -1020,7 +1020,7 @@ jr_005_45A8:
     call_open_dialog $08F                         ; $45A8
 
 jr_005_45AD:
-    ld   hl, wEntitiesSubstate1Table              ; $45AD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $45AD: $21 $B0 $C2
     add  hl, bc                                   ; $45B0: $09
     ld   a, [hl]                                  ; $45B1: $7E
     cp   $23                                      ; $45B2: $FE $23
@@ -1213,7 +1213,7 @@ jr_005_46D2:
 jr_005_46E9:
     xor  $01                                      ; $46E9: $EE $01
     ld   [hl], a                                  ; $46EB: $77
-    ld   hl, wEntitiesSubstate1Table              ; $46EC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $46EC: $21 $B0 $C2
     add  hl, bc                                   ; $46EF: $09
     ld   a, [hl]                                  ; $46F0: $7E
     cp   $23                                      ; $46F1: $FE $23
@@ -1678,7 +1678,7 @@ func_005_4A17:
     ld   hl, wEntitiesUnknownTableD               ; $4A2C: $21 $D0 $C2
     add  hl, bc                                   ; $4A2F: $09
     ld   e, [hl]                                  ; $4A30: $5E
-    ld   hl, wEntitiesSubstate2Table              ; $4A31: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4A31: $21 $C0 $C2
     add  hl, bc                                   ; $4A34: $09
     ld   a, [hl]                                  ; $4A35: $7E
     add  e                                        ; $4A36: $83
@@ -1914,7 +1914,7 @@ func_005_4B41:
     cp   $24                                      ; $4B7C: $FE $24
     jr   nc, jr_005_4B86                          ; $4B7E: $30 $06
 
-    ld   hl, wEntitiesSubstate1Table              ; $4B80: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4B80: $21 $B0 $C2
     add  hl, bc                                   ; $4B83: $09
     ld   [hl], $80                                ; $4B84: $36 $80
 
@@ -1946,7 +1946,7 @@ jr_005_4B9D:
     call SetEntitySpriteVariant                   ; $4BA8: $CD $0C $3B
 
 jr_005_4BAB:
-    ld   hl, wEntitiesSubstate1Table              ; $4BAB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4BAB: $21 $B0 $C2
     add  hl, bc                                   ; $4BAE: $09
     ld   a, [hl]                                  ; $4BAF: $7E
     and  a                                        ; $4BB0: $A7
@@ -1964,7 +1964,7 @@ Data_005_4BBF::
     db   $78, $00
 
 label_005_4BC1:
-    ld   hl, wEntitiesSubstate2Table              ; $4BC1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4BC1: $21 $C0 $C2
     add  hl, bc                                   ; $4BC4: $09
     ld   a, [hl]                                  ; $4BC5: $7E
     and  a                                        ; $4BC6: $A7
@@ -2262,7 +2262,7 @@ jr_005_4D5D:
     ld   hl, wEntitiesPosYTable                   ; $4D79: $21 $10 $C2
     add  hl, de                                   ; $4D7C: $19
     ld   [hl], a                                  ; $4D7D: $77
-    ld   hl, wEntitiesSubstate2Table              ; $4D7E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4D7E: $21 $C0 $C2
     add  hl, de                                   ; $4D81: $19
     ld   [hl], $01                                ; $4D82: $36 $01
     ld   hl, wEntitiesSpeedXTable                 ; $4D84: $21 $40 $C2
@@ -3558,7 +3558,7 @@ func_005_5584:
     jr   z, @+$3C                                 ; $558E: $28 $3A
 
     ld   [$C1C6], a                               ; $5590: $EA $C6 $C1
-    ld   hl, wEntitiesSubstate2Table              ; $5593: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5593: $21 $C0 $C2
     add  hl, bc                                   ; $5596: $09
     ld   a, [hl]                                  ; $5597: $7E
     JP_TABLE                                      ; $5598
@@ -3789,7 +3789,7 @@ func_005_56F9::
     call GetRandomByte                            ; $5706: $CD $0D $28
     and  $1F                                      ; $5709: $E6 $1F
     add  $60                                      ; $570B: $C6 $60
-    ld   hl, wEntitiesSubstate1Table              ; $570D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $570D: $21 $B0 $C2
     add  hl, bc                                   ; $5710: $09
     ld   [hl], a                                  ; $5711: $77
     ret                                           ; $5712: $C9
@@ -3867,7 +3867,7 @@ func_005_576E:
     add  hl, bc                                   ; $577D: $09
     ld   [hl], $20                                ; $577E: $36 $20
     call func_005_7ABE                            ; $5780: $CD $BE $7A
-    ld   hl, wEntitiesSubstate1Table              ; $5783: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5783: $21 $B0 $C2
     add  hl, bc                                   ; $5786: $09
     ldh  a, [wActiveEntityPosX]                   ; $5787: $F0 $EE
     cp   [hl]                                     ; $5789: $BE
@@ -4166,7 +4166,7 @@ Data_005_5A7D::
     db   $C9, $10, $F0
 
 EvilEagleEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $5A80: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5A80: $21 $B0 $C2
     add  hl, bc                                   ; $5A83: $09
     ld   a, [hl]                                  ; $5A84: $7E
     JP_TABLE                                      ; $5A85
@@ -4215,7 +4215,7 @@ jr_005_5AA7:
     add  hl, de                                   ; $5AC5: $19
     ld   [hl], a                                  ; $5AC6: $77
     pop  bc                                       ; $5AC7: $C1
-    ld   hl, wEntitiesSubstate1Table              ; $5AC8: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5AC8: $21 $B0 $C2
     add  hl, de                                   ; $5ACB: $19
     ld   [hl], $02                                ; $5ACC: $36 $02
     ldh  a, [hFFE8]                               ; $5ACE: $F0 $E8
@@ -4263,7 +4263,7 @@ func_005_5B03:
     ld   hl, wEntitiesPosYTable                   ; $5B14: $21 $10 $C2
     add  hl, de                                   ; $5B17: $19
     ld   [hl], $18                                ; $5B18: $36 $18
-    ld   hl, wEntitiesSubstate1Table              ; $5B1A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5B1A: $21 $B0 $C2
     add  hl, de                                   ; $5B1D: $19
     ld   [hl], $01                                ; $5B1E: $36 $01
     ld   hl, wEntitiesSpeedXTable                 ; $5B20: $21 $40 $C2
@@ -4406,7 +4406,7 @@ func_005_5BEC:
     ld   a, [hl]                                  ; $5C09: $7E
     xor  $04                                      ; $5C0A: $EE $04
     ld   [hl], a                                  ; $5C0C: $77
-    ld   hl, wEntitiesSubstate2Table              ; $5C0D: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5C0D: $21 $C0 $C2
     add  hl, bc                                   ; $5C10: $09
     inc  [hl]                                     ; $5C11: $34
     ld   a, [hl]                                  ; $5C12: $7E
@@ -4900,7 +4900,7 @@ jr_005_5EB0:
     call SpawnNewEntityInRange_trampoline         ; $5EC4: $CD $98 $3B
     jr   c, jr_005_5F2F                           ; $5EC7: $38 $66
 
-    ld   hl, wEntitiesSubstate1Table              ; $5EC9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5EC9: $21 $B0 $C2
     add  hl, de                                   ; $5ECC: $19
     ld   [hl], $03                                ; $5ECD: $36 $03
     push bc                                       ; $5ECF: $C5
@@ -5413,7 +5413,7 @@ func_005_6302:
 HotHeadEntityHandler::
     call label_394D                               ; $6314: $CD $4D $39
     call label_3EE8                               ; $6317: $CD $E8 $3E
-    ld   hl, wEntitiesSubstate1Table              ; $631A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $631A: $21 $B0 $C2
     add  hl, bc                                   ; $631D: $09
     ld   a, [hl]                                  ; $631E: $7E
     and  a                                        ; $631F: $A7
@@ -5433,7 +5433,7 @@ jr_005_632F:
     cp   $01                                      ; $6334: $FE $01
     jr   nz, jr_005_6375                          ; $6336: $20 $3D
 
-    ld   hl, wEntitiesSubstate2Table              ; $6338: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6338: $21 $C0 $C2
     add  hl, bc                                   ; $633B: $09
     ld   a, [hl]                                  ; $633C: $7E
     JP_TABLE                                      ; $633D
@@ -5445,7 +5445,7 @@ func_005_6342:
     ld   [hl], $FF                                ; $6345: $36 $FF
 
 label_005_6347:
-    ld   hl, wEntitiesSubstate2Table              ; $6347: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6347: $21 $C0 $C2
     add  hl, bc                                   ; $634A: $09
     inc  [hl]                                     ; $634B: $34
     ret                                           ; $634C: $C9
@@ -5832,7 +5832,7 @@ jr_005_6581:
     call SpawnNewEntity_trampoline                ; $6585: $CD $86 $3B
     jr   c, jr_005_65D3                           ; $6588: $38 $49
 
-    ld   hl, wEntitiesSubstate1Table              ; $658A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $658A: $21 $B0 $C2
     add  hl, de                                   ; $658D: $19
     ld   [hl], $03                                ; $658E: $36 $03
     push bc                                       ; $6590: $C5
@@ -5887,7 +5887,7 @@ func_005_65D9:
     call SpawnNewEntity_trampoline                ; $65DB: $CD $86 $3B
     jr   c, @+$22                                 ; $65DE: $38 $20
 
-    ld   hl, wEntitiesSubstate1Table              ; $65E0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $65E0: $21 $B0 $C2
     add  hl, de                                   ; $65E3: $19
     ld   [hl], $01                                ; $65E4: $36 $01
     ldh  a, [hScratch0]                           ; $65E6: $F0 $D7
@@ -5926,7 +5926,7 @@ jr_005_6613:
     call SpawnNewEntity_trampoline                ; $6617: $CD $86 $3B
     jr   c, jr_005_665F                           ; $661A: $38 $43
 
-    ld   hl, wEntitiesSubstate1Table              ; $661C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $661C: $21 $B0 $C2
     add  hl, de                                   ; $661F: $19
     ld   [hl], $02                                ; $6620: $36 $02
     push bc                                       ; $6622: $C5
@@ -6151,7 +6151,7 @@ label_005_67EA:
     ld   [hl], a                                  ; $6807: $77
     call GetEntityTransitionCountdown             ; $6808: $CD $05 $0C
     ld   [hl], $0F                                ; $680B: $36 $0F
-    ld   hl, wEntitiesSubstate1Table              ; $680D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $680D: $21 $B0 $C2
     add  hl, bc                                   ; $6810: $09
     ld   [hl], $02                                ; $6811: $36 $02
     ld   a, $FF                                   ; $6813: $3E $FF
@@ -6264,13 +6264,13 @@ jr_005_689B:
     ld   hl, Data_005_6867                        ; $68AE: $21 $67 $68
     add  hl, de                                   ; $68B1: $19
     ld   a, [hl]                                  ; $68B2: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $68B3: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $68B3: $21 $B0 $C2
     add  hl, bc                                   ; $68B6: $09
     ld   [hl], a                                  ; $68B7: $77
     ld   hl, Data_005_686B                        ; $68B8: $21 $6B $68
     add  hl, de                                   ; $68BB: $19
     ld   a, [hl]                                  ; $68BC: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $68BD: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $68BD: $21 $C0 $C2
     add  hl, bc                                   ; $68C0: $09
     ld   [hl], a                                  ; $68C1: $77
     ld   hl, wEntitiesLoadOrderTable              ; $68C2: $21 $60 $C4
@@ -6546,7 +6546,7 @@ func_005_6A5F:
     ld   hl, wEntitiesLoadOrderTable              ; $6A67: $21 $60 $C4
     add  hl, bc                                   ; $6A6A: $09
     ld   e, [hl]                                  ; $6A6B: $5E
-    ld   hl, wEntitiesSubstate1Table              ; $6A6C: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6A6C: $21 $B0 $C2
     add  hl, bc                                   ; $6A6F: $09
     ld   c, [hl]                                  ; $6A70: $4E
     sla  e                                        ; $6A71: $CB $23
@@ -6591,7 +6591,7 @@ func_005_6AA5:
     ld   hl, wEntitiesLoadOrderTable              ; $6AAD: $21 $60 $C4
     add  hl, bc                                   ; $6AB0: $09
     ld   e, [hl]                                  ; $6AB1: $5E
-    ld   hl, wEntitiesSubstate2Table              ; $6AB2: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6AB2: $21 $C0 $C2
     add  hl, bc                                   ; $6AB5: $09
     ld   c, [hl]                                  ; $6AB6: $4E
     sla  e                                        ; $6AB7: $CB $23
@@ -6736,7 +6736,7 @@ SlimeEelEntityHandler::
     call label_394D                               ; $6CDC: $CD $4D $39
     call label_3EE8                               ; $6CDF: $CD $E8 $3E
     call label_C56                                ; $6CE2: $CD $56 $0C
-    ld   hl, wEntitiesSubstate1Table              ; $6CE5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6CE5: $21 $B0 $C2
     add  hl, bc                                   ; $6CE8: $09
     ld   a, [hl]                                  ; $6CE9: $7E
     JP_TABLE                                      ; $6CEA
@@ -7084,7 +7084,7 @@ jr_005_6EB0:
     ld   [$D788], a                               ; $6F31: $EA $88 $D7
     ld   a, $5D                                   ; $6F34: $3E $5D
     call SpawnNewEntity_trampoline                ; $6F36: $CD $86 $3B
-    ld   hl, wEntitiesSubstate1Table              ; $6F39: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F39: $21 $B0 $C2
     add  hl, de                                   ; $6F3C: $19
     ld   [hl], $01                                ; $6F3D: $36 $01
     ld   hl, wEntitiesPosXTable                   ; $6F3F: $21 $00 $C2
@@ -7341,7 +7341,7 @@ jr_005_70F6:
     ld   hl, wEntitiesSpriteVariantTable          ; $7109: $21 $B0 $C3
     add  hl, de                                   ; $710C: $19
     ld   [hl], $FF                                ; $710D: $36 $FF
-    ld   hl, wEntitiesSubstate1Table              ; $710F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $710F: $21 $B0 $C2
     add  hl, de                                   ; $7112: $19
     ld   [hl], $01                                ; $7113: $36 $01
     ld   hl, wEntitiesStateTable                  ; $7115: $21 $90 $C2
@@ -7357,7 +7357,7 @@ jr_005_70F6:
     ld   hl, wEntitiesPosXTable                   ; $7127: $21 $00 $C2
     add  hl, de                                   ; $712A: $19
     ld   [hl], a                                  ; $712B: $77
-    ld   hl, wEntitiesSubstate2Table              ; $712C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $712C: $21 $C0 $C2
     add  hl, de                                   ; $712F: $19
     ld   [hl], a                                  ; $7130: $77
     ld   hl, Data_005_70E3                        ; $7131: $21 $E3 $70
@@ -7413,7 +7413,7 @@ jr_005_7167:
     ld   hl, wEntitiesUnknowTableR                ; $717A: $21 $90 $C3
     add  hl, bc                                   ; $717D: $09
     ld   e, [hl]                                  ; $717E: $5E
-    ld   hl, wEntitiesSubstate2Table              ; $717F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $717F: $21 $C0 $C2
     add  hl, bc                                   ; $7182: $09
     ld   a, [hl]                                  ; $7183: $7E
     add  e                                        ; $7184: $83
@@ -7448,7 +7448,7 @@ jr_005_719A:
     ld   hl, Data_005_7051                        ; $71AC: $21 $51 $70
     add  hl, de                                   ; $71AF: $19
     ld   a, [hl]                                  ; $71B0: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $71B1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $71B1: $21 $C0 $C2
     add  hl, bc                                   ; $71B4: $09
     add  [hl]                                     ; $71B5: $86
     and  $1F                                      ; $71B6: $E6 $1F
@@ -7474,7 +7474,7 @@ jr_005_719A:
     ld   hl, Data_005_7071                        ; $71D4: $21 $71 $70
     add  hl, de                                   ; $71D7: $19
     ld   a, [hl]                                  ; $71D8: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $71D9: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $71D9: $21 $C0 $C2
     add  hl, bc                                   ; $71DC: $09
     add  [hl]                                     ; $71DD: $86
     and  $1F                                      ; $71DE: $E6 $1F
@@ -7505,7 +7505,7 @@ jr_005_719A:
     ld   hl, Data_005_7091                        ; $7203: $21 $91 $70
     add  hl, de                                   ; $7206: $19
     ld   a, [hl]                                  ; $7207: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $7208: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7208: $21 $C0 $C2
     add  hl, bc                                   ; $720B: $09
     add  [hl]                                     ; $720C: $86
     and  $1F                                      ; $720D: $E6 $1F
@@ -7537,7 +7537,7 @@ jr_005_719A:
     ld   hl, Data_005_70B1                        ; $7233: $21 $B1 $70
     add  hl, de                                   ; $7236: $19
     ld   a, [hl]                                  ; $7237: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $7238: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7238: $21 $C0 $C2
     add  hl, bc                                   ; $723B: $09
     add  [hl]                                     ; $723C: $86
     and  $1F                                      ; $723D: $E6 $1F
@@ -7564,7 +7564,7 @@ jr_005_719A:
     pop  de                                       ; $725A: $D1
     ld   a, $01                                   ; $725B: $3E $01
     call func_005_7283                            ; $725D: $CD $83 $72
-    ld   hl, wEntitiesSubstate2Table              ; $7260: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7260: $21 $C0 $C2
     add  hl, bc                                   ; $7263: $09
     ld   e, [hl]                                  ; $7264: $5E
     ld   d, b                                     ; $7265: $50
@@ -7799,7 +7799,7 @@ jr_005_7395:
     and  $01                                      ; $73E2: $E6 $01
     jr   nz, jr_005_7414                          ; $73E4: $20 $2E
 
-    ld   hl, wEntitiesSubstate1Table              ; $73E6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $73E6: $21 $B0 $C2
     add  hl, bc                                   ; $73E9: $09
     ld   [hl], $02                                ; $73EA: $36 $02
     call label_BFB                                ; $73EC: $CD $FB $0B
@@ -7930,7 +7930,7 @@ jr_005_74C5:
     call SetEntitySpriteVariant                   ; $74C5: $CD $0C $3B
     ldh  a, [hLinkPositionX]                      ; $74C8: $F0 $98
     push af                                       ; $74CA: $F5
-    ld   hl, wEntitiesSubstate2Table              ; $74CB: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $74CB: $21 $C0 $C2
     add  hl, bc                                   ; $74CE: $09
     ld   a, [hl]                                  ; $74CF: $7E
     ldh  [hLinkPositionX], a                      ; $74D0: $E0 $98
@@ -8290,7 +8290,7 @@ func_005_7702:
     rra                                           ; $7716: $1F
     jr   c, jr_005_7721                           ; $7717: $38 $08
 
-    ld   hl, wEntitiesSubstate2Table              ; $7719: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7719: $21 $C0 $C2
     add  hl, bc                                   ; $771C: $09
     ld   a, [hl]                                  ; $771D: $7E
     cpl                                           ; $771E: $2F
@@ -8312,7 +8312,7 @@ jr_005_7730:
     jr   nz, jr_005_775E                          ; $7733: $20 $29
 
     ld   [hl], $04                                ; $7735: $36 $04
-    ld   hl, wEntitiesSubstate2Table              ; $7737: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7737: $21 $C0 $C2
     add  hl, bc                                   ; $773A: $09
     ld   a, [hl]                                  ; $773B: $7E
     ld   hl, wEntitiesStateTable                  ; $773C: $21 $90 $C2
@@ -8348,7 +8348,7 @@ jr_005_775E:
     call GetRandomByte                            ; $776B: $CD $0D $28
     and  $02                                      ; $776E: $E6 $02
     dec  a                                        ; $7770: $3D
-    ld   hl, wEntitiesSubstate2Table              ; $7771: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7771: $21 $C0 $C2
     add  hl, bc                                   ; $7774: $09
     ld   [hl], a                                  ; $7775: $77
 
@@ -8818,7 +8818,7 @@ jr_005_7C1C:
 func_005_7C36:
     call GetRandomByte                            ; $7C36: $CD $0D $28
     and  $01                                      ; $7C39: $E6 $01
-    ld   hl, wEntitiesSubstate1Table              ; $7C3B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7C3B: $21 $B0 $C2
     add  hl, bc                                   ; $7C3E: $09
     ld   [hl], a                                  ; $7C3F: $77
     ld   e, a                                     ; $7C40: $5F
@@ -8947,7 +8947,7 @@ label_005_7CE8:
     jp   label_005_7D40                           ; $7CFE: $C3 $40 $7D
 
 jr_005_7D01:
-    ld   hl, wEntitiesSubstate1Table              ; $7D01: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7D01: $21 $B0 $C2
     add  hl, bc                                   ; $7D04: $09
     ld   a, [hl]                                  ; $7D05: $7E
     xor  $01                                      ; $7D06: $EE $01
@@ -8957,7 +8957,7 @@ jr_005_7D09:
     call IsEntityUnknownFZero                     ; $7D09: $CD $00 $0C
     jr   nz, label_005_7D40                       ; $7D0C: $20 $32
 
-    ld   hl, wEntitiesSubstate1Table              ; $7D0E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7D0E: $21 $B0 $C2
     add  hl, bc                                   ; $7D11: $09
     ld   a, [hl]                                  ; $7D12: $7E
     ld   e, a                                     ; $7D13: $5F
@@ -8977,7 +8977,7 @@ jr_005_7D21:
     ld   [hl], b                                  ; $7D29: $70
     call IncrementEntityState                     ; $7D2A: $CD $12 $3B
     ld   [hl], $02                                ; $7D2D: $36 $02
-    ld   hl, wEntitiesSubstate1Table              ; $7D2F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7D2F: $21 $B0 $C2
     add  hl, bc                                   ; $7D32: $09
     ld   [hl], b                                  ; $7D33: $70
     ld   hl, wEntitiesPosYTable                   ; $7D34: $21 $10 $C2
@@ -9019,7 +9019,7 @@ label_005_7D5F:
     jp   SetEntitySpriteVariant                   ; $7D5F: $C3 $0C $3B
 
 func_005_7D62:
-    ld   hl, wEntitiesSubstate1Table              ; $7D62: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7D62: $21 $B0 $C2
     add  hl, bc                                   ; $7D65: $09
     ld   a, [hl]                                  ; $7D66: $7E
     and  a                                        ; $7D67: $A7
@@ -9072,7 +9072,7 @@ jr_005_7DA8:
     cp   [hl]                                     ; $7DB3: $BE
     jp   nc, label_005_7DF0                       ; $7DB4: $D2 $F0 $7D
 
-    ld   hl, wEntitiesSubstate1Table              ; $7DB7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7DB7: $21 $B0 $C2
     add  hl, bc                                   ; $7DBA: $09
     inc  [hl]                                     ; $7DBB: $34
     call ClearEntitySpeed                         ; $7DBC: $CD $7F $3D
@@ -9179,7 +9179,7 @@ jr_005_7E3A:
     ld   hl, wEntitiesPosYTable                   ; $7E4E: $21 $10 $C2
     add  hl, de                                   ; $7E51: $19
     ld   [hl], a                                  ; $7E52: $77
-    ld   hl, wEntitiesSubstate1Table              ; $7E53: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7E53: $21 $B0 $C2
     add  hl, de                                   ; $7E56: $19
     inc  [hl]                                     ; $7E57: $34
     push bc                                       ; $7E58: $C5
@@ -9197,7 +9197,7 @@ jr_005_7E61:
     jp   SetEntitySpriteVariant                   ; $7E69: $C3 $0C $3B
 
 label_005_7E6C:
-    ld   hl, wEntitiesSubstate2Table              ; $7E6C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7E6C: $21 $C0 $C2
     add  hl, bc                                   ; $7E6F: $09
     ld   a, [hl]                                  ; $7E70: $7E
     JP_TABLE                                      ; $7E71
@@ -9213,7 +9213,7 @@ func_005_7E78:
     ld   [hl], $FF                                ; $7E81: $36 $FF
 
 label_005_7E83:
-    ld   hl, wEntitiesSubstate2Table              ; $7E83: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7E83: $21 $C0 $C2
     add  hl, bc                                   ; $7E86: $09
     inc  [hl]                                     ; $7E87: $34
     ret                                           ; $7E88: $C9

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -23,7 +23,7 @@ RichardEntityHandler::
 
 jr_006_403B:
     call func_006_6441                            ; $403B: $CD $41 $64
-    ld   hl, wEntitiesSubstate1Table              ; $403E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $403E: $21 $B0 $C2
     add  hl, bc                                   ; $4041: $09
     ld   a, [hl]                                  ; $4042: $7E
     and  a                                        ; $4043: $A7
@@ -101,7 +101,7 @@ jr_006_40A0:
     ld   [hl], $03                                ; $40A9: $36 $03
     call GetEntityTransitionCountdown             ; $40AB: $CD $05 $0C
     ld   [hl], $20                                ; $40AE: $36 $20
-    ld   hl, wEntitiesSubstate1Table              ; $40B0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $40B0: $21 $B0 $C2
     add  hl, bc                                   ; $40B3: $09
     ld   [hl], $01                                ; $40B4: $36 $01
     ld   a, $FF                                   ; $40B6: $3E $FF
@@ -641,7 +641,7 @@ jr_006_43B8:
     and  a                                        ; $43CC: $A7
     jr   z, jr_006_43E2                           ; $43CD: $28 $13
 
-    ld   hl, wEntitiesSubstate1Table              ; $43CF: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $43CF: $21 $B0 $C2
     add  hl, bc                                   ; $43D2: $09
     ld   a, [hl]                                  ; $43D3: $7E
     and  a                                        ; $43D4: $A7
@@ -668,7 +668,7 @@ jr_006_43E2:
 
 jr_006_43F5:
     ld   [hl], $0C                                ; $43F5: $36 $0C
-    ld   hl, wEntitiesSubstate1Table              ; $43F7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $43F7: $21 $B0 $C2
     add  hl, bc                                   ; $43FA: $09
     ld   [hl], b                                  ; $43FB: $70
     xor  a                                        ; $43FC: $AF
@@ -2227,7 +2227,7 @@ jr_006_4CCE:
     ld   hl, wEntitiesSpriteVariantTable               ; $4D15: $21 $B0 $C3
     add  hl, de                                   ; $4D18: $19
     ld   [hl], a                                  ; $4D19: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4D1A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4D1A: $21 $B0 $C2
     add  hl, de                                   ; $4D1D: $19
     ld   [hl], $01                                ; $4D1E: $36 $01
     ld   hl, wEntitiesPhysicsFlagsTable                ; $4D20: $21 $40 $C3
@@ -2631,7 +2631,7 @@ jr_006_5037:
     ld   [hl], a                                  ; $5041: $77
     call IncrementEntityState                     ; $5042: $CD $12 $3B
     ld   [hl], b                                  ; $5045: $70
-    ld   hl, wEntitiesSubstate1Table              ; $5046: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5046: $21 $B0 $C2
     add  hl, bc                                   ; $5049: $09
     ld   a, [hl]                                  ; $504A: $7E
     inc  a                                        ; $504B: $3C
@@ -3112,7 +3112,7 @@ jr_006_52FF:
     jr   z, jr_006_5361                           ; $5306: $28 $59
 
 label_006_5308:
-    ld   hl, wEntitiesSubstate2Table              ; $5308: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5308: $21 $C0 $C2
     add  hl, bc                                   ; $530B: $09
     ld   a, [hl]                                  ; $530C: $7E
     rst  $00                                      ; $530D: $C7
@@ -3208,7 +3208,7 @@ jr_006_5394:
     ld   hl, wEntitiesHealthTable                 ; $5394: $21 $60 $C3
     add  hl, bc                                   ; $5397: $09
     ld   a, [hl]                                  ; $5398: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $5399: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5399: $21 $B0 $C2
     add  hl, bc                                   ; $539C: $09
     cp   [hl]                                     ; $539D: $BE
     ld   [hl], a                                  ; $539E: $77
@@ -3649,7 +3649,7 @@ jr_006_5611:
     cp   $01                                      ; $5616: $FE $01
     jp   nz, label_006_56C8                       ; $5618: $C2 $C8 $56
 
-    ld   hl, wEntitiesSubstate2Table              ; $561B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $561B: $21 $C0 $C2
     add  hl, bc                                   ; $561E: $09
     ld   a, [hl]                                  ; $561F: $7E
     rst  $00                                      ; $5620: $C7
@@ -3669,7 +3669,7 @@ jr_006_5611:
 
 func_006_5634:
 label_006_5634:
-    ld   hl, wEntitiesSubstate2Table              ; $5634: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5634: $21 $C0 $C2
     add  hl, bc                                   ; $5637: $09
     inc  [hl]                                     ; $5638: $34
     ret                                           ; $5639: $C9
@@ -3964,7 +3964,7 @@ jr_006_57E0:
     and  $1F                                      ; $57F5: $E6 $1F
     add  $20                                      ; $57F7: $C6 $20
     ld   [hl], a                                  ; $57F9: $77
-    ld   hl, wEntitiesSubstate1Table              ; $57FA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $57FA: $21 $B0 $C2
     add  hl, bc                                   ; $57FD: $09
     ld   [hl], $20                                ; $57FE: $36 $20
     call IncrementEntityState                     ; $5800: $CD $12 $3B
@@ -3981,7 +3981,7 @@ jr_006_5803:
     call IncrementEntityState                     ; $5813: $CD $12 $3B
 
 jr_006_5816:
-    ld   hl, wEntitiesSubstate1Table              ; $5816: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5816: $21 $B0 $C2
     add  hl, bc                                   ; $5819: $09
     ld   a, [hl]                                  ; $581A: $7E
     inc  [hl]                                     ; $581B: $34
@@ -4391,7 +4391,7 @@ jr_006_5A0D:
 
 jr_006_5A1B:
     ld   de, $59A8                                ; $5A1B: $11 $A8 $59
-    ld   hl, wEntitiesSubstate1Table              ; $5A1E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5A1E: $21 $B0 $C2
     add  hl, bc                                   ; $5A21: $09
     ld   a, [hl]                                  ; $5A22: $7E
     and  a                                        ; $5A23: $A7
@@ -5281,7 +5281,7 @@ func_006_5F23:
     set  7, [hl]                                  ; $5F3C: $CB $FE
     ld   a, [wPieceOfPowerKillCount]              ; $5F3E: $FA $15 $D4
     and  $01                                      ; $5F41: $E6 $01
-    ld   hl, wEntitiesSubstate1Table              ; $5F43: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F43: $21 $B0 $C2
     add  hl, bc                                   ; $5F46: $09
     ld   [hl], a                                  ; $5F47: $77
     ld   a, [$DB75]                               ; $5F48: $FA $75 $DB
@@ -5301,7 +5301,7 @@ jr_006_5F51:
     and  a                                        ; $5F5B: $A7
     jr   nz, jr_006_5F76                          ; $5F5C: $20 $18
 
-    ld   hl, wEntitiesSubstate1Table              ; $5F5E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F5E: $21 $B0 $C2
     add  hl, bc                                   ; $5F61: $09
     ld   a, [hl]                                  ; $5F62: $7E
     and  $01                                      ; $5F63: $E6 $01
@@ -5346,7 +5346,7 @@ jr_006_5F76:
     and  a                                        ; $5F9B: $A7
     jr   nz, jr_006_600D                          ; $5F9C: $20 $6F
 
-    ld   hl, wEntitiesSubstate1Table              ; $5F9E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F9E: $21 $B0 $C2
     add  hl, bc                                   ; $5FA1: $09
     ld   e, [hl]                                  ; $5FA2: $5E
     ld   d, b                                     ; $5FA3: $50
@@ -5379,7 +5379,7 @@ jr_006_5FBD:
     jp   IncrementEntityState                     ; $5FD2: $C3 $12 $3B
 
 jr_006_5FD5:
-    ld   hl, wEntitiesSubstate1Table              ; $5FD5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5FD5: $21 $B0 $C2
     add  hl, bc                                   ; $5FD8: $09
     ld   e, [hl]                                  ; $5FD9: $5E
     ld   d, b                                     ; $5FDA: $50
@@ -5508,7 +5508,7 @@ jr_006_6048:
 
 Kid71EntityHandler::
 Kid72EntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $607F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $607F: $21 $B0 $C2
     add  hl, bc                                   ; $6082: $09
     ld   a, [hl]                                  ; $6083: $7E
     and  a                                        ; $6084: $A7
@@ -5579,7 +5579,7 @@ jr_006_60D0:
     inc  [hl]                                     ; $60E3: $34
     ld   h, c                                     ; $60E4: $61
     call func_006_64C6                            ; $60E5: $CD $C6 $64
-    ld   hl, wEntitiesSubstate2Table              ; $60E8: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $60E8: $21 $C0 $C2
     add  hl, bc                                   ; $60EB: $09
     ld   [hl], $30                                ; $60EC: $36 $30
     ld   a, $0E                                   ; $60EE: $3E $0E
@@ -5601,7 +5601,7 @@ label_006_60F7:
     cp   $40                                      ; $6105: $FE $40
     jr   c, jr_006_6110                           ; $6107: $38 $07
 
-    ld   hl, wEntitiesSubstate2Table              ; $6109: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6109: $21 $C0 $C2
     add  hl, bc                                   ; $610C: $09
     dec  [hl]                                     ; $610D: $35
     jr   nz, jr_006_6124                          ; $610E: $20 $14
@@ -5722,7 +5722,7 @@ jr_006_619F:
     ld   hl, wEntitiesPosYTable                         ; $61C5: $21 $10 $C2
     add  hl, de                                   ; $61C8: $19
     ld   [hl], a                                  ; $61C9: $77
-    ld   hl, wEntitiesSubstate1Table              ; $61CA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $61CA: $21 $B0 $C2
     add  hl, de                                   ; $61CD: $19
     ld   [hl], $01                                ; $61CE: $36 $01
     ld   hl, wEntitiesSpeedZTable                 ; $61D0: $21 $20 $C3
@@ -6044,7 +6044,7 @@ GopongaProjectileEntityHandler::
     ld   hl, wEntitiesHealthTable                 ; $639F: $21 $60 $C3
     add  hl, bc                                   ; $63A2: $09
     ld   [hl], $30                                ; $63A3: $36 $30
-    ld   hl, wEntitiesSubstate1Table              ; $63A5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $63A5: $21 $B0 $C2
     add  hl, bc                                   ; $63A8: $09
     ld   a, [hl]                                  ; $63A9: $7E
     and  a                                        ; $63AA: $A7
@@ -6556,12 +6556,12 @@ SparkCounterClockwiseEntityHandler::
     call label_3B44                               ; $664C: $CD $44 $3B
     call func_006_6541                            ; $664F: $CD $41 $65
     call func_006_66CC                            ; $6652: $CD $CC $66
-    ld   hl, wEntitiesSubstate1Table              ; $6655: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6655: $21 $B0 $C2
     add  hl, bc                                   ; $6658: $09
     ld   a, [hl]                                  ; $6659: $7E
     ld   e, a                                     ; $665A: $5F
     ld   d, b                                     ; $665B: $50
-    ld   hl, wEntitiesSubstate2Table              ; $665C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $665C: $21 $C0 $C2
     add  hl, bc                                   ; $665F: $09
     add  [hl]                                     ; $6660: $86
     ld   e, a                                     ; $6661: $5F
@@ -6589,7 +6589,7 @@ SparkCounterClockwiseEntityHandler::
     jr   jr_006_669D                              ; $6683: $18 $18
 
 jr_006_6685:
-    ld   hl, wEntitiesSubstate1Table              ; $6685: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6685: $21 $B0 $C2
     add  hl, bc                                   ; $6688: $09
     inc  [hl]                                     ; $6689: $34
     ld   a, [hl]                                  ; $668A: $7E
@@ -6601,7 +6601,7 @@ jr_006_6690:
     cp   $06                                      ; $6690: $FE $06
     jr   nz, jr_006_669D                          ; $6692: $20 $09
 
-    ld   hl, wEntitiesSubstate1Table              ; $6694: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6694: $21 $B0 $C2
     add  hl, bc                                   ; $6697: $09
     dec  [hl]                                     ; $6698: $35
     ld   a, [hl]                                  ; $6699: $7E
@@ -6609,12 +6609,12 @@ jr_006_6690:
     ld   [hl], a                                  ; $669C: $77
 
 jr_006_669D:
-    ld   hl, wEntitiesSubstate1Table              ; $669D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $669D: $21 $B0 $C2
     add  hl, bc                                   ; $66A0: $09
     ld   a, [hl]                                  ; $66A1: $7E
     ld   e, a                                     ; $66A2: $5F
     ld   d, b                                     ; $66A3: $50
-    ld   hl, wEntitiesSubstate2Table              ; $66A4: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $66A4: $21 $C0 $C2
     add  hl, bc                                   ; $66A7: $09
     add  [hl]                                     ; $66A8: $86
     ld   e, a                                     ; $66A9: $5F
@@ -6624,12 +6624,12 @@ jr_006_669D:
     ld   hl, wEntitiesSpeedYTable                       ; $66AF: $21 $50 $C2
     add  hl, bc                                   ; $66B2: $09
     ld   [hl], a                                  ; $66B3: $77
-    ld   hl, wEntitiesSubstate1Table              ; $66B4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $66B4: $21 $B0 $C2
     add  hl, bc                                   ; $66B7: $09
     ld   a, [hl]                                  ; $66B8: $7E
     ld   e, a                                     ; $66B9: $5F
     ld   d, b                                     ; $66BA: $50
-    ld   hl, wEntitiesSubstate2Table              ; $66BB: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $66BB: $21 $C0 $C2
     add  hl, bc                                   ; $66BE: $09
     add  [hl]                                     ; $66BF: $86
     ld   e, a                                     ; $66C0: $5F
@@ -6759,7 +6759,7 @@ jr_006_674D:
     ld   a, [hl]                                  ; $6772: $7E
 
 jr_006_6773:
-    ld   hl, wEntitiesSubstate1Table              ; $6773: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6773: $21 $B0 $C2
     add  hl, bc                                   ; $6776: $09
     ld   [hl], a                                  ; $6777: $77
     call GetEntityTransitionCountdown             ; $6778: $CD $05 $0C
@@ -6767,7 +6767,7 @@ jr_006_6773:
     and  $3F                                      ; $677E: $E6 $3F
     add  $50                                      ; $6780: $C6 $50
     ld   [hl], a                                  ; $6782: $77
-    ld   hl, wEntitiesSubstate2Table              ; $6783: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6783: $21 $C0 $C2
     add  hl, bc                                   ; $6786: $09
     ld   [hl], $01                                ; $6787: $36 $01
     call IncrementEntityState                     ; $6789: $CD $12 $3B
@@ -6792,15 +6792,15 @@ jr_006_67A2:
     jr   c, jr_006_67E6                           ; $67AA: $38 $3A
 
     ld   [hl], b                                  ; $67AC: $70
-    ld   hl, wEntitiesSubstate2Table              ; $67AD: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $67AD: $21 $C0 $C2
     add  hl, bc                                   ; $67B0: $09
     ld   a, [hl]                                  ; $67B1: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $67B2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $67B2: $21 $B0 $C2
     add  hl, bc                                   ; $67B5: $09
     add  [hl]                                     ; $67B6: $86
     and  $0F                                      ; $67B7: $E6 $0F
     ld   [hl], a                                  ; $67B9: $77
-    ld   hl, wEntitiesSubstate1Table              ; $67BA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $67BA: $21 $B0 $C2
     add  hl, bc                                   ; $67BD: $09
     ld   e, [hl]                                  ; $67BE: $5E
     ld   d, b                                     ; $67BF: $50
@@ -6823,7 +6823,7 @@ jr_006_67A2:
     call GetRandomByte                            ; $67DB: $CD $0D $28
     and  $02                                      ; $67DE: $E6 $02
     dec  a                                        ; $67E0: $3D
-    ld   hl, wEntitiesSubstate2Table              ; $67E1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $67E1: $21 $C0 $C2
     add  hl, bc                                   ; $67E4: $09
     ld   [hl], a                                  ; $67E5: $77
 
@@ -7038,7 +7038,7 @@ jr_006_68EF:
 
 jr_006_68F6:
     ldh  a, [hMusicTrack]                         ; $68F6: $F0 $B0
-    ld   hl, wEntitiesSubstate1Table              ; $68F8: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $68F8: $21 $B0 $C2
     add  hl, bc                                   ; $68FB: $09
     ld   [hl], a                                  ; $68FC: $77
     ld   a, $22                                   ; $68FD: $3E $22
@@ -7178,7 +7178,7 @@ jr_006_69BD:
     and  a                                        ; $69E4: $A7
     jr   nz, jr_006_6A05                          ; $69E5: $20 $1E
 
-    ld   hl, wEntitiesSubstate1Table              ; $69E7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $69E7: $21 $B0 $C2
     add  hl, bc                                   ; $69EA: $09
     ld   a, [hl]                                  ; $69EB: $7E
     ld   [wActiveMusicTrack], a                   ; $69EC: $EA $68 $D3
@@ -7347,7 +7347,7 @@ jr_006_6AA9:
     cp   $05                                      ; $6AF2: $FE $05
     jr   nc, jr_006_6B09                          ; $6AF4: $30 $13
 
-    ld   hl, wEntitiesSubstate1Table              ; $6AF6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6AF6: $21 $B0 $C2
     add  hl, bc                                   ; $6AF9: $09
     inc  [hl]                                     ; $6AFA: $34
     ld   a, [hl]                                  ; $6AFB: $7E
@@ -7536,7 +7536,7 @@ ButterflyEntityHandler::
     ld   hl, ButterflyPossibleSpeeds                        ; $6C03: $21 $C1 $6B
     add  hl, de                                   ; $6C06: $19
     ld   a, [hl]                                  ; $6C07: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $6C08: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6C08: $21 $B0 $C2
     add  hl, bc                                   ; $6C0B: $09
     add  [hl]                                     ; $6C0C: $86
     ld   hl, wEntitiesSpeedXTable                       ; $6C0D: $21 $40 $C2
@@ -7557,7 +7557,7 @@ ButterflyEntityHandler::
     ld   hl, ButterflyPossibleSpeeds                        ; $6C21: $21 $C1 $6B
     add  hl, de                                   ; $6C24: $19
     ld   a, [hl]                                  ; $6C25: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $6C26: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6C26: $21 $C0 $C2
     add  hl, bc                                   ; $6C29: $09
     add  [hl]                                     ; $6C2A: $86
     ld   hl, wEntitiesSpeedYTable                       ; $6C2B: $21 $50 $C2
@@ -7601,14 +7601,14 @@ ButterflyEntityHandler::
     ldh  [hLinkPositionY], a                      ; $6C59: $E0 $99
     pop  af                                       ; $6C5B: $F1
     ldh  [hLinkPositionX], a                      ; $6C5C: $E0 $98
-    ; wEntitiesSubstate2Table[c] = [hScratch0]
+    ; wEntitiesPrivateState2Table[c] = [hScratch0]
     ldh  a, [hScratch0]                           ; $6C5E: $F0 $D7
-    ld   hl, wEntitiesSubstate2Table              ; $6C60: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6C60: $21 $C0 $C2
     add  hl, bc                                   ; $6C63: $09
     ld   [hl], a                                  ; $6C64: $77
-    ; wEntitiesSubstate1Table[c] = [hScratch1]
+    ; wEntitiesPrivateState1Table[c] = [hScratch1]
     ldh  a, [hScratch1]                           ; $6C65: $F0 $D8
-    ld   hl, wEntitiesSubstate1Table              ; $6C67: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6C67: $21 $B0 $C2
     add  hl, bc                                   ; $6C6A: $09
     ld   [hl], a                                  ; $6C6B: $77
 .moveCloserToLinkEnd
@@ -7635,7 +7635,7 @@ jr_006_6C7B:
     ld   hl, wEntitiesUnknowTableH                ; $6C8A: $21 $30 $C4
     add  hl, bc                                   ; $6C8D: $09
     ld   [hl], $80                                ; $6C8E: $36 $80
-    ld   hl, wEntitiesSubstate1Table              ; $6C90: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6C90: $21 $B0 $C2
     add  hl, bc                                   ; $6C93: $09
     ld   a, [hl]                                  ; $6C94: $7E
     rst  $00                                      ; $6C95: $C7
@@ -7648,7 +7648,7 @@ jr_006_6C7B:
     ld   hl, wEntitiesFlashCountdownTable         ; $6C9F: $21 $20 $C4
     add  hl, bc                                   ; $6CA2: $09
     ld   [hl], $FF                                ; $6CA3: $36 $FF
-    ld   hl, wEntitiesSubstate1Table              ; $6CA5: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6CA5: $21 $B0 $C2
     add  hl, bc                                   ; $6CA8: $09
     inc  [hl]                                     ; $6CA9: $34
     ret                                           ; $6CAA: $C9
@@ -8084,7 +8084,7 @@ jr_006_6F03:
     jr   nz, jr_006_6F47                          ; $6F11: $20 $34
 
     ld   [hl], $03                                ; $6F13: $36 $03
-    ld   hl, wEntitiesSubstate1Table              ; $6F15: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6F15: $21 $B0 $C2
     add  hl, bc                                   ; $6F18: $09
     ldh  a, [wActiveEntityPosX]                   ; $6F19: $F0 $EE
     ldh  [hScratch0], a                           ; $6F1B: $E0 $D7
@@ -8266,7 +8266,7 @@ jr_006_6FEE:
     ldh  a, [wActiveEntityPosY]                   ; $6FF4: $F0 $EC
     add  $10                                      ; $6FF6: $C6 $10
     ldh  [wActiveEntityPosY], a                   ; $6FF8: $E0 $EC
-    ld   hl, wEntitiesSubstate1Table              ; $6FFA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6FFA: $21 $B0 $C2
     add  hl, bc                                   ; $6FFD: $09
     ld   e, [hl]                                  ; $6FFE: $5E
     ld   d, b                                     ; $6FFF: $50
@@ -8409,7 +8409,7 @@ jr_006_70B8:
     and  $01                                      ; $70DC: $E6 $01
     jr   nz, jr_006_7120                          ; $70DE: $20 $40
 
-    ld   hl, wEntitiesSubstate1Table              ; $70E0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $70E0: $21 $B0 $C2
     add  hl, bc                                   ; $70E3: $09
     ld   e, [hl]                                  ; $70E4: $5E
     ld   d, b                                     ; $70E5: $50
@@ -8425,14 +8425,14 @@ jr_006_70B8:
     cp   [hl]                                     ; $70F5: $BE
     jr   nz, jr_006_7100                          ; $70F6: $20 $08
 
-    ld   hl, wEntitiesSubstate1Table              ; $70F8: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $70F8: $21 $B0 $C2
     add  hl, bc                                   ; $70FB: $09
     ld   a, [hl]                                  ; $70FC: $7E
     xor  $01                                      ; $70FD: $EE $01
     ld   [hl], a                                  ; $70FF: $77
 
 jr_006_7100:
-    ld   hl, wEntitiesSubstate2Table              ; $7100: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7100: $21 $C0 $C2
     add  hl, bc                                   ; $7103: $09
     ld   e, [hl]                                  ; $7104: $5E
     ld   d, b                                     ; $7105: $50
@@ -8448,7 +8448,7 @@ jr_006_7100:
     cp   [hl]                                     ; $7115: $BE
     jr   nz, jr_006_7120                          ; $7116: $20 $08
 
-    ld   hl, wEntitiesSubstate2Table              ; $7118: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7118: $21 $C0 $C2
     add  hl, bc                                   ; $711B: $09
     ld   a, [hl]                                  ; $711C: $7E
     xor  $01                                      ; $711D: $EE $01
@@ -8539,7 +8539,7 @@ jr_006_7197:
     jr   nz, jr_006_71BA                          ; $71A8: $20 $10
 
     ld   [hl], $01                                ; $71AA: $36 $01
-    ld   hl, wEntitiesSubstate1Table              ; $71AC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $71AC: $21 $B0 $C2
     add  hl, bc                                   ; $71AF: $09
     ld   a, [hl]                                  ; $71B0: $7E
     cp   $04                                      ; $71B1: $FE $04
@@ -8553,7 +8553,7 @@ jr_006_71BA:
     jr   nz, jr_006_71F0                          ; $71BD: $20 $31
 
     ld   [hl], $13                                ; $71BF: $36 $13
-    ld   hl, wEntitiesSubstate1Table              ; $71C1: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $71C1: $21 $B0 $C2
     add  hl, bc                                   ; $71C4: $09
     ld   a, [hl]                                  ; $71C5: $7E
     cp   $0A                                      ; $71C6: $FE $0A
@@ -9134,7 +9134,7 @@ SpikeTrapEntityHandler::
     jp   nz, label_006_7709                       ; $7532: $C2 $09 $77
 
     ldh  a, [wActiveEntityPosY]                   ; $7535: $F0 $EC
-    ld   hl, wEntitiesSubstate2Table              ; $7537: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7537: $21 $C0 $C2
     add  hl, bc                                   ; $753A: $09
     ld   [hl], a                                  ; $753B: $77
     jp   IncrementEntityState                     ; $753C: $C3 $12 $3B
@@ -9243,7 +9243,7 @@ jr_006_75B5:
     add  hl, bc                                   ; $75DE: $09
     ld   [hl], a                                  ; $75DF: $77
     call func_006_6541                            ; $75E0: $CD $41 $65
-    ld   hl, wEntitiesSubstate1Table              ; $75E3: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $75E3: $21 $B0 $C2
     add  hl, bc                                   ; $75E6: $09
     ld   a, [hl]                                  ; $75E7: $7E
     ld   hl, wEntitiesPosXTable                         ; $75E8: $21 $00 $C2
@@ -9251,7 +9251,7 @@ jr_006_75B5:
     cp   [hl]                                     ; $75EC: $BE
     ret  nz                                       ; $75ED: $C0
 
-    ld   hl, wEntitiesSubstate2Table              ; $75EE: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $75EE: $21 $C0 $C2
     add  hl, bc                                   ; $75F1: $09
     ld   a, [hl]                                  ; $75F2: $7E
     ld   hl, wEntitiesPosYTable                         ; $75F3: $21 $10 $C2
@@ -9325,7 +9325,7 @@ WizrobeEntityHandler::
     jr   nz, jr_006_765E                          ; $764E: $20 $0E
 
     call IncrementEntityState                     ; $7650: $CD $12 $3B
-    ld   hl, wEntitiesSubstate1Table              ; $7653: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7653: $21 $B0 $C2
     add  hl, bc                                   ; $7656: $09
     ld   [hl], $01                                ; $7657: $36 $01
     call IsEntityUnknownFZero                     ; $7659: $CD $00 $0C
@@ -9337,7 +9337,7 @@ jr_006_765E:
     call IsEntityUnknownFZero                     ; $7660: $CD $00 $0C
     jr   nz, jr_006_7679                          ; $7663: $20 $14
 
-    ld   hl, wEntitiesSubstate1Table              ; $7665: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7665: $21 $B0 $C2
     add  hl, bc                                   ; $7668: $09
     ld   a, [hl]                                  ; $7669: $7E
     ld   hl, wEntitiesStateTable                  ; $766A: $21 $90 $C2
@@ -9380,7 +9380,7 @@ jr_006_7686:
     jp   label_006_7735                           ; $769F: $C3 $35 $77
 
 jr_006_76A2:
-    ld   hl, wEntitiesSubstate1Table              ; $76A2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $76A2: $21 $B0 $C2
     add  hl, bc                                   ; $76A5: $09
     ld   a, [hl]                                  ; $76A6: $7E
     ld   hl, wEntitiesStateTable                  ; $76A7: $21 $90 $C2
@@ -9420,7 +9420,7 @@ jr_006_76B6:
     ret                                           ; $76DC: $C9
 
 jr_006_76DD:
-    ld   hl, wEntitiesSubstate1Table              ; $76DD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $76DD: $21 $B0 $C2
     add  hl, bc                                   ; $76E0: $09
     ld   [hl], $FF                                ; $76E1: $36 $FF
     ld   hl, wEntitiesStateTable                  ; $76E3: $21 $90 $C2
@@ -10071,7 +10071,7 @@ jr_006_7A08:
 jr_006_7A11:
     call ClearEntitySpeed                         ; $7A11: $CD $7F $3D
     call func_006_7AB0                            ; $7A14: $CD $B0 $7A
-    ld   hl, wEntitiesSubstate1Table              ; $7A17: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7A17: $21 $B0 $C2
     add  hl, bc                                   ; $7A1A: $09
     ld   a, [hl]                                  ; $7A1B: $7E
     and  a                                        ; $7A1C: $A7
@@ -10165,7 +10165,7 @@ jr_006_7A8B:
 func_006_7A8C:
     call IsEntityUnknownFZero                     ; $7A8C: $CD $00 $0C
     ld   [hl], $20                                ; $7A8F: $36 $20
-    ld   hl, wEntitiesSubstate1Table              ; $7A91: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7A91: $21 $B0 $C2
     add  hl, bc                                   ; $7A94: $09
     ld   [hl], $00                                ; $7A95: $36 $00
     ld   hl, wEntitiesPosYTable                         ; $7A97: $21 $10 $C2
@@ -10210,14 +10210,14 @@ jr_006_7AC7:
 
 jr_006_7AC9:
     call SetEntitySpriteVariant                   ; $7AC9: $CD $0C $3B
-    ld   hl, wEntitiesSubstate1Table              ; $7ACC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7ACC: $21 $B0 $C2
     add  hl, bc                                   ; $7ACF: $09
     ld   [hl], b                                  ; $7AD0: $70
     call GetEntityTransitionCountdown             ; $7AD1: $CD $05 $0C
     cp   $01                                      ; $7AD4: $FE $01
     ret  nz                                       ; $7AD6: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $7AD7: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7AD7: $21 $B0 $C2
     add  hl, bc                                   ; $7ADA: $09
     inc  [hl]                                     ; $7ADB: $34
     ret                                           ; $7ADC: $C9
@@ -10820,7 +10820,7 @@ label_006_7E09:
 jr_006_7E27:
     ld   a, $FF                                   ; $7E27: $3E $FF
     ldh  [hLinkAnimationState], a                 ; $7E29: $E0 $9D
-    ld   hl, wEntitiesSubstate1Table              ; $7E2B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7E2B: $21 $B0 $C2
     add  hl, bc                                   ; $7E2E: $09
     ld   a, [hl]                                  ; $7E2F: $7E
     and  a                                        ; $7E30: $A7
@@ -10839,7 +10839,7 @@ jr_006_7E37:
     jr   nc, jr_006_7E55                          ; $7E41: $30 $12
 
     ld   [hl], b                                  ; $7E43: $70
-    ld   hl, wEntitiesSubstate1Table              ; $7E44: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7E44: $21 $B0 $C2
     add  hl, bc                                   ; $7E47: $09
     ld   a, [wShieldLevel]                        ; $7E48: $FA $44 $DB
     ld   [hl], a                                  ; $7E4B: $77

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -66,7 +66,7 @@ BushCrawlerEntityHandler::
     ld   [hl], a                                  ; $4052: $77
 
 jr_007_4053:
-    ld   hl, wEntitiesSubstate2Table              ; $4053: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4053: $21 $C0 $C2
     add  hl, bc                                   ; $4056: $09
     ldh  a, [wActiveEntityPosY]                   ; $4057: $F0 $EC
     sub  [hl]                                     ; $4059: $96
@@ -85,7 +85,7 @@ jr_007_4053:
 jr_007_406F:
     call RenderAnimatedActiveEntity                               ; $406F: $CD $C0 $3B
     call label_3D8A                               ; $4072: $CD $8A $3D
-    ld   hl, wEntitiesSubstate2Table              ; $4075: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4075: $21 $C0 $C2
     add  hl, bc                                   ; $4078: $09
     ld   a, [hl]                                  ; $4079: $7E
     and  a                                        ; $407A: $A7
@@ -144,7 +144,7 @@ Data_007_40D2::
     db   $00, $00, $F0, $10
 
 BushCrawlerState0Handler::
-    ld   hl, wEntitiesSubstate2Table              ; $40D6: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $40D6: $21 $C0 $C2
     add  hl, bc                                   ; $40D9: $09
     ld   [hl], b                                  ; $40DA: $70
     call GetEntityTransitionCountdown                 ; $40DB: $CD $05 $0C
@@ -272,7 +272,7 @@ label_007_4198:
     ld   hl, wEntitiesPosYTable                         ; $41A7: $21 $10 $C2
     add  hl, de                                   ; $41AA: $19
     ld   [hl], a                                  ; $41AB: $77
-    ld   hl, wEntitiesSubstate1Table              ; $41AC: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $41AC: $21 $B0 $C2
     add  hl, de                                   ; $41AF: $19
     ld   [hl], $02                                ; $41B0: $36 $02
     ld   hl, wEntitiesTransitionCountdownTable           ; $41B2: $21 $E0 $C2
@@ -302,7 +302,7 @@ jr_007_41C8:
     and  a                                        ; $41D3: $A7
     jr   nz, jr_007_41BE                          ; $41D4: $20 $E8
 
-    ld   hl, wEntitiesSubstate2Table              ; $41D6: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $41D6: $21 $C0 $C2
     add  hl, bc                                   ; $41D9: $09
     ld   [hl], $04                                ; $41DA: $36 $04
     ldh  a, [hFrameCounter]                       ; $41DC: $F0 $E7
@@ -430,7 +430,7 @@ FishermanUnderBridgeEntityHandler::
     add  hl, de                                   ; $42AD: $19
     add  $10                                      ; $42AE: $C6 $10
     ld   [hl], a                                  ; $42B0: $77
-    ld   hl, wEntitiesSubstate1Table              ; $42B1: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $42B1: $21 $B0 $C2
     add  hl, de                                   ; $42B4: $19
     ld   [hl], $02                                ; $42B5: $36 $02
     ld   hl, wEntitiesHitboxFlagsTable                ; $42B7: $21 $50 $C3
@@ -1316,7 +1316,7 @@ jr_007_47D5:
     call GetEntityTransitionCountdown                 ; $47D9: $CD $05 $0C
     ret  nz                                       ; $47DC: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $47DD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $47DD: $21 $B0 $C2
     add  hl, bc                                   ; $47E0: $09
     ld   a, [hl]                                  ; $47E1: $7E
     cpl                                           ; $47E2: $2F
@@ -2246,7 +2246,7 @@ label_007_4D84:
     and  $01                                      ; $4DA7: $E6 $01
     jr   nz, jr_007_4DEA                          ; $4DA9: $20 $3F
 
-    ld   hl, wEntitiesSubstate1Table              ; $4DAB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4DAB: $21 $B0 $C2
     add  hl, bc                                   ; $4DAE: $09
     ld   e, [hl]                                  ; $4DAF: $5E
     ld   d, b                                     ; $4DB0: $50
@@ -2262,14 +2262,14 @@ label_007_4D84:
     cp   [hl]                                     ; $4DC0: $BE
     jr   nz, jr_007_4DCB                          ; $4DC1: $20 $08
 
-    ld   hl, wEntitiesSubstate1Table              ; $4DC3: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4DC3: $21 $B0 $C2
     add  hl, bc                                   ; $4DC6: $09
     ld   a, [hl]                                  ; $4DC7: $7E
     xor  $01                                      ; $4DC8: $EE $01
     ld   [hl], a                                  ; $4DCA: $77
 
 jr_007_4DCB:
-    ld   hl, wEntitiesSubstate2Table              ; $4DCB: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4DCB: $21 $C0 $C2
     add  hl, bc                                   ; $4DCE: $09
     ld   e, [hl]                                  ; $4DCF: $5E
     ld   d, b                                     ; $4DD0: $50
@@ -2284,7 +2284,7 @@ jr_007_4DCB:
     cp   [hl]                                     ; $4DDF: $BE
     jr   nz, jr_007_4DEA                          ; $4DE0: $20 $08
 
-    ld   hl, wEntitiesSubstate2Table              ; $4DE2: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4DE2: $21 $C0 $C2
     add  hl, bc                                   ; $4DE5: $09
     ld   a, [hl]                                  ; $4DE6: $7E
     xor  $01                                      ; $4DE7: $EE $01
@@ -3239,11 +3239,11 @@ PincerEntityHandler::
     call $D853                                    ; $5345: $CD $53 $D8
     ld   d, e                                     ; $5348: $53
     ldh  a, [wActiveEntityPosX]                   ; $5349: $F0 $EE
-    ld   hl, wEntitiesSubstate1Table              ; $534B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $534B: $21 $B0 $C2
     add  hl, bc                                   ; $534E: $09
     ld   [hl], a                                  ; $534F: $77
     ldh  a, [$FFEF]                               ; $5350: $F0 $EF
-    ld   hl, wEntitiesSubstate2Table              ; $5352: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5352: $21 $C0 $C2
     add  hl, bc                                   ; $5355: $09
     ld   [hl], a                                  ; $5356: $77
     jp   IncrementEntityState                     ; $5357: $C3 $12 $3B
@@ -3327,11 +3327,11 @@ jr_007_53D5:
     push af                                       ; $53DA: $F5
     ldh  a, [hLinkPositionY]                      ; $53DB: $F0 $99
     push af                                       ; $53DD: $F5
-    ld   hl, wEntitiesSubstate1Table              ; $53DE: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $53DE: $21 $B0 $C2
     add  hl, bc                                   ; $53E1: $09
     ld   a, [hl]                                  ; $53E2: $7E
     ldh  [hLinkPositionX], a                      ; $53E3: $E0 $98
-    ld   hl, wEntitiesSubstate2Table              ; $53E5: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $53E5: $21 $C0 $C2
     add  hl, bc                                   ; $53E8: $09
     ld   a, [hl]                                  ; $53E9: $7E
     ldh  [hLinkPositionY], a                      ; $53EA: $E0 $99
@@ -3419,7 +3419,7 @@ func_007_5453:
     ret  c                                        ; $545D: $D8
 
     ldh  a, [wActiveEntityPosX]                   ; $545E: $F0 $EE
-    ld   hl, wEntitiesSubstate1Table              ; $5460: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5460: $21 $B0 $C2
     add  hl, bc                                   ; $5463: $09
     sub  [hl]                                     ; $5464: $96
     sra  a                                        ; $5465: $CB $2F
@@ -3427,7 +3427,7 @@ func_007_5453:
     ldh  [hScratch0], a                           ; $5469: $E0 $D7
     ldh  [hScratch2], a                           ; $546B: $E0 $D9
     ldh  a, [wActiveEntityPosY]                   ; $546D: $F0 $EC
-    ld   hl, wEntitiesSubstate2Table              ; $546F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $546F: $21 $C0 $C2
     add  hl, bc                                   ; $5472: $09
     sub  [hl]                                     ; $5473: $96
     sra  a                                        ; $5474: $CB $2F
@@ -3445,13 +3445,13 @@ func_007_5453:
 
 jr_007_548A:
     ldh  [$FFDB], a                               ; $548A: $E0 $DB
-    ld   hl, wEntitiesSubstate2Table              ; $548C: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $548C: $21 $C0 $C2
     add  hl, bc                                   ; $548F: $09
     ldh  a, [hScratch1]                           ; $5490: $F0 $D8
     add  [hl]                                     ; $5492: $86
     ld   [de], a                                  ; $5493: $12
     inc  de                                       ; $5494: $13
-    ld   hl, wEntitiesSubstate1Table              ; $5495: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5495: $21 $B0 $C2
     add  hl, bc                                   ; $5498: $09
     ldh  a, [hScratch0]                           ; $5499: $F0 $D7
     add  [hl]                                     ; $549B: $86
@@ -3818,7 +3818,7 @@ jr_007_566F:
     ld   hl, wEntitiesSpeedZTable                                ; $5689: $21 $20 $C3
     add  hl, bc                                   ; $568C: $09
     ld   [hl], b                                  ; $568D: $70
-    ld   hl, wEntitiesSubstate2Table              ; $568E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $568E: $21 $C0 $C2
     add  hl, bc                                   ; $5691: $09
     ld   [hl], b                                  ; $5692: $70
 
@@ -3858,7 +3858,7 @@ jr_007_56BD:
     ld   hl, wEntitiesStateTable                  ; $56C5: $21 $90 $C2
     add  hl, bc                                   ; $56C8: $09
     ld   [hl], $00                                ; $56C9: $36 $00
-    ld   hl, wEntitiesSubstate1Table              ; $56CB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $56CB: $21 $B0 $C2
     add  hl, bc                                   ; $56CE: $09
     ld   a, [hl]                                  ; $56CF: $7E
     inc  a                                        ; $56D0: $3C
@@ -3978,7 +3978,7 @@ label_007_577A:
     rra                                           ; $577C: $1F
     rra                                           ; $577D: $1F
     and  $01                                      ; $577E: $E6 $01
-    ld   hl, wEntitiesSubstate2Table              ; $5780: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5780: $21 $C0 $C2
     add  hl, bc                                   ; $5783: $09
     ld   [hl], a                                  ; $5784: $77
     call func_007_7E7D                            ; $5785: $CD $7D $7E
@@ -4438,13 +4438,13 @@ jr_007_59E2:
     ld   hl, $5978                                ; $59F5: $21 $78 $59
     add  hl, bc                                   ; $59F8: $09
     ld   a, [hl]                                  ; $59F9: $7E
-    ld   hl, wEntitiesSubstate1Table              ; $59FA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $59FA: $21 $B0 $C2
     add  hl, de                                   ; $59FD: $19
     ld   [hl], a                                  ; $59FE: $77
     ld   hl, $597F                                ; $59FF: $21 $7F $59
     add  hl, bc                                   ; $5A02: $09
     ld   a, [hl]                                  ; $5A03: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $5A04: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5A04: $21 $C0 $C2
     add  hl, de                                   ; $5A07: $19
     ld   [hl], a                                  ; $5A08: $77
     ld   hl, $5986                                ; $5A09: $21 $86 $59
@@ -4676,11 +4676,11 @@ jr_007_5B64:
     push af                                       ; $5B70: $F5
     ldh  a, [hLinkPositionY]                      ; $5B71: $F0 $99
     push af                                       ; $5B73: $F5
-    ld   hl, wEntitiesSubstate1Table              ; $5B74: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5B74: $21 $B0 $C2
     add  hl, bc                                   ; $5B77: $09
     ld   a, [hl]                                  ; $5B78: $7E
     ldh  [hLinkPositionX], a                      ; $5B79: $E0 $98
-    ld   hl, wEntitiesSubstate2Table              ; $5B7B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $5B7B: $21 $C0 $C2
     add  hl, bc                                   ; $5B7E: $09
     ld   a, [hl]                                  ; $5B7F: $7E
     ldh  [hLinkPositionY], a                      ; $5B80: $E0 $99
@@ -5151,7 +5151,7 @@ SmashablePillarEntityHandler::
     ld   [$DE00], a                               ; $5DCD: $EA $00 $DE
 
 jr_007_5DD0:
-    ld   hl, wEntitiesSubstate1Table              ; $5DD0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5DD0: $21 $B0 $C2
     add  hl, bc                                   ; $5DD3: $09
     ld   a, [hl]                                  ; $5DD4: $7E
     cp   $02                                      ; $5DD5: $FE $02
@@ -5284,7 +5284,7 @@ jr_007_5E67:
     ld   hl, wEntitiesTransitionCountdownTable           ; $5E9A: $21 $E0 $C2
     add  hl, de                                   ; $5E9D: $19
     ld   [hl], $10                                ; $5E9E: $36 $10
-    ld   hl, wEntitiesSubstate1Table              ; $5EA0: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5EA0: $21 $B0 $C2
     add  hl, de                                   ; $5EA3: $19
     ld   [hl], $01                                ; $5EA4: $36 $01
 
@@ -5421,7 +5421,7 @@ func_007_5F61:
     call SpawnNewEntity_trampoline                ; $5F63: $CD $86 $3B
     jr   c, jr_007_5F9A                           ; $5F66: $38 $32
 
-    ld   hl, wEntitiesSubstate1Table              ; $5F68: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $5F68: $21 $B0 $C2
     add  hl, de                                   ; $5F6B: $19
     ld   [hl], $02                                ; $5F6C: $36 $02
     ld   hl, wEntitiesPhysicsFlagsTable                ; $5F6E: $21 $40 $C3
@@ -5854,7 +5854,7 @@ SideViewWeightsEntityHandler::
     and  a                                        ; $61E4: $A7
     jr   nz, jr_007_61FA                          ; $61E5: $20 $13
 
-    ld   hl, wEntitiesSubstate2Table              ; $61E7: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $61E7: $21 $C0 $C2
     add  hl, bc                                   ; $61EA: $09
     ld   a, [hl]                                  ; $61EB: $7E
     and  a                                        ; $61EC: $A7
@@ -6142,7 +6142,7 @@ SideViewPlatformVerticalEntityHandler::
     cp   $A4                                      ; $6374: $FE $A4
     jp   z, $63FB                                 ; $6376: $CA $FB $63
 
-    ld   hl, wEntitiesSubstate1Table              ; $6379: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6379: $21 $B0 $C2
     add  hl, bc                                   ; $637C: $09
     ld   e, [hl]                                  ; $637D: $5E
     ld   d, b                                     ; $637E: $50
@@ -6158,7 +6158,7 @@ SideViewPlatformVerticalEntityHandler::
     cp   [hl]                                     ; $638E: $BE
     jr   nz, jr_007_639E                          ; $638F: $20 $0D
 
-    ld   hl, wEntitiesSubstate1Table              ; $6391: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6391: $21 $B0 $C2
     add  hl, bc                                   ; $6394: $09
     ld   a, [hl]                                  ; $6395: $7E
     xor  $01                                      ; $6396: $EE $01
@@ -6169,7 +6169,7 @@ SideViewPlatformVerticalEntityHandler::
 func_007_639E:
 label_007_639E:
 jr_007_639E:
-    ld   hl, wEntitiesSubstate2Table              ; $639E: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $639E: $21 $C0 $C2
     add  hl, bc                                   ; $63A1: $09
     ld   [hl], b                                  ; $63A2: $70
     ldh  a, [wActiveEntityPosX]                   ; $63A3: $F0 $EE
@@ -6216,7 +6216,7 @@ jr_007_639E:
     ldh  [hLinkPositionYIncrement], a             ; $63E9: $E0 $9B
     ld   a, $01                                   ; $63EB: $3E $01
     ld   [$C147], a                               ; $63ED: $EA $47 $C1
-    ld   hl, wEntitiesSubstate2Table              ; $63F0: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $63F0: $21 $C0 $C2
     add  hl, bc                                   ; $63F3: $09
     ld   [hl], $10                                ; $63F4: $36 $10
 
@@ -6239,7 +6239,7 @@ jr_007_63F6:
     cp   [hl]                                     ; $640F: $BE
     jr   nz, jr_007_641F                          ; $6410: $20 $0D
 
-    ld   hl, wEntitiesSubstate1Table              ; $6412: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6412: $21 $B0 $C2
     add  hl, bc                                   ; $6415: $09
     ld   a, [hl]                                  ; $6416: $7E
     xor  $01                                      ; $6417: $EE $01
@@ -6278,7 +6278,7 @@ jr_007_643B:
     call label_3CE6                               ; $6440: $CD $E6 $3C
     call func_007_7D96                            ; $6443: $CD $96 $7D
     call func_007_639E                            ; $6446: $CD $9E $63
-    ld   hl, wEntitiesSubstate2Table              ; $6449: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6449: $21 $C0 $C2
     add  hl, bc                                   ; $644C: $09
     ld   a, [hl]                                  ; $644D: $7E
     and  a                                        ; $644E: $A7
@@ -6580,7 +6580,7 @@ jr_007_65CB:
     ld   [hl+], a                                 ; $65D9: $22
 
 GoombaEntityHandler::
-    ld   hl, wEntitiesSubstate1Table              ; $65DA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $65DA: $21 $B0 $C2
     add  hl, bc                                   ; $65DD: $09
     ld   a, [hl]                                  ; $65DE: $7E
     and  a                                        ; $65DF: $A7
@@ -6869,7 +6869,7 @@ jr_007_6776:
     call IncrementEntityState                     ; $677B: $CD $12 $3B
 
 jr_007_677E:
-    ld   hl, wEntitiesSubstate1Table              ; $677E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $677E: $21 $B0 $C2
     add  hl, bc                                   ; $6781: $09
     ld   a, [hl]                                  ; $6782: $7E
     and  a                                        ; $6783: $A7
@@ -6884,7 +6884,7 @@ jr_007_677E:
 jr_007_678D:
     jp   label_007_67AE                           ; $678D: $C3 $AE $67
 
-    ld   hl, wEntitiesSubstate1Table              ; $6790: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6790: $21 $B0 $C2
     add  hl, bc                                   ; $6793: $09
     ld   a, [hl]                                  ; $6794: $7E
     cp   $08                                      ; $6795: $FE $08
@@ -6907,7 +6907,7 @@ jr_007_67A7:
 func_007_67AE:
 label_007_67AE:
 jr_007_67AE:
-    ld   hl, wEntitiesSubstate1Table              ; $67AE: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $67AE: $21 $B0 $C2
     add  hl, bc                                   ; $67B1: $09
     ld   a, [hl]                                  ; $67B2: $7E
     ld   hl, wEntitiesUnknowTableY                ; $67B3: $21 $D0 $C3
@@ -6972,7 +6972,7 @@ jr_007_67F6:
     jr   c, jr_007_683D                           ; $67FE: $38 $3D
 
     ld   [hl], b                                  ; $6800: $70
-    ld   hl, wEntitiesSubstate2Table              ; $6801: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6801: $21 $C0 $C2
     add  hl, bc                                   ; $6804: $09
     ld   a, [hl]                                  ; $6805: $7E
     ld   hl, wEntitiesUnknowTableP                ; $6806: $21 $40 $C4
@@ -7004,7 +7004,7 @@ jr_007_67F6:
     call GetRandomByte                            ; $6832: $CD $0D $28
     and  $02                                      ; $6835: $E6 $02
     dec  a                                        ; $6837: $3D
-    ld   hl, wEntitiesSubstate2Table              ; $6838: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $6838: $21 $C0 $C2
     add  hl, bc                                   ; $683B: $09
     ld   [hl], a                                  ; $683C: $77
 
@@ -7269,7 +7269,7 @@ jr_007_69AC:
     call GetEntityTransitionCountdown                 ; $69B0: $CD $05 $0C
     ret  nz                                       ; $69B3: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $69B4: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $69B4: $21 $B0 $C2
     add  hl, bc                                   ; $69B7: $09
     ld   a, [hl]                                  ; $69B8: $7E
     ld   e, a                                     ; $69B9: $5F
@@ -7841,7 +7841,7 @@ jr_007_6CFE:
 
     call IncrementEntityState                     ; $6D20: $CD $12 $3B
     call func_007_733F                            ; $6D23: $CD $3F $73
-    ld   hl, wEntitiesSubstate1Table              ; $6D26: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6D26: $21 $B0 $C2
     add  hl, bc                                   ; $6D29: $09
     ld   a, [hl]                                  ; $6D2A: $7E
     ld   hl, wEntitiesSpeedZTable                                ; $6D2B: $21 $20 $C3
@@ -8123,7 +8123,7 @@ jr_007_6EA1:
     ret                                           ; $6EA1: $C9
 
 func_007_6EA2:
-    ld   hl, wEntitiesSubstate1Table              ; $6EA2: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6EA2: $21 $B0 $C2
     add  hl, bc                                   ; $6EA5: $09
     ld   [hl], b                                  ; $6EA6: $70
     call func_007_7E5D                            ; $6EA7: $CD $5D $7E
@@ -8140,7 +8140,7 @@ func_007_6EA2:
     cp   $02                                      ; $6EBA: $FE $02
     ret  nz                                       ; $6EBC: $C0
 
-    ld   hl, wEntitiesSubstate1Table              ; $6EBD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $6EBD: $21 $B0 $C2
     add  hl, bc                                   ; $6EC0: $09
     ld   [hl], $01                                ; $6EC1: $36 $01
 
@@ -8886,7 +8886,7 @@ jr_007_7302:
     call GetRandomByte                            ; $7313: $CD $0D $28
     and  $03                                      ; $7316: $E6 $03
     add  $03                                      ; $7318: $C6 $03
-    ld   hl, wEntitiesSubstate1Table              ; $731A: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $731A: $21 $B0 $C2
     add  hl, bc                                   ; $731D: $09
     ld   [hl], a                                  ; $731E: $77
 
@@ -8985,7 +8985,7 @@ jr_007_739B:
     ld   [hl], $04                                ; $73B4: $36 $04
     call GetEntityTransitionCountdown                 ; $73B6: $CD $05 $0C
     ld   [hl], $20                                ; $73B9: $36 $20
-    ld   hl, wEntitiesSubstate1Table              ; $73BB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $73BB: $21 $B0 $C2
     add  hl, bc                                   ; $73BE: $09
     dec  [hl]                                     ; $73BF: $35
     jr   nz, jr_007_73D2                          ; $73C0: $20 $10
@@ -9193,7 +9193,7 @@ FlyingTilesEntityHandler::
     jr   c, jr_007_752C                           ; $74C8: $38 $62
 
 jr_007_74CA:
-    ld   hl, wEntitiesSubstate1Table              ; $74CA: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $74CA: $21 $B0 $C2
     add  hl, de                                   ; $74CD: $19
     ld   [hl], $02                                ; $74CE: $36 $02
     push bc                                       ; $74D0: $C5
@@ -9319,13 +9319,13 @@ jr_007_756A:
     call GetRandomByte                            ; $7580: $CD $0D $28
     and  $02                                      ; $7583: $E6 $02
     dec  a                                        ; $7585: $3D
-    ld   hl, wEntitiesSubstate1Table              ; $7586: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $7586: $21 $B0 $C2
     add  hl, bc                                   ; $7589: $09
     ld   [hl], a                                  ; $758A: $77
     call GetRandomByte                            ; $758B: $CD $0D $28
     and  $02                                      ; $758E: $E6 $02
     dec  a                                        ; $7590: $3D
-    ld   hl, wEntitiesSubstate2Table              ; $7591: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7591: $21 $C0 $C2
     add  hl, bc                                   ; $7594: $09
     ld   [hl], a                                  ; $7595: $77
 
@@ -9338,7 +9338,7 @@ jr_007_7596:
     and  $01                                      ; $759D: $E6 $01
     jr   nz, jr_007_75B6                          ; $759F: $20 $15
 
-    ld   hl, wEntitiesSubstate1Table              ; $75A1: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $75A1: $21 $B0 $C2
 
 jr_007_75A4:
     add  hl, bc                                   ; $75A4: $09
@@ -9347,7 +9347,7 @@ jr_007_75A4:
     add  hl, bc                                   ; $75A9: $09
     add  [hl]                                     ; $75AA: $86
     ld   [hl], a                                  ; $75AB: $77
-    ld   hl, wEntitiesSubstate2Table              ; $75AC: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $75AC: $21 $C0 $C2
     add  hl, bc                                   ; $75AF: $09
     ld   a, [hl]                                  ; $75B0: $7E
     call GetEntitySpeedYAddress                            ; $75B1: $CD $05 $40
@@ -10748,7 +10748,7 @@ label_007_7EA4:
     ret                                           ; $7EA9: $C9
 
 label_007_7EAA:
-    ld   hl, wEntitiesSubstate2Table              ; $7EAA: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7EAA: $21 $C0 $C2
     add  hl, bc                                   ; $7EAD: $09
     ld   a, [hl]                                  ; $7EAE: $7E
     rst  $00                                      ; $7EAF: $C7
@@ -10764,7 +10764,7 @@ label_007_7EAA:
     ld   [hl], $FF                                ; $7EBF: $36 $FF
 
 label_007_7EC1:
-    ld   hl, wEntitiesSubstate2Table              ; $7EC1: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $7EC1: $21 $C0 $C2
     add  hl, bc                                   ; $7EC4: $09
     inc  [hl]                                     ; $7EC5: $34
     ret                                           ; $7EC6: $C9

--- a/src/code/entities/genie.asm
+++ b/src/code/entities/genie.asm
@@ -1,7 +1,7 @@
 GenieEntityHandler::
     call label_394D                               ; $4000: $CD $4D $39
     call label_3EE8                               ; $4003: $CD $E8 $3E
-    ld   hl, wEntitiesSubstate1Table              ; $4006: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4006: $21 $B0 $C2
     add  hl, bc                                   ; $4009: $09
     ld   a, [hl]                                  ; $400A: $7E
     JP_TABLE                                      ; $400B: $C7
@@ -30,7 +30,7 @@ GenieState0Handler::
     add  hl, de                                   ; $4030: $19
     sub  $18                                      ; $4031: $D6 $18
     ld   [hl], a                                  ; $4033: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4034: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4034: $21 $B0 $C2
     add  hl, de                                   ; $4037: $19
     ld   [hl], $02                                ; $4038: $36 $02
     ld   hl, wEntitiesTransitionCountdownTable           ; $403A: $21 $E0 $C2
@@ -186,7 +186,7 @@ jr_004_4118:
     add  hl, de                                   ; $4130: $19
     sub  $26                                      ; $4131: $D6 $26
     ld   [hl], a                                  ; $4133: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4134: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4134: $21 $B0 $C2
     add  hl, de                                   ; $4137: $19
     ld   [hl], $02                                ; $4138: $36 $02
     ld   hl, wEntitiesTransitionCountdownTable           ; $413A: $21 $E0 $C2
@@ -592,7 +592,7 @@ jr_004_43B7:
     and  $01                                      ; $43B9: $E6 $01
     jr   nz, jr_004_43DD                          ; $43BB: $20 $20
 
-    ld   hl, wEntitiesSubstate2Table              ; $43BD: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $43BD: $21 $C0 $C2
     add  hl, bc                                   ; $43C0: $09
     ld   e, [hl]                                  ; $43C1: $5E
     ld   d, b                                     ; $43C2: $50
@@ -608,7 +608,7 @@ jr_004_43B7:
     cp   [hl]                                     ; $43D2: $BE
     jr   nz, jr_004_43DD                          ; $43D3: $20 $08
 
-    ld   hl, wEntitiesSubstate2Table              ; $43D5: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $43D5: $21 $C0 $C2
     add  hl, bc                                   ; $43D8: $09
     ld   a, [hl]                                  ; $43D9: $7E
     xor  $01                                      ; $43DA: $EE $01
@@ -660,7 +660,7 @@ jr_004_43FF:
     ld   hl, wEntitiesPosYTable                   ; $441B: $21 $10 $C2
     add  hl, de                                   ; $441E: $19
     ld   [hl], a                                  ; $441F: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4420: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4420: $21 $B0 $C2
     add  hl, de                                   ; $4423: $19
     ld   [hl], $03                                ; $4424: $36 $03
     ld   hl, wEntitiesSpeedZTable                                ; $4426: $21 $20 $C3
@@ -704,7 +704,7 @@ jr_004_4438:
     ld   hl, wEntitiesSpeedZTable                                ; $4463: $21 $20 $C3
     add  hl, de                                   ; $4466: $19
     ld   [hl], $24                                ; $4467: $36 $24
-    ld   hl, wEntitiesSubstate1Table              ; $4469: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4469: $21 $B0 $C2
     add  hl, de                                   ; $446C: $19
     ld   [hl], $04                                ; $446D: $36 $04
     ld   hl, wEntitiesPhysicsFlagsTable                ; $446F: $21 $40 $C3
@@ -805,7 +805,7 @@ func_004_44E9::
     ld   hl, wEntitiesPosYTable                   ; $4501: $21 $10 $C2
     add  hl, de                                   ; $4504: $19
     ld   [hl], a                                  ; $4505: $77
-    ld   hl, wEntitiesSubstate1Table              ; $4506: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4506: $21 $B0 $C2
     add  hl, de                                   ; $4509: $19
     ld   [hl], $02                                ; $450A: $36 $02
     ld   hl, wEntitiesTransitionCountdownTable           ; $450C: $21 $E0 $C2
@@ -941,7 +941,7 @@ jr_004_45A6:
     ld   hl, wEntitiesSpeedZTable                                ; $45D2: $21 $20 $C3
     add  hl, de                                   ; $45D5: $19
     ld   [hl], $24                                ; $45D6: $36 $24
-    ld   hl, wEntitiesSubstate1Table              ; $45D8: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $45D8: $21 $B0 $C2
     add  hl, de                                   ; $45DB: $19
     ld   [hl], $04                                ; $45DC: $36 $04
     ld   hl, wEntitiesPhysicsFlagsTable                ; $45DE: $21 $40 $C3
@@ -1187,7 +1187,7 @@ jr_004_4889:
     ld   hl, wEntitiesPosYTable                   ; $4889: $21 $10 $C2
     add  hl, de                                   ; $488C: $19
     ld   [hl], a                                  ; $488D: $77
-    ld   hl, wEntitiesSubstate1Table              ; $488E: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $488E: $21 $B0 $C2
     add  hl, de                                   ; $4891: $19
     ld   [hl], $01                                ; $4892: $36 $01
     ld   hl, wEntitiesTransitionCountdownTable           ; $4894: $21 $E0 $C2

--- a/src/code/entities/moving_block.asm
+++ b/src/code/entities/moving_block.asm
@@ -19,11 +19,11 @@ MovingBlockLeftTopState0Handler::
     ld   hl, wEntitiesPosYTable                   ; $4113: $21 $10 $C2
     add  hl, bc                                   ; $4116: $09
     ld   a, [hl]                                  ; $4117: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $4118: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4118: $21 $C0 $C2
     add  hl, bc                                   ; $411B: $09
     ld   [hl], a                                  ; $411C: $77
     add  $10                                      ; $411D: $C6 $10
-    ld   hl, wEntitiesSubstate1Table              ; $411F: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $411F: $21 $B0 $C2
     add  hl, bc                                   ; $4122: $09
     ld   [hl], a                                  ; $4123: $77
     jp   IncrementEntityState                     ; $4124: $C3 $12 $3B
@@ -46,7 +46,7 @@ MovingBlockLeftTopState1Handler::
     ld   [hl], b                                  ; $413A: $70
     ld   a, $11                                   ; $413B: $3E $11
     ldh  [hNoiseSfx], a                           ; $413D: $E0 $F4
-    ld   hl, wEntitiesSubstate2Table              ; $413F: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $413F: $21 $C0 $C2
     add  hl, bc                                   ; $4142: $09
     ld   a, [hl]                                  ; $4143: $7E
     ld   hl, wEntitiesPosYTable                         ; $4144: $21 $10 $C2
@@ -60,7 +60,7 @@ jr_015_414C:
     ret                                           ; $414C: $C9
 
 jr_015_414D:
-    ld   hl, wEntitiesSubstate1Table              ; $414D: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $414D: $21 $B0 $C2
     add  hl, bc                                   ; $4150: $09
     ld   a, [hl]                                  ; $4151: $7E
     ld   hl, wEntitiesPosYTable                         ; $4152: $21 $10 $C2
@@ -170,11 +170,11 @@ MovingBlockLeftBottomState0Handler::
     ld   hl, wEntitiesPosYTable                   ; $41DD: $21 $10 $C2
     add  hl, bc                                   ; $41E0: $09
     ld   a, [hl]                                  ; $41E1: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $41E2: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $41E2: $21 $C0 $C2
     add  hl, bc                                   ; $41E5: $09
     ld   [hl], a                                  ; $41E6: $77
     sub  $10                                      ; $41E7: $D6 $10
-    ld   hl, wEntitiesSubstate1Table              ; $41E9: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $41E9: $21 $B0 $C2
     add  hl, bc                                   ; $41EC: $09
     ld   [hl], a                                  ; $41ED: $77
     jp   IncrementEntityState                     ; $41EE: $C3 $12 $3B
@@ -197,7 +197,7 @@ MovingBlockLeftBottomState1Handler::
     ld   [hl], b                                  ; $4204: $70
     ld   a, $11                                   ; $4205: $3E $11
     ldh  [hNoiseSfx], a                           ; $4207: $E0 $F4
-    ld   hl, wEntitiesSubstate2Table              ; $4209: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4209: $21 $C0 $C2
     add  hl, bc                                   ; $420C: $09
     ld   a, [hl]                                  ; $420D: $7E
     ld   hl, wEntitiesPosYTable                         ; $420E: $21 $10 $C2
@@ -211,7 +211,7 @@ jr_015_4216:
     ret                                           ; $4216: $C9
 
 jr_015_4217:
-    ld   hl, wEntitiesSubstate1Table              ; $4217: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4217: $21 $B0 $C2
     add  hl, bc                                   ; $421A: $09
     ld   a, [hl]                                  ; $421B: $7E
     ld   hl, wEntitiesPosYTable                         ; $421C: $21 $10 $C2
@@ -255,11 +255,11 @@ MovingBlockBottomLeftState0Handler::
     ld   hl, wEntitiesPosXTable                   ; $424F: $21 $00 $C2
     add  hl, bc                                   ; $4252: $09
     ld   a, [hl]                                  ; $4253: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $4254: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $4254: $21 $C0 $C2
     add  hl, bc                                   ; $4257: $09
     ld   [hl], a                                  ; $4258: $77
     add  $10                                      ; $4259: $C6 $10
-    ld   hl, wEntitiesSubstate1Table              ; $425B: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $425B: $21 $B0 $C2
     add  hl, bc                                   ; $425E: $09
     ld   [hl], a                                  ; $425F: $77
     jp   IncrementEntityState                     ; $4260: $C3 $12 $3B
@@ -282,7 +282,7 @@ MovingBlockBottomLeftState1Handler::
     ld   [hl], b                                  ; $4276: $70
     ld   a, $11                                   ; $4277: $3E $11
     ldh  [hNoiseSfx], a                           ; $4279: $E0 $F4
-    ld   hl, wEntitiesSubstate2Table              ; $427B: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $427B: $21 $C0 $C2
     add  hl, bc                                   ; $427E: $09
     ld   a, [hl]                                  ; $427F: $7E
     ld   hl, wEntitiesPosXTable                         ; $4280: $21 $00 $C2
@@ -296,7 +296,7 @@ jr_015_4288:
     ret                                           ; $4288: $C9
 
 jr_015_4289:
-    ld   hl, wEntitiesSubstate1Table              ; $4289: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4289: $21 $B0 $C2
     add  hl, bc                                   ; $428C: $09
     ld   a, [hl]                                  ; $428D: $7E
     ld   hl, wEntitiesPosXTable                         ; $428E: $21 $00 $C2
@@ -340,11 +340,11 @@ MovingBlockBottomRightState0Handler::
     ld   hl, wEntitiesPosXTable                   ; $42C1: $21 $00 $C2
     add  hl, bc                                   ; $42C4: $09
     ld   a, [hl]                                  ; $42C5: $7E
-    ld   hl, wEntitiesSubstate2Table              ; $42C6: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $42C6: $21 $C0 $C2
     add  hl, bc                                   ; $42C9: $09
     ld   [hl], a                                  ; $42CA: $77
     sub  $10                                      ; $42CB: $D6 $10
-    ld   hl, wEntitiesSubstate1Table              ; $42CD: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $42CD: $21 $B0 $C2
     add  hl, bc                                   ; $42D0: $09
     ld   [hl], a                                  ; $42D1: $77
     jp   IncrementEntityState                     ; $42D2: $C3 $12 $3B
@@ -367,7 +367,7 @@ MovingBlockBottomRightState1Handler::
     ld   [hl], b                                  ; $42E8: $70
     ld   a, $11                                   ; $42E9: $3E $11
     ldh  [hNoiseSfx], a                           ; $42EB: $E0 $F4
-    ld   hl, wEntitiesSubstate2Table              ; $42ED: $21 $C0 $C2
+    ld   hl, wEntitiesPrivateState2Table          ; $42ED: $21 $C0 $C2
     add  hl, bc                                   ; $42F0: $09
     ld   a, [hl]                                  ; $42F1: $7E
     ld   hl, wEntitiesPosXTable                         ; $42F2: $21 $00 $C2
@@ -381,7 +381,7 @@ jr_015_42FA:
     ret                                           ; $42FA: $C9
 
 jr_015_42FB:
-    ld   hl, wEntitiesSubstate1Table              ; $42FB: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $42FB: $21 $B0 $C2
     add  hl, bc                                   ; $42FE: $09
     ld   a, [hl]                                  ; $42FF: $7E
     ld   hl, wEntitiesPosXTable                         ; $4300: $21 $00 $C2

--- a/src/code/entities/slime_eye.asm
+++ b/src/code/entities/slime_eye.asm
@@ -205,7 +205,7 @@ jr_004_4AA5:
     rra                                           ; $4AAD: $1F
     and  $01                                      ; $4AAE: $E6 $01
     call SetEntitySpriteVariant                   ; $4AB0: $CD $0C $3B
-    ld   hl, wEntitiesSubstate1Table              ; $4AB3: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4AB3: $21 $B0 $C2
     add  hl, bc                                   ; $4AB6: $09
     ld   a, [hl]                                  ; $4AB7: $7E
     and  a                                        ; $4AB8: $A7
@@ -217,7 +217,7 @@ jr_004_4AA5:
     jr   nz, jr_004_4ACB                          ; $4AC2: $20 $07
 
     ld   [hl], $28                                ; $4AC4: $36 $28
-    ld   hl, wEntitiesSubstate1Table              ; $4AC6: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4AC6: $21 $B0 $C2
     add  hl, bc                                   ; $4AC9: $09
     dec  [hl]                                     ; $4ACA: $35
 
@@ -256,7 +256,7 @@ jr_004_4AEF:
 
     call IsEntityUnknownFZero                                ; $4B02: $CD $00 $0C
     ld   [hl], $50                                ; $4B05: $36 $50
-    ld   hl, wEntitiesSubstate1Table              ; $4B07: $21 $B0 $C2
+    ld   hl, wEntitiesPrivateState1Table          ; $4B07: $21 $B0 $C2
     add  hl, bc                                   ; $4B0A: $09
     ld   a, [hl]                                  ; $4B0B: $7E
     cp   $04                                      ; $4B0C: $FE $04

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -453,14 +453,14 @@ wEntitiesCollisionsTable:: ; C2A0
 ;  - Butterfly: stores a delta X to move closer to Link
 ;  - Genie: store the substate
 ;  - LikeLike: swallowed item
-wEntitiesSubstate1Table:: ; C2B0
+wEntitiesPrivateState1Table:: ; C2B0
   ds $10
 
 ; Entity-specific state.
 ;
 ; Examples:
 ;  - Butterfly: stores a delta Y to move closer to Link
-wEntitiesSubstate2Table:: ; C2C0
+wEntitiesPrivateState2Table:: ; C2C0
   ds $10
 
 wEntitiesUnknownTableD:: ; C2D0
@@ -584,6 +584,7 @@ wEntitiesFlashCountdownTable:: ; C420
 wEntitiesUnknowTableH::  ; C430
   ds $10
 
+; Entities-specific private state?
 wEntitiesUnknowTableP:: ; C440
   ds $10
 


### PR DESCRIPTION
It makes more sense to state the state is not subordinate to the main state, but private as in entity-specific.