### PR TITLE
Adding/shifting health and rupee buffer labels

### DIFF
--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -884,12 +884,12 @@ label_531D::
     xor  a
     ld   [wLinkMotionState], a
     ldh  [$FF9C], a
-    ld   [wSubstractRupeeBufferLow], a
-    ld   [$DB94], a
-    ld   [wAddRupeeBufferHigh], a
-    ld   [$DB8F], a
-    ld   [wSubstractRupeeBufferHigh], a
+    ld   [wAddHealthBuffer], a
+    ld   [wSubtractHealthBuffer], a
     ld   [wAddRupeeBufferLow], a
+    ld   [wAddRupeeBufferHigh], a
+    ld   [wSubstractRupeeBufferLow], a
+    ld   [wSubstractRupeeBufferHigh], a
     ld   a, [$DB6F]
     and  a
     jr   nz, .setStartingPoint

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -2458,9 +2458,9 @@ jr_002_518E:
 
 jr_002_51AC:
     call label_002_52B9                           ; $51AC: $CD $B9 $52
-    ld   a, [wDB94]                               ; $51AF: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $51AF: $FA $94 $DB
     add  $04                                      ; $51B2: $C6 $04
-    ld   [wDB94], a                               ; $51B4: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $51B4: $EA $94 $DB
     xor  a                                        ; $51B7: $AF
     ld   [wC167], a                               ; $51B8: $EA $67 $C1
     ret                                           ; $51BB: $C9
@@ -2595,9 +2595,9 @@ LinkMotionRecoverHandler::
     cp   $06                                      ; $5277: $FE $06
     jr   nz, jr_002_5283                          ; $5279: $20 $08
 
-    ld   a, [wDB94]                               ; $527B: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $527B: $FA $94 $DB
     add  $04                                      ; $527E: $C6 $04
-    ld   [wDB94], a                               ; $5280: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $5280: $EA $94 $DB
 
 jr_002_5283:
     xor  a                                        ; $5283: $AF
@@ -4526,16 +4526,16 @@ UpdateRupeesCount::
     ret                                           ; $621A: $C9
 .C3CENotZero
 
-    ld   hl, $DB8F                                ; $621B: $21 $8F $DB
-    ld   a, [wAddRupeeBufferHigh]                 ; $621E: $FA $90 $DB
+    ld   hl, wAddRupeeBufferHigh                  ; $621B: $21 $8F $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $621E: $FA $90 $DB
     or   [hl]                                     ; $6221: $B6
     jr   z, .jr_002_6274                          ; $6222: $28 $50
 
     ld   a, WAVE_SFX_RUPEE                        ; $6224: $3E $05
     ldh  [hWaveSfx], a                            ; $6226: $E0 $F3
-    ld   a, [wAddRupeeBufferHigh]                 ; $6228: $FA $90 $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $6228: $FA $90 $DB
     ld   e, a                                     ; $622B: $5F
-    ld   a, [$DB8F]                               ; $622C: $FA $8F $DB
+    ld   a, [wAddRupeeBufferHigh]                 ; $622C: $FA $8F $DB
     sla  e                                        ; $622F: $CB $23
     rla                                           ; $6231: $17
     sla  e                                        ; $6232: $CB $23
@@ -4550,9 +4550,9 @@ UpdateRupeesCount::
 .noReinitTo9
 
     ld   e, a                                     ; $623F: $5F
-    ld   a, [wAddRupeeBufferHigh]                 ; $6240: $FA $90 $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $6240: $FA $90 $DB
     sub  e                                        ; $6243: $93
-    ld   [wAddRupeeBufferHigh], a                 ; $6244: $EA $90 $DB
+    ld   [wAddRupeeBufferLow], a                  ; $6244: $EA $90 $DB
     ld   a, [hl]                                  ; $6247: $7E
     sbc  $00                                      ; $6248: $DE $00
     ld   [hl], a                                  ; $624A: $77
@@ -4572,23 +4572,23 @@ UpdateRupeesCount::
     ld   a, $99                                   ; $6265: $3E $99
     ld   [wRupeeCountLow], a                      ; $6267: $EA $5E $DB
     xor  a                                        ; $626A: $AF
-    ld   [$DB8F], a                               ; $626B: $EA $8F $DB
-    ld   [wAddRupeeBufferHigh], a                 ; $626E: $EA $90 $DB
+    ld   [wAddRupeeBufferHigh], a                 ; $626B: $EA $8F $DB
+    ld   [wAddRupeeBufferLow], a                  ; $626E: $EA $90 $DB
 .rupeesLessThan16
 
     call LoadRupeesDigits                           ; $6271: $CD $CE $62
 
 .jr_002_6274
-    ld   hl, wAddRupeeBufferLow                   ; $6274: $21 $91 $DB
-    ld   a, [wSubstractRupeeBufferHigh]           ; $6277: $FA $92 $DB
+    ld   hl, wSubstractRupeeBufferHigh            ; $6274: $21 $91 $DB
+    ld   a, [wSubstractRupeeBufferLow]            ; $6277: $FA $92 $DB
     or   [hl]                                     ; $627A: $B6
     ret  z                                        ; $627B: $C8
 
     ld   a, NOISE_SFX_RUPEE                             ; $627C: $3E $05
     ldh  [hWaveSfx], a                                ; $627E: $E0 $F3
-    ld   a, [wSubstractRupeeBufferHigh]           ; $6280: $FA $92 $DB
+    ld   a, [wSubstractRupeeBufferLow]            ; $6280: $FA $92 $DB
     ld   e, a                                     ; $6283: $5F
-    ld   a, [wAddRupeeBufferLow]                  ; $6284: $FA $91 $DB
+    ld   a, [wSubstractRupeeBufferHigh]           ; $6284: $FA $91 $DB
     sla  e                                        ; $6287: $CB $23
     rla                                           ; $6289: $17
     sla  e                                        ; $628A: $CB $23
@@ -4603,9 +4603,9 @@ UpdateRupeesCount::
 
     ; If wRupeeCountLow == 0 || wRupeeCountHigh == 0, return
     ld   e, a                                     ; $6297: $5F
-    ld   a, [wSubstractRupeeBufferHigh]           ; $6298: $FA $92 $DB
+    ld   a, [wSubstractRupeeBufferLow]            ; $6298: $FA $92 $DB
     sub  e                                        ; $629B: $93
-    ld   [wSubstractRupeeBufferHigh], a           ; $629C: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $629C: $EA $92 $DB
     ld   a, [hl]                                  ; $629F: $7E
     sbc  $00                                      ; $62A0: $DE $00
     ld   [hl], a                                  ; $62A2: $77
@@ -4628,8 +4628,8 @@ UpdateRupeesCount::
     xor  a                                        ; $62BE: $AF
     ld   [wRupeeCountHigh], a                     ; $62BF: $EA $5D $DB
     ld   [wRupeeCountLow], a                      ; $62C2: $EA $5E $DB
-    ld   [wAddRupeeBufferLow], a                  ; $62C5: $EA $91 $DB
-    ld   [wSubstractRupeeBufferHigh], a           ; $62C8: $EA $92 $DB
+    ld   [wSubstractRupeeBufferHigh], a           ; $62C5: $EA $91 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $62C8: $EA $92 $DB
 .resetEnd
 
     jp   LoadRupeesDigits                           ; $62CB: $C3 $CE $62
@@ -4709,12 +4709,12 @@ jr_002_6342:
     and  a                                        ; $634B: $A7
     jr   nz, jr_002_63A2                          ; $634C: $20 $54
 
-    ld   a, [wSubstractRupeeBufferLow]            ; $634E: $FA $93 $DB
+    ld   a, [wAddHealthBuffer]                    ; $634E: $FA $93 $DB
     and  a                                        ; $6351: $A7
     jr   z, jr_002_6385                           ; $6352: $28 $31
 
     dec  a                                        ; $6354: $3D
-    ld   [wSubstractRupeeBufferLow], a            ; $6355: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $6355: $EA $93 $DB
     ld   a, [wMaxHealth]                          ; $6358: $FA $5B $DB
     cp   $0F                                      ; $635B: $FE $0F
     jr   c, jr_002_6361                           ; $635D: $38 $02
@@ -4731,7 +4731,7 @@ jr_002_6361:
     jr   nz, jr_002_6374                          ; $636C: $20 $06
 
     xor  a                                        ; $636E: $AF
-    ld   [wSubstractRupeeBufferLow], a            ; $636F: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $636F: $EA $93 $DB
     jr   jr_002_6385                              ; $6372: $18 $11
 
 jr_002_6374:
@@ -4748,12 +4748,12 @@ jr_002_6382:
     jp   LoadHeartsCount                          ; $6382: $C3 $14 $64
 
 jr_002_6385:
-    ld   a, [wDB94]                               ; $6385: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $6385: $FA $94 $DB
     and  a                                        ; $6388: $A7
     jr   z, jr_002_63A2                           ; $6389: $28 $17
 
     dec  a                                        ; $638B: $3D
-    ld   [wDB94], a                               ; $638C: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $638C: $EA $94 $DB
     ld   a, [wHealth]                             ; $638F: $FA $5A $DB
     and  a                                        ; $6392: $A7
     jr   z, jr_002_6399                           ; $6393: $28 $04
@@ -4779,9 +4779,9 @@ jr_002_63A3:
     ld   [wHasMedicine], a                        ; $63AA: $EA $0D $DB
     ld   a, $08                                   ; $63AD: $3E $08
     ld   [wHealth], a                             ; $63AF: $EA $5A $DB
-    ld   a, [wSubstractRupeeBufferLow]            ; $63B2: $FA $93 $DB
+    ld   a, [wAddHealthBuffer]                    ; $63B2: $FA $93 $DB
     add  $80                                      ; $63B5: $C6 $80
-    ld   [wSubstractRupeeBufferLow], a            ; $63B7: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $63B7: $EA $93 $DB
     ld   a, $A0                                   ; $63BA: $3E $A0
     ld   [$DBC7], a                               ; $63BC: $EA $C7 $DB
     ld   a, [wRequests]                           ; $63BF: $FA $00 $D6
@@ -4989,9 +4989,9 @@ func_002_6910::
     jr   nz, jr_002_692B                          ; $6914: $20 $15
 
     call label_002_7719                           ; $6916: $CD $19 $77
-    ld   a, [wDB94]                               ; $6919: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $6919: $FA $94 $DB
     add  $04                                      ; $691C: $C6 $04
-    ld   [wDB94], a                               ; $691E: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $691E: $EA $94 $DB
     ld   a, WAVE_SFX_LINK_HURT                    ; $6921: $3E $03
     ldh  [hWaveSfx], a                            ; $6923: $E0 $F3
     ld   a, $80                                   ; $6925: $3E $80
@@ -7301,9 +7301,9 @@ jr_002_761E:
     ld   [$C13E], a                               ; $7620: $EA $3E $C1
     ld   a, $30                                   ; $7623: $3E $30
     ld   [$DBC7], a                               ; $7625: $EA $C7 $DB
-    ld   a, [wDB94]                               ; $7628: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $7628: $FA $94 $DB
     add  $04                                      ; $762B: $C6 $04
-    ld   [wDB94], a                               ; $762D: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $762D: $EA $94 $DB
     ld   a, WAVE_SFX_LINK_HURT                    ; $7630: $3E $03
     ldh  [hWaveSfx], a                            ; $7632: $E0 $F3
 

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -622,9 +622,9 @@ jr_020_4917:
     dec  c                                        ; $4924: $0D
     ld   [$DDD8], a                               ; $4925: $EA $D8 $DD
     ld   [hl], a                                  ; $4928: $77
-    ld   a, [wAddRupeeBufferHigh]                 ; $4929: $FA $90 $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $4929: $FA $90 $DB
     add  $05                                      ; $492C: $C6 $05
-    ld   [wAddRupeeBufferHigh], a                 ; $492E: $EA $90 $DB
+    ld   [wAddRupeeBufferLow], a                  ; $492E: $EA $90 $DB
     di                                            ; $4931: $F3
     ld   a, $05                                   ; $4932: $3E $05
     ld   [rSVBK], a                               ; $4934: $E0 $70

--- a/src/code/entities/anti_kirby.asm
+++ b/src/code/entities/anti_kirby.asm
@@ -312,7 +312,7 @@ jr_006_440C:
     ld   a, $02                                   ; $4417: $3E $02
     ld   [$C146], a                               ; $4419: $EA $46 $C1
     ld   a, $02                                   ; $441C: $3E $02
-    ld   [wDB94], a                               ; $441E: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $441E: $EA $94 $DB
     ld   a, $08                                   ; $4421: $3E $08
     ldh  [hJingle], a                             ; $4423: $E0 $F2
     jp   IncrementEntityState                     ; $4425: $C3 $12 $3B

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -1149,9 +1149,9 @@ func_015_499C::
     ld   [$C13E], a                               ; $49AD: $EA $3E $C1
     ld   a, $40                                   ; $49B0: $3E $40
     ld   [$DBC7], a                               ; $49B2: $EA $C7 $DB
-    ld   a, [wDB94]                               ; $49B5: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $49B5: $FA $94 $DB
     add  $08                                      ; $49B8: $C6 $08
-    ld   [wDB94], a                               ; $49BA: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $49BA: $EA $94 $DB
     ld   a, $0B                                   ; $49BD: $3E $0B
     ldh  [hJingle], a                             ; $49BF: $E0 $F2
     ret                                           ; $49C1: $C9
@@ -5583,7 +5583,7 @@ jr_015_6E4E:
     jr   z, jr_015_6E5A                           ; $6E54: $28 $04
 
     xor  a                                        ; $6E56: $AF
-    ld   [wDB94], a                               ; $6E57: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $6E57: $EA $94 $DB
 
 jr_015_6E5A:
     call func_015_7B0D                            ; $6E5A: $CD $0D $7B
@@ -6189,7 +6189,7 @@ func_015_72CF::
     jr   nz, jr_015_731D                          ; $72FB: $20 $20
 
     ld   a, $08                                   ; $72FD: $3E $08
-    ld   [wDB94], a                               ; $72FF: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $72FF: $EA $94 $DB
     ld   a, $20                                   ; $7302: $3E $20
     call GetVectorTowardsLink_trampoline          ; $7304: $CD $B5 $3B
     ldh  a, [hScratch0]                           ; $7307: $F0 $D7

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -126,12 +126,12 @@ jr_018_40AF:
     cp   $03                                      ; $40B2: $FE $03
     jr   c, jr_018_40A9                           ; $40B4: $38 $F3
 
-    ld   a, [wSubstractRupeeBufferHigh]           ; $40B6: $FA $92 $DB
+    ld   a, [wSubstractRupeeBufferLow]            ; $40B6: $FA $92 $DB
     add  $2C                                      ; $40B9: $C6 $2C
-    ld   [wSubstractRupeeBufferHigh], a           ; $40BB: $EA $92 $DB
-    ld   a, [wAddRupeeBufferLow]                  ; $40BE: $FA $91 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $40BB: $EA $92 $DB
+    ld   a, [wSubstractRupeeBufferHigh]           ; $40BE: $FA $91 $DB
     adc  $01                                      ; $40C1: $CE $01
-    ld   [wAddRupeeBufferLow], a                  ; $40C3: $EA $91 $DB
+    ld   [wSubstractRupeeBufferHigh], a           ; $40C3: $EA $91 $DB
     call GetEntityTransitionCountdown             ; $40C6: $CD $05 $0C
     ld   [hl], $FF                                ; $40C9: $36 $FF
     call label_27F2                               ; $40CB: $CD $F2 $27
@@ -9359,7 +9359,7 @@ jr_018_76FE:
     ld   a, $10                                   ; $7709: $3E $10
     ld   [$DBC7], a                               ; $770B: $EA $C7 $DB
     ld   a, $08                                   ; $770E: $3E $08
-    ld   [wDB94], a                               ; $7710: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $7710: $EA $94 $DB
     ld   a, $03                                   ; $7713: $3E $03
     ldh  [hWaveSfx], a                            ; $7715: $E0 $F3
 

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -470,7 +470,7 @@ jr_019_42E0:
     ld   bc, $CD02                                ; $42F3: $01 $02 $CD
     xor  a                                        ; $42F6: $AF
     inc  c                                        ; $42F7: $0C
-    ld   [wDB94], a                               ; $42F8: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $42F8: $EA $94 $DB
     ld   [$DBC7], a                               ; $42FB: $EA $C7 $DB
     ld   [$C13E], a                               ; $42FE: $EA $3E $C1
     ld   [wSwordAnimationState], a                ; $4301: $EA $37 $C1
@@ -9622,7 +9622,7 @@ jr_019_76D6:
     ld   a, $02                                   ; $76F5: $3E $02
     ld   [wSwordLevel], a                         ; $76F7: $EA $4E $DB
     ld   a, $FF                                   ; $76FA: $3E $FF
-    ld   [wSubstractRupeeBufferLow], a            ; $76FC: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $76FC: $EA $93 $DB
     xor  a                                        ; $76FF: $AF
     ld   [wSeashellsCount], a                     ; $7700: $EA $0F $DB
     ld   [wC167], a                               ; $7703: $EA $67 $C1

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1555,11 +1555,11 @@ jr_003_50B9:
     ld   hl, (Data_003_504F - 2)                  ; $50C1: $21 $4D $50
     add  hl, de                                   ; $50C4: $19
     ld   a, [hl]                                  ; $50C5: $7E
-    ld   [wAddRupeeBufferHigh], a                 ; $50C6: $EA $90 $DB
+    ld   [wAddRupeeBufferLow], a                  ; $50C6: $EA $90 $DB
     ld   hl, Data_003_5048                        ; $50C9: $21 $48 $50
     add  hl, de                                   ; $50CC: $19
     ld   a, [hl]                                  ; $50CD: $7E
-    ld   [$DB8F], a                               ; $50CE: $EA $8F $DB
+    ld   [wAddRupeeBufferHigh], a                 ; $50CE: $EA $8F $DB
     ld   a, $18                                   ; $50D1: $3E $18
     ld   [$C3CE], a                               ; $50D3: $EA $CE $C3
     jr   func_003_512A                              ; $50D6: $18 $52
@@ -2855,7 +2855,7 @@ HeartContainerEntityHandler::
     ; Increase max health
     ld   hl, wMaxHealth                           ; $59F0: $21 $5B $DB
     inc  [hl]                                     ; $59F3: $34
-    ld   hl, wSubstractRupeeBufferLow             ; $59F4: $21 $93 $DB
+    ld   hl, wAddHealthBuffer                     ; $59F4: $21 $93 $DB
     ld   [hl], $FF                                ; $59F7: $36 $FF
     call func_003_5134                            ; $59F9: $CD $34 $51
     ld   a, [hl]                                  ; $59FC: $7E
@@ -3001,7 +3001,7 @@ HeartPieceState6Handler::
     xor  a                                        ; $5ADB: $AF
     ld   [wHeartPiecesCount], a                   ; $5ADC: $EA $5C $DB
     ; Configure the heart increase animation
-    ld   hl, wSubstractRupeeBufferLow             ; $5ADF: $21 $93 $DB
+    ld   hl, wAddHealthBuffer                     ; $5ADF: $21 $93 $DB
     ld   [hl], $40                                ; $5AE2: $36 $40
     ; Increase the maximum number of hearts
     ld   hl, wMaxHealth                           ; $5AE4: $21 $5B $DB
@@ -4589,7 +4589,7 @@ PickDroppableHeart::
     ld   a, $08                                   ; $64B7: $3E $08
 
 jr_003_64B9:
-    ld   hl, wSubstractRupeeBufferLow             ; $64B9: $21 $93 $DB
+    ld   hl, wAddHealthBuffer                     ; $64B9: $21 $93 $DB
 
 jr_003_64BC:
     add  [hl]                                     ; $64BC: $86
@@ -4598,7 +4598,7 @@ jr_003_64BC:
 
 PickDroppableRupee::
     ld   a, $01                                   ; $64BF: $3E $01
-    ld   hl, wAddRupeeBufferHigh                  ; $64C1: $21 $90 $DB
+    ld   hl, wAddRupeeBufferLow                   ; $64C1: $21 $90 $DB
     jr   jr_003_64BC                              ; $64C4: $18 $F6
 
 PickDroppableFairy::
@@ -5972,9 +5972,9 @@ jr_003_6D73:
     srl  e                                        ; $6DA9: $CB $3B
 .damageModifiersEnd
 
-    ld   a, [wDB94]                               ; $6DAB: $FA $94 $DB
+    ld   a, [wSubtractHealthBuffer]               ; $6DAB: $FA $94 $DB
     add  e                                        ; $6DAE: $83
-    ld   [wDB94], a                               ; $6DAF: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $6DAF: $EA $94 $DB
     ld   a, $50                                   ; $6DB2: $3E $50
     ld   [$DBC7], a                               ; $6DB4: $EA $C7 $DB
     xor  a                                        ; $6DB7: $AF

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -2761,9 +2761,9 @@ func_004_5FEF::
 jr_004_6007:
     push hl                                       ; $6007: $E5
     push de                                       ; $6008: $D5
-    ld   a, [wAddRupeeBufferHigh]                 ; $6009: $FA $90 $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $6009: $FA $90 $DB
     ld   e, a                                     ; $600C: $5F
-    ld   a, [$DB8F]                               ; $600D: $FA $8F $DB
+    ld   a, [wAddRupeeBufferHigh]                 ; $600D: $FA $8F $DB
     ld   d, a                                     ; $6010: $57
     ld   a, [wRupeeCountLow]                      ; $6011: $FA $5E $DB
     ld   l, a                                     ; $6014: $6F
@@ -2791,7 +2791,7 @@ jr_004_6023:
     jr   c, jr_004_6037                           ; $602B: $38 $0A
 
     ld   a, $0A                                   ; $602D: $3E $0A
-    ld   [wSubstractRupeeBufferHigh], a           ; $602F: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $602F: $EA $92 $DB
     jp_open_dialog $047                           ; $6032
 
 jr_004_6037:
@@ -3053,9 +3053,9 @@ func_004_61E5::
 jr_004_6202:
     push hl                                       ; $6202: $E5
     push de                                       ; $6203: $D5
-    ld   a, [wAddRupeeBufferHigh]                 ; $6204: $FA $90 $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $6204: $FA $90 $DB
     ld   e, a                                     ; $6207: $5F
-    ld   a, [$DB8F]                               ; $6208: $FA $8F $DB
+    ld   a, [wAddRupeeBufferHigh]                 ; $6208: $FA $8F $DB
     ld   d, a                                     ; $620B: $57
     ld   a, [wRupeeCountLow]                      ; $620C: $FA $5E $DB
     ld   l, a                                     ; $620F: $6F
@@ -3083,7 +3083,7 @@ jr_004_621E:
     jr   c, jr_004_623F                           ; $6226: $38 $17
 
     ld   a, $0A                                   ; $6228: $3E $0A
-    ld   [wSubstractRupeeBufferHigh], a           ; $622A: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $622A: $EA $92 $DB
     call_open_dialog $047                         ; $622D
     call IncrementEntityState                     ; $6232: $CD $12 $3B
     ld   [hl], b                                  ; $6235: $70
@@ -3874,7 +3874,7 @@ func_004_6689::
 
     xor  a                                        ; $66C9: $AF
     ld   [wHeartPiecesCount], a                   ; $66CA: $EA $5C $DB
-    ld   hl, wSubstractRupeeBufferLow             ; $66CD: $21 $93 $DB
+    ld   hl, wAddHealthBuffer                     ; $66CD: $21 $93 $DB
     ld   [hl], $40                                ; $66D0: $36 $40
     ld   hl, wMaxHealth                           ; $66D2: $21 $5B $DB
     inc  [hl]                                     ; $66D5: $34
@@ -3886,7 +3886,7 @@ jr_004_66DA:
 
 jr_004_66DC:
     call OpenDialogInTable1                       ; $66DC: $CD $73 $23
-    ld   hl, wAddRupeeBufferHigh                  ; $66DF: $21 $90 $DB
+    ld   hl, wAddRupeeBufferLow                   ; $66DF: $21 $90 $DB
     ld   [hl], $14                                ; $66E2: $36 $14
     jr   jr_004_66FE                              ; $66E4: $18 $18
 
@@ -3903,7 +3903,7 @@ jr_004_66E6:
     ld   a, $4D                                   ; $66F5: $3E $4D
 
 jr_004_66F7:
-    ld   hl, wAddRupeeBufferHigh                  ; $66F7: $21 $90 $DB
+    ld   hl, wAddRupeeBufferLow                   ; $66F7: $21 $90 $DB
     ld   [hl], e                                  ; $66FA: $73
     call OpenDialog                               ; $66FB: $CD $85 $23
 
@@ -5512,7 +5512,7 @@ jr_004_7066:
 jr_004_7074:
     call OpenDialog                               ; $7074: $CD $85 $23
     ld   a, $0A                                   ; $7077: $3E $0A
-    ld   [wSubstractRupeeBufferHigh], a           ; $7079: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $7079: $EA $92 $DB
     jp   IncrementEntityState                     ; $707C: $C3 $12 $3B
 
 func_004_707F::
@@ -6493,9 +6493,9 @@ jr_004_7647:
     dec  a                                        ; $7647: $3D
     jr   nz, jr_004_7653                          ; $7648: $20 $09
 
-    ld   a, [wAddRupeeBufferHigh]                 ; $764A: $FA $90 $DB
+    ld   a, [wAddRupeeBufferLow]                  ; $764A: $FA $90 $DB
     add  $1E                                      ; $764D: $C6 $1E
-    ld   [wAddRupeeBufferHigh], a                 ; $764F: $EA $90 $DB
+    ld   [wAddRupeeBufferLow], a                  ; $764F: $EA $90 $DB
     ret                                           ; $7652: $C9
 
 jr_004_7653:
@@ -6531,7 +6531,7 @@ jr_004_7673:
 
 jr_004_767B:
     ld   a, $FF                                   ; $767B: $3E $FF
-    ld   [wSubstractRupeeBufferLow], a            ; $767D: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $767D: $EA $93 $DB
 
 label_004_7680:
     ret                                           ; $7680: $C9
@@ -7099,16 +7099,16 @@ jr_004_7A2E:
     ld   d, b                                     ; $7A36: $50
     ld   hl, Data_004_77EE                        ; $7A37: $21 $EE $77
     add  hl, de                                   ; $7A3A: $19
-    ld   a, [wSubstractRupeeBufferHigh]           ; $7A3B: $FA $92 $DB
+    ld   a, [wSubstractRupeeBufferLow]            ; $7A3B: $FA $92 $DB
     add  [hl]                                     ; $7A3E: $86
-    ld   [wSubstractRupeeBufferHigh], a           ; $7A3F: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $7A3F: $EA $92 $DB
     rl   a                                        ; $7A42: $CB $17
     ld   hl, Data_004_77E5                        ; $7A44: $21 $E5 $77
     add  hl, de                                   ; $7A47: $19
     rr   a                                        ; $7A48: $CB $1F
-    ld   a, [wAddRupeeBufferLow]                  ; $7A4A: $FA $91 $DB
+    ld   a, [wSubstractRupeeBufferHigh]           ; $7A4A: $FA $91 $DB
     adc  [hl]                                     ; $7A4D: $8E
-    ld   [wAddRupeeBufferLow], a                  ; $7A4E: $EA $91 $DB
+    ld   [wSubstractRupeeBufferHigh], a           ; $7A4E: $EA $91 $DB
     ld   hl, wEntitiesStateTable                  ; $7A51: $21 $90 $C2
     add  hl, bc                                   ; $7A54: $09
     ld   [hl], $01                                ; $7A55: $36 $01
@@ -7203,7 +7203,7 @@ jr_004_7ACA:
 
 func_004_7AD2::
     ld   a, $18                                   ; $7AD2: $3E $18
-    ld   [wSubstractRupeeBufferLow], a            ; $7AD4: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $7AD4: $EA $93 $DB
     ret                                           ; $7AD7: $C9
 
 func_004_7AD8::
@@ -7249,7 +7249,7 @@ func_004_7AED::
     xor  a                                        ; $7B1E: $AF
     ld   [wHasMedicine], a                        ; $7B1F: $EA $0D $DB
     ld   a, $FF                                   ; $7B22: $3E $FF
-    ld   [wDB94], a                               ; $7B24: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $7B24: $EA $94 $DB
     ldh  a, [hIsGBC]                              ; $7B27: $F0 $FE
     and  a                                        ; $7B29: $A7
     jr   z, jr_004_7B3F                           ; $7B2A: $28 $13

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -7547,7 +7547,7 @@ jr_007_70E0:
     ld   a, $13                                   ; $70FF: $3E $13
     ldh  [$FFA3], a                               ; $7101: $E0 $A3
     ld   a, $08                                   ; $7103: $3E $08
-    ld   [wDB94], a                               ; $7105: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $7105: $EA $94 $DB
     ld   a, $20                                   ; $7108: $3E $20
     ld   [$DBC7], a                               ; $710A: $EA $C7 $DB
     ld   a, $03                                   ; $710D: $3E $03

--- a/src/code/entities/big_fairy.asm
+++ b/src/code/entities/big_fairy.asm
@@ -188,7 +188,7 @@ jr_006_7197:
     jr   c, jr_006_71BA                           ; $71B3: $38 $05
 
     ld   a, $04                                   ; $71B5: $3E $04
-    ld   [wSubstractRupeeBufferLow], a            ; $71B7: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $71B7: $EA $93 $DB
 
 jr_006_71BA:
     call IsEntityUnknownFZero                     ; $71BA: $CD $00 $0C

--- a/src/code/entities/crazy_tracy.asm
+++ b/src/code/entities/crazy_tracy.asm
@@ -249,16 +249,16 @@ CrazyTracySellingHandler::
     ld   d, b                                     ; $5FDA: $50
     ld   hl, MedecinePriceDecimal                 ; $5FDB: $21 $89 $5F
     add  hl, de                                   ; $5FDE: $19
-    ld   a, [wSubstractRupeeBufferHigh]           ; $5FDF: $FA $92 $DB
+    ld   a, [wSubstractRupeeBufferLow]            ; $5FDF: $FA $92 $DB
     add  [hl]                                     ; $5FE2: $86
-    ld   [wSubstractRupeeBufferHigh], a           ; $5FE3: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $5FE3: $EA $92 $DB
     rl   a                                        ; $5FE6: $CB $17
     ld   hl, Data_006_5F8D                        ; $5FE8: $21 $8D $5F
     add  hl, de                                   ; $5FEB: $19
     rr   a                                        ; $5FEC: $CB $1F
-    ld   a, [wAddRupeeBufferLow]                  ; $5FEE: $FA $91 $DB
+    ld   a, [wSubstractRupeeBufferHigh]           ; $5FEE: $FA $91 $DB
     adc  [hl]                                     ; $5FF1: $8E
-    ld   [wAddRupeeBufferLow], a                  ; $5FF2: $EA $91 $DB
+    ld   [wSubstractRupeeBufferHigh], a           ; $5FF2: $EA $91 $DB
     ld   hl, wHasMedicine                         ; $5FF5: $21 $0D $DB
     inc  [hl]                                     ; $5FF8: $34
 
@@ -309,7 +309,7 @@ CrazyTracyBonusHandler::
     jr   nz, .fillHeartsEnd                       ; $6033: $20 $0F
     ; Also fill hearts
     ld   a, $FF                                   ; $6035: $3E $FF
-    ld   [wSubstractRupeeBufferLow], a            ; $6037: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $6037: $EA $93 $DB
     call_open_dialog $19A                         ; $603A
     ld   hl, wDialogState                         ; $603F: $21 $9F $C1
     set  7, [hl]                                  ; $6042: $CB $FE

--- a/src/code/entities/floating_item.asm
+++ b/src/code/entities/floating_item.asm
@@ -110,14 +110,14 @@ jr_006_7B85:
 ._05 dw FloatingArrowsHandler
 
 func_006_7BA2::
-    ld   a, [wSubstractRupeeBufferLow]            ; $7BA2: $FA $93 $DB
+    ld   a, [wAddHealthBuffer]                    ; $7BA2: $FA $93 $DB
     add  $18                                      ; $7BA5: $C6 $18
     jr   nc, jr_006_7BAB                          ; $7BA7: $30 $02
 
     ld   a, $FF                                   ; $7BA9: $3E $FF
 
 jr_006_7BAB:
-    ld   [wSubstractRupeeBufferLow], a            ; $7BAB: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $7BAB: $EA $93 $DB
     ret                                           ; $7BAE: $C9
 
 FloatingArrowsHandler::
@@ -129,7 +129,7 @@ FloatingArrowsHandler::
 
 Floating10RupeesHandler::
     ld   a, 10                                    ; $7BB9: $3E $0A
-    ld   [wAddRupeeBufferHigh], a                 ; $7BBB: $EA $90 $DB
+    ld   [wAddRupeeBufferLow], a                  ; $7BBB: $EA $90 $DB
     ret                                           ; $7BBE: $C9
 
 FloatingMagicPowderHandler::

--- a/src/code/entities/hinox.asm
+++ b/src/code/entities/hinox.asm
@@ -269,7 +269,7 @@ jr_006_5157:
     ld   a, $08                                   ; $5162: $3E $08
     ldh  [hJingle], a                             ; $5164: $E0 $F2
     ld   a, $08                                   ; $5166: $3E $08
-    ld   [wDB94], a                               ; $5168: $EA $94 $DB
+    ld   [wSubtractHealthBuffer], a               ; $5168: $EA $94 $DB
     ldh  a, [hActiveEntityPosX]                   ; $516B: $F0 $EE
     ldh  [hLinkPositionX], a                      ; $516D: $E0 $98
     ldh  a, [hActiveEntityPosY]                   ; $516F: $F0 $EF

--- a/src/code/entities/madam_meow_meow.asm
+++ b/src/code/entities/madam_meow_meow.asm
@@ -9,7 +9,7 @@ MadamMeowMeowEntityHandler::
 
     ld   [hl], b                                  ; $5B7D: $70
     ld   a, $FF                                   ; $5B7E: $3E $FF
-    ld   [wSubstractRupeeBufferLow], a            ; $5B80: $EA $93 $DB
+    ld   [wAddHealthBuffer], a                    ; $5B80: $EA $93 $DB
 
 jr_006_5B83:
     ldh  a, [hFrameCounter]                       ; $5B83: $F0 $E7

--- a/src/code/entities/raft_owner.asm
+++ b/src/code/entities/raft_owner.asm
@@ -66,7 +66,7 @@ jr_005_53B1:
     jr   c, jr_005_53C5                           ; $53B6: $38 $0D
 
     ld   a, $64                                   ; $53B8: $3E $64
-    ld   [wSubstractRupeeBufferHigh], a           ; $53BA: $EA $92 $DB
+    ld   [wSubstractRupeeBufferLow], a            ; $53BA: $EA $92 $DB
     ld   a, $F1                                   ; $53BD: $3E $F1
     ld   [$D477], a                               ; $53BF: $EA $77 $D4
     jp   OpenDialog                               ; $53C2: $C3 $85 $23

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -1250,26 +1250,30 @@ wIsRoosterFollowingLink:: ; DB7B
 
 ; Unlabeled
 wDB7C equ $DB7C
-  ds $14
+  ds $13
 
-wAddRupeeBufferHigh:: ; DB90
+wAddRupeeBufferHigh:: ; DB8F
   ; Higher digits of the amount of rupees to be added to your wallet (high digits)
   ds 1
 
-wAddRupeeBufferLow:: ; DB91
+wAddRupeeBufferLow:: ; DB90
   ; Amount of rupees to be added to your wallet (low digits)
   ds 1
 
-wSubstractRupeeBufferHigh:: ; DB92
+wSubstractRupeeBufferHigh:: ; DB91
   ; Amount of rupees to be removed from your wallet (high digits)
   ds 1
 
-wSubstractRupeeBufferLow:: ; DB93
+wSubstractRupeeBufferLow:: ; DB92
   ; Amount of rupees to be removed from your wallet (low digits)
   ds 1
 
-; Unlabeled
-wDB94:: ; DB94
+wAddHealthBuffer:: ; DB93
+  ; Amount of health to be added to your health total (wHealth)
+  ds 1
+
+wSubtractHealthBuffer:: ; DB94
+  ; Amount of health to be removed from your health total (wHealth)
   ds 1
 
 wGameplayType:: ; DB95


### PR DESCRIPTION
There were a couple of buffers that were missing in wram:
* wAddHealthBuffer (DB93)
* wSubtractHealthBuffer (DB94)


Also, the remaining rupee buffers were one byte higher than they were supposed to be, so I shifted them all down by one. These changes were already reflected in game.map, but weren't in the asm files.