### PR TITLE
hram: document hActiveEntityFlipAttribute

### DIFF
--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -2183,7 +2183,7 @@ label_5C7B::
     ld   [wEntitiesPhysicsFlagsTable], a
     ld   a, $00
     ld   [wActiveEntityIndex], a
-    ldh  [$FFED], a
+    ldh  [hActiveEntityFlipAttribute], a
     ld   e, $00
     ld   a, [$C1B4]
     cp   $70
@@ -3575,7 +3575,7 @@ label_6A7C::
     ret  nz
     xor  a
     ldh  [hActiveEntitySpriteVariant], a
-    ldh  [$FFED], a
+    ldh  [hActiveEntityFlipAttribute], a
     ldh  [hActiveEntityTilesOffset], a
     ld   a, $38
     ldh  [hActiveEntityPosX], a

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -1111,16 +1111,16 @@ UpdateEntityTimers::
     dec  [hl]                                     ; $4DE3: $35
 .flashCountdownEnd
 
-    ; $FFED = entity flash countdown
+    ; When the flash countdown is active, invert the palette every 4 frames
     sla  a                                        ; $4DE4: $CB $27
     sla  a                                        ; $4DE6: $CB $27
-    and  $10                                      ; $4DE8: $E6 $10
-    ldh  [$FFED], a                               ; $4DEA: $E0 $ED
+    and  OAMF_PAL1                                ; $4DE8: $E6 $10
+    ldh  [hActiveEntityFlipAttribute], a          ; $4DEA: $E0 $ED
     ret                                           ; $4DEC: $C9
 
 .done
     xor  a                                        ; $4DED: $AF
-    ldh  [$FFED], a                               ; $4DEE: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $4DEE: $E0 $ED
     ret                                           ; $4DF0: $C9
 
     ld   bc, $1700                                ; $4DF1: $01 $00 $17

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -6258,7 +6258,8 @@ jr_017_7784:
     and  $80                                      ; $778F: $E6 $80
     jr   z, jr_017_7798                           ; $7791: $28 $05
 
-    ld   hl, $FFED                                ; $7793: $21 $ED $FF
+    ; X-flip the entity
+    ld   hl, hActiveEntityFlipAttribute           ; $7793: $21 $ED $FF
     set  5, [hl]                                  ; $7796: $CB $EE
 
 jr_017_7798:
@@ -6744,7 +6745,7 @@ func_017_7A29::
     inc  de                                       ; $7A38: $13
     ld   a, [$C155]                               ; $7A39: $FA $55 $C1
     ld   c, a                                     ; $7A3C: $4F
-    ldh  a, [$FFED]                               ; $7A3D: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $7A3D: $F0 $ED
     and  $20                                      ; $7A3F: $E6 $20
     rra                                           ; $7A41: $1F
     rra                                           ; $7A42: $1F
@@ -6767,7 +6768,7 @@ func_017_7A29::
     inc  de                                       ; $7A5B: $13
     ld   a, [hl+]                                 ; $7A5C: $2A
     push hl                                       ; $7A5D: $E5
-    ld   hl, $FFED                                ; $7A5E: $21 $ED $FF
+    ld   hl, hActiveEntityFlipAttribute           ; $7A5E: $21 $ED $FF
     xor  [hl]                                     ; $7A61: $AE
     ld   [de], a                                  ; $7A62: $12
     inc  de                                       ; $7A63: $13
@@ -6776,7 +6777,7 @@ func_017_7A29::
     inc  de                                       ; $7A67: $13
     ld   a, [$C155]                               ; $7A68: $FA $55 $C1
     ld   c, a                                     ; $7A6B: $4F
-    ldh  a, [$FFED]                               ; $7A6C: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $7A6C: $F0 $ED
     and  $20                                      ; $7A6E: $E6 $20
     xor  $20                                      ; $7A70: $EE $20
     rra                                           ; $7A72: $1F
@@ -6791,7 +6792,7 @@ func_017_7A29::
     ld   [de], a                                  ; $7A7D: $12
     inc  de                                       ; $7A7E: $13
     ld   a, [hl]                                  ; $7A7F: $7E
-    ld   hl, $FFED                                ; $7A80: $21 $ED $FF
+    ld   hl, hActiveEntityFlipAttribute           ; $7A80: $21 $ED $FF
     xor  [hl]                                     ; $7A83: $AE
     ld   [de], a                                  ; $7A84: $12
     pop  bc                                       ; $7A85: $C1

--- a/src/code/entities/angler_fish.asm
+++ b/src/code/entities/angler_fish.asm
@@ -498,7 +498,7 @@ func_005_5984::
     rra                                           ; $598A: $1F
     rra                                           ; $598B: $1F
     and  $20                                      ; $598C: $E6 $20
-    ldh  [$FFED], a                               ; $598E: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $598E: $E0 $ED
     ld   de, Data_005_5978                        ; $5990: $11 $78 $59
     call RenderActiveEntitySpritesPair            ; $5993: $CD $C0 $3B
     call func_005_7A3A                            ; $5996: $CD $3A $7A

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -114,7 +114,7 @@ CrystalSwitchEntityHandler::
     call GetEntityTransitionCountdown             ; $432A: $CD $05 $0C
     rla                                           ; $432D: $17
     and  $10                                      ; $432E: $E6 $10
-    ldh  [$FFED], a                               ; $4330: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $4330: $E0 $ED
     ld   de, Data_015_4320                        ; $4332: $11 $20 $43
     call RenderActiveEntitySpritesPair            ; $4335: $CD $C0 $3B
     call func_015_7B0D                            ; $4338: $CD $0D $7B
@@ -1587,7 +1587,7 @@ label_015_4DB5:
     rla                                           ; $4DBC: $17
     rla                                           ; $4DBD: $17
     and  $10                                      ; $4DBE: $E6 $10
-    ldh  [$FFED], a                               ; $4DC0: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $4DC0: $E0 $ED
     ld   de, Data_015_4D9D                        ; $4DC2: $11 $9D $4D
     call RenderActiveEntitySpritesPair            ; $4DC5: $CD $C0 $3B
     call func_015_7B0D                            ; $4DC8: $CD $0D $7B
@@ -1695,7 +1695,7 @@ label_015_4E62:
     rla                                           ; $4E64: $17
     rla                                           ; $4E65: $17
     and  $10                                      ; $4E66: $E6 $10
-    ldh  [$FFED], a                               ; $4E68: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $4E68: $E0 $ED
     ld   de, Data_015_4DA9                        ; $4E6A: $11 $A9 $4D
     call RenderActiveEntitySpritesPair            ; $4E6D: $CD $C0 $3B
     call func_015_7B0D                            ; $4E70: $CD $0D $7B
@@ -3564,11 +3564,11 @@ Data_015_5D89::
     db   $00, $00, $F0, $04
 
 func_015_5D8D::
-    ldh  a, [$FFED]                               ; $5D8D: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $5D8D: $F0 $ED
     push af                                       ; $5D8F: $F5
     call func_015_5D97                            ; $5D90: $CD $97 $5D
     pop  af                                       ; $5D93: $F1
-    ldh  [$FFED], a                               ; $5D94: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $5D94: $E0 $ED
     ret                                           ; $5D96: $C9
 
 func_015_5D97::
@@ -3585,7 +3585,7 @@ jr_015_5D9A:
     rla                                           ; $5DA2: $17
     rla                                           ; $5DA3: $17
     and  $50                                      ; $5DA4: $E6 $50
-    ldh  [$FFED], a                               ; $5DA6: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $5DA6: $E0 $ED
     ld   a, [$D21E]                               ; $5DA8: $FA $1E $D2
     ld   e, a                                     ; $5DAB: $5F
     ld   d, b                                     ; $5DAC: $50
@@ -3622,7 +3622,7 @@ label_015_5DED:
     rla                                           ; $5DF0: $17
     rla                                           ; $5DF1: $17
     and  $50                                      ; $5DF2: $E6 $50
-    ldh  [$FFED], a                               ; $5DF4: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $5DF4: $E0 $ED
     ld   de, Data_015_5DD9                        ; $5DF6: $11 $D9 $5D
     call RenderActiveEntitySpritesPair            ; $5DF9: $CD $C0 $3B
     call func_015_7B0D                            ; $5DFC: $CD $0D $7B
@@ -4219,7 +4219,7 @@ jr_015_62AC:
     rla                                           ; $62F2: $17
     rla                                           ; $62F3: $17
     and  $10                                      ; $62F4: $E6 $10
-    ld   hl, $FFED                                ; $62F6: $21 $ED $FF
+    ld   hl, hActiveEntityFlipAttribute           ; $62F6: $21 $ED $FF
     xor  [hl]                                     ; $62F9: $AE
     ld   [hl], a                                  ; $62FA: $77
     ld   de, Data_015_6235                        ; $62FB: $11 $35 $62
@@ -5456,7 +5456,7 @@ label_015_6D6E:
     rla                                           ; $6D70: $17
     rla                                           ; $6D71: $17
     and  $10                                      ; $6D72: $E6 $10
-    ldh  [$FFED], a                               ; $6D74: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $6D74: $E0 $ED
     ld   de, Data_015_6D5E                        ; $6D76: $11 $5E $6D
     call RenderActiveEntitySpritesPair            ; $6D79: $CD $C0 $3B
     call func_015_7B0D                            ; $6D7C: $CD $0D $7B

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -5532,7 +5532,7 @@ func_018_68EA::
 
     inc  a                                        ; $6913: $3C
     ldh  [hFFE8], a                               ; $6914: $E0 $E8
-    ld   hl, $FFED                                ; $6916: $21 $ED $FF
+    ld   hl, hActiveEntityFlipAttribute           ; $6916: $21 $ED $FF
     set  5, [hl]                                  ; $6919: $CB $EE
 
 jr_018_691B:
@@ -5620,14 +5620,14 @@ jr_018_6972:
 
 jr_018_6984:
     inc  de                                       ; $6984: $13
-    ldh  a, [$FFED]                               ; $6985: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $6985: $F0 $ED
     xor  [hl]                                     ; $6987: $AE
     ld   [de], a                                  ; $6988: $12
     ldh  a, [hIsGBC]                              ; $6989: $F0 $FE
     and  a                                        ; $698B: $A7
     jr   z, jr_018_699A                           ; $698C: $28 $0C
 
-    ldh  a, [$FFED]                               ; $698E: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $698E: $F0 $ED
     bit  4, a                                     ; $6990: $CB $67
     jr   z, jr_018_699A                           ; $6992: $28 $06
 

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -649,7 +649,7 @@ label_019_4406:
     rla                                           ; $440E: $17
     rla                                           ; $440F: $17
     and  $10                                      ; $4410: $E6 $10
-    ldh  [$FFED], a                               ; $4412: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $4412: $E0 $ED
     ldh  a, [hActiveEntityPosX]                   ; $4414: $F0 $EE
     ldh  [$FFE5], a                               ; $4416: $E0 $E5
     ldh  a, [$FFEC]                               ; $4418: $F0 $EC
@@ -2420,7 +2420,7 @@ label_019_4F30:
     rla                                           ; $4F32: $17
     rla                                           ; $4F33: $17
     and  $10                                      ; $4F34: $E6 $10
-    ldh  [$FFED], a                               ; $4F36: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $4F36: $E0 $ED
     ld   de, $4EAA                                ; $4F38: $11 $AA $4E
     call RenderActiveEntitySprite                 ; $4F3B: $CD $77 $3C
     call func_019_7D3D                            ; $4F3E: $CD $3D $7D
@@ -3156,7 +3156,7 @@ GiantBubbleEntityHandler::
     rla                                           ; $5392: $17
     rla                                           ; $5393: $17
     and  $10                                      ; $5394: $E6 $10
-    ldh  [$FFED], a                               ; $5396: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $5396: $E0 $ED
     ldh  a, [hFrameCounter]                       ; $5398: $F0 $E7
     rra                                           ; $539A: $1F
     rra                                           ; $539B: $1F
@@ -7634,9 +7634,9 @@ CheepCheepJumpingEntityHandler::
     cp   $05                                      ; $6BC9: $FE $05
     jr   nz, jr_019_6BD3                          ; $6BCB: $20 $06
 
-    ldh  a, [$FFED]                               ; $6BCD: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $6BCD: $F0 $ED
     or   $40                                      ; $6BCF: $F6 $40
-    ldh  [$FFED], a                               ; $6BD1: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $6BD1: $E0 $ED
 
 jr_019_6BD3:
     ld   de, $6B44                                ; $6BD3: $11 $44 $6B

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -1857,7 +1857,7 @@ jr_004_5963:
     rla                                           ; $59DE: $17
     rla                                           ; $59DF: $17
     and  $10                                      ; $59E0: $E6 $10
-    ld   hl, $FFED                                ; $59E2: $21 $ED $FF
+    ld   hl, hActiveEntityFlipAttribute           ; $59E2: $21 $ED $FF
     xor  [hl]                                     ; $59E5: $AE
     ld   [hl], a                                  ; $59E6: $77
     ld   de, Data_004_58F2                        ; $59E7: $11 $F2 $58
@@ -2411,14 +2411,14 @@ Data_004_5D26::
 
 func_004_5DA6::
     call func_004_7F90                            ; $5DA6: $CD $90 $7F
-    ldh  a, [$FFED]                               ; $5DA9: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $5DA9: $F0 $ED
     push af                                       ; $5DAB: $F5
     rla                                           ; $5DAC: $17
     and  $40                                      ; $5DAD: $E6 $40
     ldh  [hScratch0], a                           ; $5DAF: $E0 $D7
     pop  af                                       ; $5DB1: $F1
     and  $0F                                      ; $5DB2: $E6 $0F
-    ldh  [$FFED], a                               ; $5DB4: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $5DB4: $E0 $ED
     ld   hl, wEntitiesSpriteVariantTable          ; $5DB6: $21 $B0 $C3
     add  hl, bc                                   ; $5DB9: $09
     ld   a, [hl]                                  ; $5DBA: $7E
@@ -7571,7 +7571,7 @@ jr_004_7D2B:
     rla                                           ; $7D2F: $17
     rla                                           ; $7D30: $17
     and  $10                                      ; $7D31: $E6 $10
-    ldh  [$FFED], a                               ; $7D33: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $7D33: $E0 $ED
     call RenderActiveEntitySpritesPair            ; $7D35: $CD $C0 $3B
     call func_004_7FA3                            ; $7D38: $CD $A3 $7F
     ld   hl, wEntitiesIgnoreHitsCountdownTable    ; $7D3B: $21 $10 $C4
@@ -7976,7 +7976,7 @@ func_004_7F90::
     ld   a, $20                                   ; $7F9B: $3E $20
 
 jr_004_7F9D:
-    ld   hl, $FFED                                ; $7F9D: $21 $ED $FF
+    ld   hl, hActiveEntityFlipAttribute           ; $7F9D: $21 $ED $FF
     xor  [hl]                                     ; $7FA0: $AE
     ld   [hl], a                                  ; $7FA1: $77
     ret                                           ; $7FA2: $C9

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -4438,7 +4438,7 @@ jr_007_5CC0:
 jr_007_5CDF:
     pop  bc                                       ; $5CDF: $C1
     inc  de                                       ; $5CE0: $13
-    ldh  a, [$FFED]                               ; $5CE1: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $5CE1: $F0 $ED
     xor  [hl]                                     ; $5CE3: $AE
     inc  hl                                       ; $5CE4: $23
     ld   [de], a                                  ; $5CE5: $12
@@ -4942,7 +4942,7 @@ jr_007_608F:
     ld   [hl], $03                                ; $6093: $36 $03
     ld   e, $03                                   ; $6095: $1E $03
     ld   a, e                                     ; $6097: $7B
-    ldh  [$FFED], a                               ; $6098: $E0 $ED
+    ldh  [hActiveEntityFlipAttribute], a          ; $6098: $E0 $ED
     ld   hl, wEntitiesPosYTable                   ; $609A: $21 $10 $C2
     add  hl, bc                                   ; $609D: $09
     ld   a, [hl]                                  ; $609E: $7E
@@ -4952,7 +4952,7 @@ jr_007_608F:
     add  e                                        ; $60A3: $83
     ldh  [hActiveEntityPosY], a                   ; $60A4: $E0 $EF
     call label_3B23                               ; $60A6: $CD $23 $3B
-    ldh  a, [$FFED]                               ; $60A9: $F0 $ED
+    ldh  a, [hActiveEntityFlipAttribute]          ; $60A9: $F0 $ED
     ld   e, a                                     ; $60AB: $5F
     ld   hl, wEntitiesPosYTable                   ; $60AC: $21 $10 $C2
     add  hl, bc                                   ; $60AF: $09

--- a/src/code/entities/goponga_projectile.asm
+++ b/src/code/entities/goponga_projectile.asm
@@ -1,26 +1,43 @@
-
-Data_006_638F::
-    db   $1E, $02, $1E, $62, $1E, $42, $1E, $22, $32, $00, $32, $20, $30, $00, $30, $20
+GopongaFlowerDisplayList::
+.variant0
+    db   $1E, $02
+    db   $1E, $62
+.variant1
+    db   $1E, $42
+    db   $1E, $22
+.variant2
+    db   $32, $00
+    db   $32, $20
+.variant3
+    db   $30, $00
+    db   $30, $20
 
 GopongaProjectileEntityHandler::
+    ; Make the projectile invicible, by setting its health
+    ; to a large number every frame.
     ld   hl, wEntitiesHealthTable                 ; $639F: $21 $60 $C3
     add  hl, bc                                   ; $63A2: $09
     ld   [hl], $30                                ; $63A3: $36 $30
+
+    ; If entity's private state 1 is != 0…
     ld   hl, wEntitiesPrivateState1Table          ; $63A5: $21 $B0 $C2
     add  hl, bc                                   ; $63A8: $09
     ld   a, [hl]                                  ; $63A9: $7E
     and  a                                        ; $63AA: $A7
-    jr   z, jr_006_63B5                           ; $63AB: $28 $08
-
+    jr   z, .flashEnd                             ; $63AB: $28 $08
+    ; Flip palette every 8 frames.
+    ; (used during the Final Nightmare battle)
     ldh  a, [hFrameCounter]                       ; $63AD: $F0 $E7
     rla                                           ; $63AF: $17
     rla                                           ; $63B0: $17
-    and  $10                                      ; $63B1: $E6 $10
-    ldh  [$FFED], a                               ; $63B3: $E0 $ED
+    and  OAMF_PAL1                                ; $63B1: $E6 $10
+    ldh  [hActiveEntityFlipAttribute], a          ; $63B3: $E0 $ED
+.flashEnd
 
-jr_006_63B5:
-    ld   de, Data_006_638F                        ; $63B5: $11 $8F $63
+    ; Render the projectile
+    ld   de, GopongaFlowerDisplayList                        ; $63B5: $11 $8F $63
     call RenderActiveEntitySpritesPair            ; $63B8: $CD $C0 $3B
+
     call GetEntityTransitionCountdown             ; $63BB: $CD $05 $0C
     jr   z, jr_006_63CE                           ; $63BE: $28 $0E
 
@@ -35,6 +52,7 @@ jr_006_63B5:
     jp   SetEntitySpriteVariant                   ; $63CB: $C3 $0C $3B
 
 jr_006_63CE:
+
     ld   hl, wEntitiesIgnoreHitsCountdownTable    ; $63CE: $21 $10 $C4
     add  hl, bc                                   ; $63D1: $09
     ld   a, [hl]                                  ; $63D2: $7E

--- a/src/code/entities/wizrobe_projectile.asm
+++ b/src/code/entities/wizrobe_projectile.asm
@@ -2,11 +2,13 @@ Data_006_65E1::
     db   $6A, $23, $68, $23, $68, $03, $6A, $03, $6C, $43, $6C, $63, $6C, $03, $6C, $23
 
 WizrobeProjectileEntityHandler::
+    ; Flip palette every 8 frame
     ldh  a, [hFrameCounter]                       ; $65F1: $F0 $E7
     rla                                           ; $65F3: $17
     rla                                           ; $65F4: $17
-    and  $10                                      ; $65F5: $E6 $10
-    ldh  [$FFED], a                               ; $65F7: $E0 $ED
+    and  OAMF_PAL1                                ; $65F5: $E6 $10
+    ldh  [hActiveEntityFlipAttribute], a          ; $65F7: $E0 $ED
+
     ld   de, Data_006_65E1                        ; $65F9: $11 $E1 $65
     call RenderActiveEntitySpritesPair            ; $65FC: $CD $C0 $3B
     call func_006_64C6                            ; $65FF: $CD $C6 $64

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -206,7 +206,7 @@ IntroSceneStage2Handler::
     ld   [$C3B0], a
     ld   [$C3B1], a
     ld   [$C3B2], a
-    ldh  [$FFED], a
+    ldh  [hActiveEntityFlipAttribute], a
 
     ; Configure Link's ship entity
     ld   a, $05

--- a/src/constants/hram.asm
+++ b/src/constants/hram.asm
@@ -314,9 +314,17 @@ hActiveEntityType:: ; FFEB
 ; Active entity Y of the second sprite of a pair?
 ds 1 ; FFEC
 
-; Active entity render flags?
-; Maybe a bitfield
-ds 1 ; FFED
+; Invert OAM attribute bits of the active entity.
+;
+; Each bit set inverts the OAM attributes of the active sprite pair.
+;
+; bit 0-3: GBC palette
+; bit 4: use inverted color palette
+; bit 5: x-flip the entity
+; bit 6: y-flip the entity
+; bit 7: invert the background priority
+hActiveEntityFlipAttribute:: ; FFED
+  ds 1
 
 hActiveEntityPosX:: ; FFEE
   ds 1


### PR DESCRIPTION
hActiveEntityFlipAttribute Invers the OAM attribute bits of the active entity. Each bit set inverts the OAM attributes of the active sprite pair.

- bit 0-3: GBC palette
- bit 4: use inverted color palette
- bit 5: x-flip the entity
- bit 6: y-flip the entity
- bit 7: invert the background priority

This is used mostly to flip a sprite direction, or to invert the color palette to make sprites flash.