### PR TITLE
Yet more improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ DumpBanks
 
 # save files
 game.sav
+game.ss*

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -1707,16 +1707,16 @@ CheckItemsToUse::
     and  a
     jr   z, .notRunning
 
-    ld   a, [wBButtonSlot]
-    cp   INVENTORY_SWORD
-    jr   z, .swordEquiped
     ld   a, [wAButtonSlot]
     cp   INVENTORY_SWORD
     jr   z, .swordEquiped
     ld   a, [wBButtonSlot]
+    cp   INVENTORY_SWORD
+    jr   z, .swordEquiped
+    ld   a, [wAButtonSlot]
     cp   INVENTORY_SHIELD
     jr   z, .shieldEquiped
-    ld   a, [wAButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   INVENTORY_SHIELD
     jr   nz, .shieldEnd
 
@@ -1764,7 +1764,7 @@ CheckItemsToUse::
     jp   nz, UseItem.return
 
 .jr_11E8
-    ld   a, [wAButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   INVENTORY_PEGASUS_BOOTS
     jr   nz, .jr_11FE
     ldh  a, [hPressedButtonsMask]
@@ -1778,7 +1778,7 @@ CheckItemsToUse::
     ld   [wPegasusBootsChargeMeter], a
 
 .jr_11FE
-    ld   a, [wBButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   INVENTORY_PEGASUS_BOOTS
     jr   nz, .jr_1214
     ldh  a, [hPressedButtonsMask]
@@ -1793,7 +1793,7 @@ CheckItemsToUse::
 
 .jr_1214
 
-    ld   a, [wBButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   INVENTORY_SHIELD
     jr   nz, .shieldBEnd
     ld   a, [wShieldLevel]
@@ -1809,7 +1809,7 @@ CheckItemsToUse::
     call SetShieldVals
 .shieldBEnd
 
-    ld   a, [wAButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   INVENTORY_SHIELD
     jr   nz, .shieldAEnd
     ld   a, [wShieldLevel]
@@ -1828,7 +1828,7 @@ CheckItemsToUse::
     jr   z, .jr_125E
 
     ; Use item in A slot
-    ld   a, [wAButtonSlot]
+    ld   a, [wBButtonSlot]
     call UseItem
 
 .jr_125E
@@ -1842,21 +1842,21 @@ CheckItemsToUse::
     jr   z, .jr_1275
 
     ; Use item in B slot
-    ld   a, [wBButtonSlot]
+    ld   a, [wAButtonSlot]
     call UseItem
 
 .jr_1275
     ldh  a, [hPressedButtonsMask]
     and  $20
     jr   z, .jr_1281
-    ld   a, [wAButtonSlot]
+    ld   a, [wBButtonSlot]
     call label_1321
 
 .jr_1281
     ldh  a, [hPressedButtonsMask]
     and  $10
     jr   z, .jr_128D
-    ld   a, [wBButtonSlot]
+    ld   a, [wAButtonSlot]
     call label_1321
 
 .jr_128D
@@ -3615,7 +3615,7 @@ label_1F69::
 
 .specialCasesEnd
 
-    ld   a, [wAButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   INVENTORY_POWER_BRACELET
     jr   nz, .jr_20DD
     ldh  a, [hPressedButtonsMask]
@@ -3624,7 +3624,7 @@ label_1F69::
     ret
 
 .jr_20DD
-    ld   a, [wBButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   INVENTORY_POWER_BRACELET
     jp   nz, func_2165.return
     ldh  a, [hPressedButtonsMask]

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -1821,19 +1821,19 @@ CheckItemsToUse::
 .shieldAEnd
 
     ldh  a, [hJoypadState]
-    and  $20
+    and  J_B
     jr   z, .jr_125E
     ld   a, [$C1AD]
     cp   $02
     jr   z, .jr_125E
 
-    ; Use item in A slot
+    ; Use item in B slot
     ld   a, [wBButtonSlot]
     call UseItem
 
 .jr_125E
     ldh  a, [hJoypadState]
-    and  $10
+    and  J_A
     jr   z, .jr_1275
     ld   a, [$C1AD]
     cp   $01
@@ -1841,20 +1841,20 @@ CheckItemsToUse::
     cp   $02
     jr   z, .jr_1275
 
-    ; Use item in B slot
+    ; Use item in A slot
     ld   a, [wAButtonSlot]
     call UseItem
 
 .jr_1275
     ldh  a, [hPressedButtonsMask]
-    and  $20
+    and  J_B
     jr   z, .jr_1281
     ld   a, [wBButtonSlot]
     call label_1321
 
 .jr_1281
     ldh  a, [hPressedButtonsMask]
-    and  $10
+    and  J_A
     jr   z, .jr_128D
     ld   a, [wAButtonSlot]
     call label_1321
@@ -1887,7 +1887,7 @@ UseItem::
     cp   INVENTORY_HOOKSHOT
     jp   z, UseHookshot
     cp   INVENTORY_ROCS_FEATHER
-    jp   z, UseRocksFeather
+    jp   z, UseRocsFeather
     cp   INVENTORY_OCARINA
     jp   z, UseOcarina
     cp   INVENTORY_MAGIC_POWDER
@@ -2211,7 +2211,7 @@ data_14C3::
 data_14C7::
     db 0, 0, $E4, $1C
 
-UseRocksFeather::
+UseRocsFeather::
     ld   a, [$C130]
     cp   $07
     ret  z
@@ -2230,7 +2230,7 @@ UseRocksFeather::
     jr   z, label_1508
     call label_1508
     ldh  a, [hPressedButtonsMask]
-    and  $03
+    and  J_LEFT | J_RIGHT
     ld   a, $EA
     jr   z, label_14F8
     ld   a, $E8
@@ -2484,6 +2484,7 @@ label_1653::
 
 .dropRandomItem
     ; In some random cases, don't drop anything.
+    ; (~ 1/8 chance to drop an item)
     call GetRandomByte
     and  $07
     ret  nz
@@ -2860,7 +2861,7 @@ LinkMotionMapFadeOutHandler::
     and  a
     jr   z, .label_1907
     xor  a
-    ld   [wActivePowerUp], a
+    ld   [wActivePowerUp], a            ; Clear any active powerup on room change
 
 .label_1907
     jr   .label_196F
@@ -2887,12 +2888,12 @@ LinkMotionMapFadeOutHandler::
     jr   .label_193C
 .colorDungeonEnd
 
-    cp   $06
-    jr   nz, .label_193C
-    ld   a, [$DB6B]
+    cp   MAP_EAGLES_TOWER           ; Is this Eagle's Tower?
+    jr   nz, .label_193C            ; If not, skip this...
+    ld   a, [wHasInstrument7]       ; Otherwise, check if the pillars have all been dunked...
     and  $04
-    jr   z, .label_193C
-    ld   hl, MapLayout12
+    jr   z, .label_193C             ; If not, skip this...
+    ld   hl, MapLayout12            ; Otherwise, swap to the alternate Eagle's Tower map (post-3F collapse)
 
 .label_193C
     ld   e, $00
@@ -2913,11 +2914,11 @@ LinkMotionMapFadeOutHandler::
     and  a
     jr   nz, .label_196E
     xor  a
-    ld   [wActivePowerUp], a
+    ld   [wActivePowerUp], a        ; Clear any active powerup
     ldh  a, [hMapId]
     cp   MAP_CAVE_B
     jr   nc, .label_196E
-    callsw IsMapRoomE8
+    callsw IsMapRoomE8              ; @TODO Either Eagle's Tower boss room bottom half or Yarna Desert quicksand pit
     ld   a, $30
     ldh  [$FFB4], a
     xor  a
@@ -3522,7 +3523,7 @@ label_1F69::
     ldh  a, [hMapRoom]
     jr   nz, .noSwordEnd
     ld   e, $FF
-    cp   $A3
+    cp   $A3                        ; Marin & Tarin's house
     jr   z, .jr_2046
 .noSwordEnd
 
@@ -3600,7 +3601,7 @@ label_1F69::
     jr   nz, .specialCasesEnd
     ld   [$C1AD], a
     ldh  a, [hJoypadState]
-    and  $30
+    and  J_A | J_B
     jr   z, .specialCasesEnd
     ldh  a, [hIsSideScrolling]
     and  a
@@ -3619,7 +3620,7 @@ label_1F69::
     cp   INVENTORY_POWER_BRACELET
     jr   nz, .jr_20DD
     ldh  a, [hPressedButtonsMask]
-    and  $20
+    and  J_B
     jr   nz, .jr_20EC
     ret
 
@@ -3628,7 +3629,7 @@ label_1F69::
     cp   INVENTORY_POWER_BRACELET
     jp   nz, func_2165.return
     ldh  a, [hPressedButtonsMask]
-    and  $10
+    and  J_A
     jp   z, func_2165.return
 
 .jr_20EC

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -1036,278 +1036,57 @@ label_531D::
     jr   .finish
 
 
-; @TODO Code as data
 label_53D8::
-    sbc  a, l
-    sbc  a, l
-    sbc  a, l
-    rst  $38
-    sbc  a, l
-    sbc  a, l
-    sbc  a, l
-    rst  $38
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    rst  $38
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    rst  $38
+    db   $9D, $9D, $9D, $FF, $9D, $9D, $9D, $FF   ; $53D8
+    db   $9D, $9D, $9C, $FF, $9D, $9D, $9C, $FF   ; $53E0
 
 label_53E8::
-    ldd  [hl], a
-    ldd  [hl], a
-    add  hl, bc
-    rst  $38
-    ld   l, $2E
-    add  hl, bc
-    rst  $38
-    adc  a, d
-    ldd  [hl], a
-    jp   hl
-    rst  $38
-    adc  a, d
-    ld   l, $E9
-    rst  $38
+    db   $32, $32, $09, $FF, $2E, $2E, $09, $FF   ; $53E8
+    db   $8A, $32, $E9, $FF, $8A, $2E, $E9, $FF   ; $53F0
 
 label_53F8::
-    ret  z
-    ret  z
-    nop
-    rst  $38
-    ret  z
-    ret  z
-    nop
-    rst  $38
-    ld   c, b
-    ret  z
-    nop
-    rst  $38
-    ld   c, b
-    ret  z
-    nop
-    rst  $38
+    db   $C8, $C8, $00, $FF, $C8, $C8, $00, $FF   ; $53F8
+    db   $48, $C8, $00, $FF, $48, $C8, $00, $FF   ; $5400
 
 label_5408::
-    ld   a, a
-    ld   a, a
-    cp   d
-    rst  $38
-    ld   a, a
-    ld   a, a
-    cp   d
-    rst  $38
-    ld   a, a
-    ld   a, a
-    cp   d
-    rst  $38
-    ld   a, a
-    ld   a, a
-    cp   d
-    rst  $38
+    db   $7F, $7F, $BA, $FF, $7F, $7F, $BA, $FF   ; $5408
+    db   $7F, $7F, $BA, $FF, $7F, $7F, $BA, $FF   ; $5410
 
 label_5418::
-    nop
-    nop
-    nop
-    rst  $38
-    nop
-    nop
-    nop
-    rst  $38
-    sbc  a, l
-    sbc  a, l
-    rst  $38
-    nop
-    sbc  a, l
-    sbc  a, l
-    sbc  a, l
-    rst  $38
-    sbc  a, l
-    sbc  a, h
-    rst  $38
-    nop
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    rst  $38
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    rst  $38
-    nop
-    nop
-    nop
-    nop
-    nop
-    nop
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    sbc  a, h
-    sbc  a, h
-    rst  $38
-    nop
-    nop
-    nop
-    nop
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    rst  $38
-    nop
-    nop
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    sbc  a, l
-    sbc  a, l
-    sbc  a, h
-    sbc  a, h
-    sbc  a, h
-    sbc  a, h
-    rst  $38
+    db   $00, $00, $00, $FF, $00, $00, $00, $FF   ; $5418
+    db   $9D, $9D, $FF, $00, $9D, $9D, $9D, $FF   ; $5420
+    db   $9D, $9C, $FF, $00, $9D, $9C, $9C, $FF   ; $5428
+    db   $9D, $9D, $9C, $9C, $FF, $00, $00, $00   ; $5430
+    db   $00, $00, $00, $9D, $9D, $9C, $9C, $9C   ; $5438
+    db   $9C, $FF, $00, $00, $00, $00, $9D, $9D   ; $5440
+    db   $9C, $9C, $9D, $9D, $9C, $9C, $FF, $00   ; $5448
+    db   $00, $9D, $9D, $9C, $9C, $9D, $9D, $9C   ; $5450
+    db   $9C, $9C, $9C, $FF                       ; $5458
 
 label_545C::
-    nop
-    nop
-    nop
-    rst  $38
-    nop
-    nop
-    nop
-    rst  $38
-    dec  c
-    ld   [de], a
-    rst  $38
-    nop
-    dec  c
-    ld   de, rNR12
-    sub  a, d
-    db   $F2 ; Undefined instruction
-    rst  $38
-    nop
-    sub  a, d
-    pop  af
-    db   $F2 ; Undefined instruction
-    rst  $38
-    adc  a, l
-    sub  a, d
-    db   $ED ; Undefined instruction
-    db   $F2 ; Undefined instruction
-    rst  $38
-    nop
-    nop
-    nop
-    nop
-    nop
-    nop
-    adc  a, l
-    sub  a, d
-    db   $ED ; Undefined instruction
-    db   $F2 ; Undefined instruction
-    pop  af
-    db   $F2 ; Undefined instruction
-    rst  $38
-    nop
-    nop
-    nop
-    nop
-    adc  a, l
-    sub  a, d
-    db   $ED ; Undefined instruction
-    db   $F2 ; Undefined instruction
-    sub  a, c
-    sub  a, d
-    pop  af
-    db   $F2 ; Undefined instruction
-    rst  $38
-    nop
-    nop
-    adc  a, l
-    sub  a, d
-    db   $ED ; Undefined instruction
-    db   $F2 ; Undefined instruction
-    sub  a, c
-    sub  a, d
-    db   $EC ; Undefined instruction
-    db   $ED ; Undefined instruction
-    pop  af
-    db   $F2 ; Undefined instruction
-    rst  $38
+    db   $00, $00, $00, $FF, $00, $00, $00, $FF   ; $545C
+    db   $0D, $12, $FF, $00, $0D, $11, $12, $FF   ; $5464
+    db   $92, $F2, $FF, $00, $92, $F1, $F2, $FF   ; $546C
+    db   $8D, $92, $ED, $F2, $FF, $00, $00, $00   ; $5474
+    db   $00, $00, $00, $8D, $92, $ED, $F2, $F1   ; $547C
+    db   $F2, $FF, $00, $00, $00, $00, $8D, $92   ; $5484
+    db   $ED, $F2, $91, $92, $F1, $F2, $FF, $00   ; $548C
+    db   $00, $8D, $92, $ED, $F2, $91, $92, $EC   ; $5494
+    db   $ED, $F1, $F2, $FF                       ; $549C
 
 label_54A0::
-    nop
-    nop
-    nop
-    rst  $38
-    nop
-    nop
-    nop
-    rst  $38
-    db   $E8 ; add  sp, d
-    jp   hl
-    rst  $38
-    nop
-    db   $E8 ; add  sp, d
-    db   $EC ; Undefined instruction
-    db   $E8 ; add  sp, d
-    rst  $38
-    db   $E8 ; add  sp, d
-    jp   hl
-    rst  $38
-    nop
-    db   $E8 ; add  sp, d
-    db   $EC ; Undefined instruction
-    db   $E8 ; add  sp, d
-    rst  $38
-    db   $E8 ; add  sp, d
-    ld   [$EBE9], a
-    rst  $38
-    nop
-    nop
-    nop
-    nop
-    nop
-    nop
-    db   $E8 ; add  sp, d
-    ld   [$EBE9], a
-    db   $EC ; Undefined instruction
-    db   $E8 ; add  sp, d
-    rst  $38
-    nop
-    nop
-    nop
-    nop
-    db   $E8 ; add  sp, d
-    ld   [$EBE9], a
-    db   $EC ; Undefined instruction
-    db   $E8 ; add  sp, d
-    db   $EC ; Undefined instruction
-    jp   hl
-    rst  $38
-    nop
-    nop
-    db   $E8 ; add  sp, d
-    ld   [$EBE9], a
-    db   $EC ; Undefined instruction
-    db   $E8 ; add  sp, d
-    db   $EC ; Undefined instruction
-    ld   [$E9EC], a
-    rst  $38
+    db   $00, $00, $00, $FF, $00, $00, $00, $FF   ; $54A0
+    db   $E8, $E9, $FF, $00, $E8, $EC, $E8, $FF   ; $54A8
+    db   $E8, $E9, $FF, $00, $E8, $EC, $E8, $FF   ; $54B0
+    db   $E8, $EA, $E9, $EB, $FF, $00, $00, $00   ; $54B8
+    db   $00, $00, $00, $E8, $EA, $E9, $EB, $EC   ; $54C0
+    db   $E8, $FF, $00, $00, $00, $00, $E8, $EA   ; $54C8
+    db   $E9, $EB, $EC, $E8, $EC, $E9, $FF, $00   ; $54D0
+    db   $00, $E8, $EA, $E9, $EB, $EC, $E8, $EC   ; $54D8
+    db   $EA, $EC, $E9, $FF                       ; $54E0
 
 label_54E4::
-    sbc  a, l
-    sbc  a, h
+    db   $9D, $9C                                 ; $54E4
 
 label_54E6::
     db $A, $EA
@@ -1813,6 +1592,8 @@ label_5818::
     call label_5A71
     call label_5C49
     ret
+
+label_5822::
     call func_6A7C
 
 FileSaveFadeOut::
@@ -2359,67 +2140,19 @@ label_5D13::
     ret
 
 label_5D14::
-    sbc  a, b
-    rlc  [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    sbc  a, b
-    db   $EB ; Undefined instruction
-    ld   b, $7E
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    nop
+    db  $98, $CB, $06, $7E, $7E, $7E, $7E, $7E, $7E, $7E
+    db  $98, $EB, $06, $7E, $7E, $7E, $7E, $7E, $7E, $7E
+    db  $00
 
 label_5D29::
-    sbc  a, c
-    dec  hl
-    ld   b, $7E
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    sbc  a, c
-    ld   c, e
-    ld   b, $7E
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    nop
+    db  $99, $2B, $06, $7E, $7E, $7E, $7E, $7E, $7E, $7E
+    db  $99, $4B, $06, $7E, $7E, $7E, $7E, $7E, $7E, $7E
+    db  $00
 
 label_5D3E::
-    sbc  a, c
-    adc  a, e
-    ld   b, $7E
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    sbc  a, c
-    xor  e
-    ld   b, $7E
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    ld   a, [hl]
-    nop
+    db  $99, $8B, $06, $7E, $7E, $7E, $7E, $7E, $7E, $7E
+    db  $99, $AB, $06, $7E, $7E, $7E, $7E, $7E, $7E, $7E
+    db  $00
 
 label_5D53::
     ld   a, [$D600]
@@ -3348,9 +3081,24 @@ OpenDungeonNameDialog::
 include "code/marin_beach.asm"
 
 PeachPictureEntryPoint::
-    ; Actually code for a jump table
-    db $FA, $96, $DB, $C7, 8, $68, $29, $68, $56, $68, $73, $68, $AA, $68, $C0, $68
-    db $25, $58, $E4, $68, 8, $69, $45, $69, $22, $58, $CD, $D6, $44
+    ld a, [wGameplaySubtype]
+    JP_TABLE
+
+    dw label_6808
+    dw label_6829
+    dw label_6856
+    dw label_6873
+    dw label_68AA
+    dw label_68C0
+    dw FileSaveFadeOut
+    dw label_68E4
+    dw label_6908
+    dw label_6945
+    dw label_5822
+
+
+label_6808::
+    call IncrementGameplaySubtypeAndReturn
 
 label_680B::
     ldh  a, [hIsGBC]
@@ -3401,6 +3149,7 @@ label_6849::
 
 label_6855::
     ret
+label_6856::
     ld   e, $21
     ldh  a, [hMapId]
     cp   MAP_EAGLES_TOWER
@@ -3417,6 +3166,7 @@ label_6868::
     xor  a
     ld   [$C13F], a
     jp   IncrementGameplaySubtypeAndReturn
+label_6873::
     ld   e, $24
     ldh  a, [hMapId]
     cp   MAP_EAGLES_TOWER
@@ -3447,6 +3197,8 @@ label_689E::
     ld   a, $01
     ld   [$DDD5], a
     jp   IncrementGameplaySubtypeAndReturn
+
+label_68AA::
     call func_6A7C
     call func_1A39
     ld   a, [$C16B]
@@ -3458,6 +3210,8 @@ label_689E::
 
 label_68BF::
     ret
+
+label_68C0::
     ldh  a, [hMapId]
     cp   MAP_EAGLES_TOWER
     jr   nz, label_68CF
@@ -3482,6 +3236,7 @@ label_68D9::
 
 label_68E3::
     ret
+label_68E4::
     call func_6A7C
     ld   a, [$D210]
     dec  a
@@ -3502,6 +3257,7 @@ label_6903::
     ld   a, e
     ld   [wScreenShakeVertical], a
     ret
+label_6908::
     call func_6A7C
     call label_695B
     ld   a, [$D210]
@@ -3529,6 +3285,7 @@ label_6903::
 
 label_6944::
     ret
+label_6945::
     call func_6A7C
     call label_695B
     ld   hl, $D210

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -1179,7 +1179,7 @@ jr_014_536B:
 
 jr_014_537D:
     ld   e, $10                                   ; $537D: $1E $10
-    ld   a, [wAButtonSlot]                        ; $537F: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $537F: $FA $00 $DB
     cp   d                                        ; $5382: $BA
     jr   nz, jr_014_5389                          ; $5383: $20 $04
 
@@ -1187,7 +1187,7 @@ jr_014_537D:
     jr   jr_014_5391                              ; $5387: $18 $08
 
 jr_014_5389:
-    ld   a, [wBButtonSlot]                        ; $5389: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $5389: $FA $01 $DB
     cp   d                                        ; $538C: $BA
     jr   z, jr_014_5391                           ; $538D: $28 $02
 

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -5379,7 +5379,7 @@ jr_002_6B34:
     jr   z, jr_002_6B55                           ; $6B43: $28 $10
 
     ld   e, $20                                   ; $6B45: $1E $20
-    ld   a, [wAButtonSlot]                        ; $6B47: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $6B47: $FA $00 $DB
     cp   $0A                                      ; $6B4A: $FE $0A
     jr   z, jr_002_6B50                           ; $6B4C: $28 $02
 
@@ -6738,11 +6738,11 @@ jr_002_72D1:
     cp   $20                                      ; $72D1: $FE $20
     jr   nz, jr_002_72FA                          ; $72D3: $20 $25
 
-    ld   a, [wBButtonSlot]                        ; $72D5: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $72D5: $FA $01 $DB
     cp   $03                                      ; $72D8: $FE $03
     jr   z, jr_002_72FA                           ; $72DA: $28 $1E
 
-    ld   a, [wAButtonSlot]                        ; $72DC: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $72DC: $FA $00 $DB
     cp   $03                                      ; $72DF: $FE $03
     jr   z, jr_002_72FA                           ; $72E1: $28 $17
 
@@ -6918,7 +6918,7 @@ jr_002_73EE:
     cp   $04                                      ; $73EF: $FE $04
     jr   c, jr_002_742D                           ; $73F1: $38 $3A
 
-    ld   hl, wAButtonSlot                         ; $73F3: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $73F3: $21 $00 $DB
 
 jr_002_73F6:
     ld   a, [hl+]                                 ; $73F6: $2A

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -688,7 +688,7 @@ jr_020_48FC:
     jr   nz, jr_020_4917                          ; $4900: $20 $15
 
     call func_020_4954                            ; $4902: $CD $54 $49
-    call UseRocksFeather                          ; $4905: $CD $CB $14
+    call UseRocsFeather                          ; $4905: $CD $CB $14
     jr   jr_020_4917                              ; $4908: $18 $0D
 
 jr_020_490A:

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -3153,7 +3153,7 @@ func_020_5F06::
     jr   nz, jr_020_5F38                          ; $5F19: $20 $1D
 
     ldh  a, [hJoypadState]                        ; $5F1B: $F0 $CC
-    and  $03                                      ; $5F1D: $E6 $03
+    and  J_LEFT | J_RIGHT                         ; $5F1D: $E6 $03
     ld   e, a                                     ; $5F1F: $5F
     ld   d, $00                                   ; $5F20: $16 $00
     ld   hl, Data_020_5F00                        ; $5F22: $21 $00 $5F
@@ -3176,7 +3176,7 @@ jr_020_5F38:
     ldh  a, [hJoypadState]                        ; $5F38: $F0 $CC
     srl  a                                        ; $5F3A: $CB $3F
     srl  a                                        ; $5F3C: $CB $3F
-    and  $03                                      ; $5F3E: $E6 $03
+    and  (J_UP | J_DOWN) >> 2                     ; ...probably
     ld   e, a                                     ; $5F40: $5F
     ld   d, $00                                   ; $5F41: $16 $00
     ld   hl, Data_020_5F03                        ; $5F43: $21 $03 $5F
@@ -3197,7 +3197,7 @@ jr_020_5F56:
 
 jr_020_5F59:
     ldh  a, [hPressedButtonsMask]                 ; $5F59: $F0 $CB
-    and  $0F                                      ; $5F5B: $E6 $0F
+    and  J_UP | J_DOWN | J_LEFT | J_RIGHT         ; $5F5B: $E6 $0F
     jr   z, jr_020_5F69                           ; $5F5D: $28 $0A
 
     ld   a, [$C1B5]                               ; $5F5F: $FA $B5 $C1
@@ -3218,7 +3218,7 @@ jr_020_5F69:
     jr   nz, jr_020_5F85                          ; $5F76: $20 $0D
 
     ldh  a, [hJoypadState]                        ; $5F78: $F0 $CC
-    and  $80                                      ; $5F7A: $E6 $80
+    and  J_START                                  ; $5F7A: $E6 $80
     jr   z, jr_020_5F85                           ; $5F7C: $28 $07
 
     ld   a, $01                                   ; $5F7E: $3E $01
@@ -3271,7 +3271,7 @@ jr_020_5FC1:
     jp   nz, jr_020_604A                          ; $5FC8: $C2 $4A $60
 
     ldh  a, [hJoypadState]                        ; $5FCB: $F0 $CC
-    and  $10                                      ; $5FCD: $E6 $10
+    and  J_A                                      ; $5FCD: $E6 $10
     jr   z, jr_020_5FED                           ; $5FCF: $28 $1C
 
     ld   a, [wBButtonSlot]                        ; $5FD1: $FA $01 $DB
@@ -3294,7 +3294,7 @@ label_020_5FDB:
 
 jr_020_5FED:
     ldh  a, [hJoypadState]                        ; $5FED: $F0 $CC
-    and  $20                                      ; $5FEF: $E6 $20
+    and  J_B                                      ; $5FEF: $E6 $20
     jr   z, jr_020_604A                           ; $5FF1: $28 $57
 
     ld   a, [wAButtonSlot]                        ; $5FF3: $FA $00 $DB

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -2674,7 +2674,7 @@ func_020_5BB9::
     ld   [$DC90], a                               ; $5BC6: $EA $90 $DC
     push hl                                       ; $5BC9: $E5
     sla  c                                        ; $5BCA: $CB $21
-    ld   hl, Data_020_5C84                        ; $5BCC: $21 $84 $5C
+    ld   hl, InventoryTileMapPositions            ; $5BCC: $21 $84 $5C
     add  hl, bc                                   ; $5BCF: $09
     push hl                                       ; $5BD0: $E5
     pop  de                                       ; $5BD1: $D1
@@ -2735,6 +2735,8 @@ jr_020_5C10:
     ret                                           ; $5C13: $C9
 
 InventoryItemPaletteIndexes::
+    ; Palettes used by the inventory items. This only affects the
+    ; leftmost column.
     db  $01, $01 ; (blank)
     db  $01, $01 ; INVENTORY_SWORD
     db  $01, $01 ; INVENTORY_BOMBS
@@ -2751,6 +2753,8 @@ InventoryItemPaletteIndexes::
     db  $02, $02 ; INVENTORY_BOOMERANG
 
 InventoryItemTiles::
+    ; Tiles used for the inventory items.
+    ; The "L-" is baked in for the sword/shield/bracelet.
     db $7F, $7F, $7F ; (Blank space)
     db $7F, $7F, $7F ;
     db $84, $7F, $7F ; INVENTORY_SWORD
@@ -2781,9 +2785,16 @@ InventoryItemTiles::
     db $A5, $7F, $7F ;
 
 
-Data_020_5C84::
-    db   $9C, $01, $9C, $06, $9C, $61, $9C, $65, $9C, $C1, $9C, $C5, $9D, $21, $9D, $25
-    db   $9D, $81, $9D, $85, $9D, $E1, $9D, $E5
+InventoryTileMapPositions::
+    ; Where each inventory item is drawn in the subscreen
+    ; (and, for the first one, the status bar)
+    db  $9C, $01,   $9C, $06  ; B[   ] A[   ]
+    ;    -------  |  ------     ------------|---
+    db  $9C, $61,   $9C, $65  ;  [   ] [   ]
+    db  $9C, $C1,   $9C, $C5  ;  [   ] [   ]
+    db  $9D, $21,   $9D, $25  ;  [   ] [   ]
+    db  $9D, $81,   $9D, $85  ;  [   ] [   ]
+    db  $9D, $E1,   $9D, $E5  ;  [   ] [   ]
 
 func_020_5C9C::
     push de                                       ; $5C9C: $D5
@@ -2813,7 +2824,7 @@ jr_020_5CB5:
     ld   [wRequests], a                           ; $5CC1: $EA $00 $D6
     push hl                                       ; $5CC4: $E5
     sla  c                                        ; $5CC5: $CB $21
-    ld   hl, Data_020_5C84                        ; $5CC7: $21 $84 $5C
+    ld   hl, InventoryTileMapPositions            ; $5CC7: $21 $84 $5C
     add  hl, bc                                   ; $5CCA: $09
     push hl                                       ; $5CCB: $E5
     pop  de                                       ; $5CCC: $D1
@@ -2847,7 +2858,7 @@ jr_020_5CB5:
     push bc                                       ; $5CEC: $C5
     push hl                                       ; $5CED: $E5
     sla  c                                        ; $5CEE: $CB $21
-    ld   hl, Data_020_5C84                        ; $5CF0: $21 $84 $5C
+    ld   hl, InventoryTileMapPositions            ; $5CF0: $21 $84 $5C
     add  hl, bc                                   ; $5CF3: $09
     push hl                                       ; $5CF4: $E5
     pop  de                                       ; $5CF5: $D1

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -3356,6 +3356,8 @@ jr_020_604A:
     ret                                           ; $604A: $C9
 
 Data_020_604B::
+    ; @TODO This is a big block of data for the ocarina song selection popup
+    ; involving how it animates and draws on the subscreen
     db   $F8, $F0, $22, $01, $F8, $F8, $22, $21, $F8, $00, $24, $02, $F8, $08, $24, $22
     db   $F8, $10, $26, $00, $F8, $18, $26, $20, $08, $F0, $20, $00, $08, $F8, $20, $00
     db   $08, $00, $20, $00, $08, $08, $20, $00, $08, $10, $20, $00, $08, $18, $20, $00
@@ -3886,8 +3888,10 @@ InventoryVisibleHandler::
     jr   jr_020_6436                              ; $63F3: $18 $41
 
 jr_020_63F5:
+    ; POI: Debug tool 3 check to enable free movement mode on the subscreen
+    ; and resetting the photo album on pushing Select
     ldh  a, [hJoypadState]                        ; $63F5: $F0 $CC
-    and  $40                                      ; $63F7: $E6 $40
+    and  J_SELECT                                 ; $63F7: $E6 $40
     jr   z, jr_020_641E                           ; $63F9: $28 $23
 
     ld   a, $09                                   ; $63FB: $3E $09
@@ -3918,7 +3922,7 @@ jr_020_641E:
     jr   nz, jr_020_6445                          ; $6429: $20 $1A
 
     ldh  a, [hJoypadState]                        ; $642B: $F0 $CC
-    and  $80                                      ; $642D: $E6 $80
+    and  J_START                                  ; $642D: $E6 $80
     jr   z, jr_020_6445                           ; $642F: $28 $14
 
     ld   a, $0C                                   ; $6431: $3E $0C
@@ -4165,7 +4169,7 @@ InventoryFadeOutHandler::
     jr   nz, jr_020_6628                          ; $6610: $20 $16
 
     ldh  a, [hMapRoom]                            ; $6612: $F0 $F6
-    cp   $64                                      ; $6614: $FE $64
+    cp   $64                                      ; @TODO ?? Map screen where you take the ghost after the house
     jr   nz, jr_020_6626                          ; $6616: $20 $0E
 
     ld   hl, $C193                                ; $6618: $21 $93 $C1
@@ -4230,7 +4234,7 @@ jr_020_6659:
     and  $7F                                      ; $666E: $E6 $7F
     ld   [rLCDC], a                               ; $6670: $E0 $40
     ldh  a, [hMapId]                              ; $6672: $F0 $F7
-    cp   $FF                                      ; $6674: $FE $FF
+    cp   MAP_COLOR_DUNGEON                        ; $6674: $FE $FF
     jr   nz, jr_020_667C                          ; $6676: $20 $04
 
     ld   a, $01                                   ; $6678: $3E $01
@@ -5480,6 +5484,7 @@ data_020_763B::
 
 ; These look like pointers, but actually point to random locations in
 ; the ROM, to make the water geyser splashing effect.
+; @TODO Actually seems to be palette colors
 Data_020_783F::
     dw   $7845
     dw   $787D
@@ -5569,7 +5574,7 @@ Data_020_783F::
     dw   $660F
     dw   $6ED6
 
-; Copy semi-random data to $DC10
+; Copy palette data to $DC10
 ; (Called during the Credits water geyser sequence; to animate the water?)
 func_020_78ED::
     ld   a, [wCreditsScratch0]                    ; $78ED: $FA $00 $D0

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -2510,8 +2510,22 @@ jr_020_5ADE:
     ldh  [hWindowXUnused], a                      ; $5AE9: $E0 $AA
     jp   label_020_5D34                           ; $5AEB: $C3 $34 $5D
 
-Data_020_5AEE::
-    db   $00, $05, $02, $05, $05, $06, $06, $05, $05, $05, $06, $01, $02, $02, $05
+tradingItemPaletteIndexes:
+    db $00  ; TRADING_ITEM_NONE
+    db $05  ; TRADING_ITEM_YOSHI_DOLL
+    db $02  ; TRADING_ITEM_RIBBON
+    db $05  ; TRADING_ITEM_DOG_FOOD
+    db $05  ; TRADING_ITEM_BANANAS
+    db $06  ; TRADING_ITEM_STICK
+    db $06  ; TRADING_ITEM_HONEYCOMB
+    db $05  ; TRADING_ITEM_PINEAPPLE
+    db $05  ; TRADING_ITEM_HIBISCUS
+    db $05  ; TRADING_ITEM_LETTER
+    db $06  ; TRADING_ITEM_BROOM
+    db $01  ; TRADING_ITEM_FISHING_HOOK
+    db $02  ; TRADING_ITEM_NECKLACE
+    db $02  ; TRADING_ITEM_SCALE
+    db $05  ; TRADING_ITEM_MAGNIFIYING_GLASS
 
 InventoryLoad2Handler::
     ldh  a, [hIsGBC]                              ; $5AFD: $F0 $FE
@@ -2521,7 +2535,7 @@ InventoryLoad2Handler::
     ld   b, $00                                   ; $5B02: $06 $00
     ld   a, [wTradeSequenceItem]                  ; $5B04: $FA $0E $DB
     ld   c, a                                     ; $5B07: $4F
-    ld   hl, Data_020_5AEE                        ; $5B08: $21 $EE $5A
+    ld   hl, tradingItemPaletteIndexes           ; $5B08: $21 $EE $5A
     add  hl, bc                                   ; $5B0B: $09
     ld   a, [hl]                                  ; $5B0C: $7E
     ldh  [hScratch0], a                           ; $5B0D: $E0 $D7
@@ -2676,7 +2690,7 @@ func_020_5BB9::
     ldh  a, [hScratch1]                           ; $5BDC: $F0 $D8
     sla  a                                        ; $5BDE: $CB $27
     ld   c, a                                     ; $5BE0: $4F
-    ld   hl, Data_020_5C14                        ; $5BE1: $21 $14 $5C
+    ld   hl, InventoryItemPaletteIndexes          ; $5BE1: $21 $14 $5C
     add  hl, bc                                   ; $5BE4: $09
     push hl                                       ; $5BE5: $E5
     pop  de                                       ; $5BE6: $D1
@@ -2720,20 +2734,52 @@ jr_020_5C10:
     pop  bc                                       ; $5C12: $C1
     ret                                           ; $5C13: $C9
 
-Data_020_5C14::
-    db   $01, $01, $01, $01, $01, $01, $01, $01, $01, $01, $03, $03, $01, $02, $02, $01
-    db   $03, $03, $02, $02, $03, $03, $03, $01, $03, $03, $02, $02
+InventoryItemPaletteIndexes::
+    db  $01, $01 ; (blank)
+    db  $01, $01 ; INVENTORY_SWORD
+    db  $01, $01 ; INVENTORY_BOMBS
+    db  $01, $01 ; INVENTORY_POWER_BRACELET  (note: L2 has special code elsewhere)
+    db  $01, $01 ; INVENTORY_SHIELD
+    db  $03, $03 ; INVENTORY_BOW
+    db  $01, $02 ; INVENTORY_HOOKSHOT
+    db  $02, $01 ; INVENTORY_MAGIC_ROD
+    db  $03, $03 ; INVENTORY_PEGASUS_BOOTS
+    db  $02, $02 ; INVENTORY_OCARINA
+    db  $03, $03 ; INVENTORY_ROCS_FEATHER
+    db  $03, $01 ; INVENTORY_SHOVEL
+    db  $03, $03 ; INVENTORY_MAGIC_POWDER
+    db  $02, $02 ; INVENTORY_BOOMERANG
 
-Data_020_5C30::
-    db   $7F, $7F, $7F
+InventoryItemTiles::
+    db $7F, $7F, $7F ; (Blank space)
+    db $7F, $7F, $7F ;
+    db $84, $7F, $7F ; INVENTORY_SWORD
+    db $85, $BA, $7F ; L-
+    db $80, $7F, $7F ; INVENTORY_BOMBS
+    db $81, $7F, $7F ;
+    db $82, $7F, $7F ; INVENTORY_POWER_BRACELET
+    db $83, $BA, $7F ; L-
+    db $86, $7F, $7F ; INVENTORY_SHIELD
+    db $87, $BA, $7F ; L-
+    db $88, $7F, $7F ; INVENTORY_BOW
+    db $89, $7F, $7F ;
+    db $8A, $7F, $7F ; INVENTORY_HOOKSHOT
+    db $8B, $7F, $7F ;
+    db $8C, $7F, $7F ; INVENTORY_MAGIC_ROD
+    db $8D, $7F, $7F ;
+    db $98, $7F, $7F ; INVENTORY_PEGASUS_BOOTS
+    db $99, $7F, $7F ;
+    db $90, $7F, $7F ; INVENTORY_OCARINA
+    db $91, $7F, $7F ;
+    db $92, $7F, $7F ; INVENTORY_ROCS_FEATHER
+    db $93, $7F, $7F ;
+    db $96, $7F, $7F ; INVENTORY_SHOVEL
+    db $97, $7F, $7F ;
+    db $8E, $7F, $7F ; INVENTORY_MAGIC_POWDER
+    db $8F, $7F, $7F ;
+    db $A4, $7F, $7F ; INVENTORY_BOOMERANG
+    db $A5, $7F, $7F ;
 
-Data_020_5C33::
-    db   $7F, $7F, $7F, $84, $7F, $7F, $85, $BA, $7F, $80, $7F, $7F, $81, $7F, $7F, $82
-    db   $7F, $7F, $83, $BA, $7F, $86, $7F, $7F, $87, $BA, $7F, $88, $7F, $7F, $89, $7F
-    db   $7F, $8A, $7F, $7F, $8B, $7F, $7F, $8C, $7F, $7F, $8D, $7F, $7F, $98, $7F, $7F
-    db   $99, $7F, $7F, $90, $7F, $7F, $91, $7F, $7F, $92, $7F, $7F, $93, $7F, $7F, $96
-    db   $7F, $7F, $97, $7F, $7F, $8E, $7F, $7F, $8F, $7F, $7F, $A4, $7F, $7F, $A5, $7F
-    db   $7F
 
 Data_020_5C84::
     db   $9C, $01, $9C, $06, $9C, $61, $9C, $65, $9C, $C1, $9C, $C5, $9D, $21, $9D, $25
@@ -2783,7 +2829,7 @@ jr_020_5CB5:
     push hl                                       ; $5CD7: $E5
     ldh  a, [hScratch0]                           ; $5CD8: $F0 $D7
     ld   c, a                                     ; $5CDA: $4F
-    ld   hl, Data_020_5C30                        ; $5CDB: $21 $30 $5C
+    ld   hl, InventoryItemTiles                   ; $5CDB: $21 $30 $5C
     add  hl, bc                                   ; $5CDE: $09
     push hl                                       ; $5CDF: $E5
     pop  de                                       ; $5CE0: $D1
@@ -2824,7 +2870,7 @@ jr_020_5CB5:
     push hl                                       ; $5D09: $E5
     ldh  a, [hScratch0]                           ; $5D0A: $F0 $D7
     ld   c, a                                     ; $5D0C: $4F
-    ld   hl, Data_020_5C33                        ; $5D0D: $21 $33 $5C
+    ld   hl, InventoryItemTiles + 3               ; $5D0D: $21 $33 $5C
     add  hl, bc                                   ; $5D10: $09
     push hl                                       ; $5D11: $E5
     pop  de                                       ; $5D12: $D1

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -2932,48 +2932,65 @@ InventoryLoad4Handler::
     call func_020_6683                            ; $5D5D: $CD $83 $66
     ret                                           ; $5D60: $C9
 
-Data_020_5D61::
-    db   $FF, $57, $C4, $26, $21, $15, $00, $00, $FF, $57, $31, $52, $C5, $28, $00, $00
-    db   $FF, $57, $7F, $2C, $0E, $14, $00, $00, $FF, $57, $D9, $11, $CE, $10, $00, $00
-    db   $FF, $57, $AE, $7E, $00, $7C, $00, $00, $FF, $57, $FF, $7F, $42, $06, $00, $00
-    db   $FF, $57, $BB, $12, $51, $01, $00, $00, $FF, $57, $02, $2B, $00, $0A, $00, $00
-    db   $FF, $57, $00, $00, $A2, $22, $FF, $4E, $00, $7C, $00, $00, $FF, $05, $FF, $4E
-    db   $00, $7C, $00, $00, $03, $7E, $FF, $4E, $00, $7C, $00, $00, $31, $52, $FF, $7F
-    db   $00, $7C, $DF, $1A, $7D, $18, $00, $00, $00, $7C, $00, $00, $A2, $22, $FF, $7F
-    db   $00, $7C, $00, $00, $1F, $00, $FF, $7F, $00, $7C, $00, $00, $00, $7C, $FF, $7F
+InventoryPalettes::
+    ; 8 + 8 palettes used for the inventory subscreen
+    ;       0      1      2      3
+    dw   $57FF, $26C4, $1521, $0000
+    dw   $57FF, $5231, $28C5, $0000
+    dw   $57FF, $2C7F, $140E, $0000
+    dw   $57FF, $11D9, $10CE, $0000
+    dw   $57FF, $7EAE, $7C00, $0000
+    dw   $57FF, $7FFF, $0642, $0000
+    dw   $57FF, $12BB, $0151, $0000
+    dw   $57FF, $2B02, $0A00, $0000
+    dw   $57FF, $0000, $22A2, $4EFF
+    dw   $7C00, $0000, $05FF, $4EFF
+    dw   $7C00, $0000, $7E03, $4EFF
+    dw   $7C00, $0000, $5231, $7FFF
+    dw   $7C00, $1ADF, $187D, $0000
+    dw   $7C00, $0000, $22A2, $7FFF
+    dw   $7C00, $0000, $001F, $7FFF
+    dw   $7C00, $0000, $7C00, $7FFF
 
-Data_020_5DE1::
-    db   $FF, $7F, $42, $06
+InventoryTradingItemPalettes::
+    ; Replaces the second and third color in the fifth BG palette line
+    ; Used for trading sequence items
+    ;       2      3
+    dw   $7FFF, $0642
+    dw   $0FBE, $0213
+    dw   $0F7F, $09E0
+    dw   $32DF, $187D
+    dw   $7FFF, $083D
+    dw   $7EAE, $7C00
+    dw   $7FFF, $5231
 
-Data_020_5DE5::
-    db   $BE, $0F, $13, $02
+InventoryTradingItemPaletteTable::
+    ; Pointers to InventoryTradingItemPalettes
+    dw   InventoryTradingItemPalettes
+    dw   InventoryTradingItemPalettes + $04
+    dw   InventoryTradingItemPalettes + $08
+    dw   InventoryTradingItemPalettes + $0C
+    dw   InventoryTradingItemPalettes + $10
+    dw   InventoryTradingItemPalettes + $14
+    dw   InventoryTradingItemPalettes + $18
 
-Data_020_5DE9::
-    db   $7F, $0F, $E0, $09
-
-Data_020_5DED::
-    db   $DF, $32, $7D, $18
-
-Data_020_5DF1::
-    db   $FF, $7F, $3D, $08
-
-Data_020_5DF5::
-    db   $AE, $7E, $00, $7C
-
-Data_020_5DF9::
-    db   $FF, $7F, $31, $52
-
-Data_020_5DFD::
-    dw   Data_020_5DE1
-    dw   Data_020_5DE5
-    dw   Data_020_5DE9
-    dw   Data_020_5DED
-    dw   Data_020_5DF1
-    dw   Data_020_5DF5
-    dw   Data_020_5DF9
-
-Data_020_5E0B::
-    db   $00, $01, $00, $07, $02, $00, $00, $03, $04, $05, $00, $00, $00, $00, $06
+InventoryTradingItemPaletteIndex::
+    ; Which trading item palette should be used, per trading item
+    db  $00  ; TRADING_ITEM_NONE
+    db  $01  ; TRADING_ITEM_YOSHI_DOLL
+    db  $00  ; TRADING_ITEM_RIBBON
+    db  $07  ; TRADING_ITEM_DOG_FOOD
+    db  $02  ; TRADING_ITEM_BANANAS
+    db  $00  ; TRADING_ITEM_STICK
+    db  $00  ; TRADING_ITEM_HONEYCOMB
+    db  $03  ; TRADING_ITEM_PINEAPPLE
+    db  $04  ; TRADING_ITEM_HIBISCUS
+    db  $05  ; TRADING_ITEM_LETTER
+    db  $00  ; TRADING_ITEM_BROOM
+    db  $00  ; TRADING_ITEM_FISHING_HOOK
+    db  $00  ; TRADING_ITEM_NECKLACE
+    db  $00  ; TRADING_ITEM_SCALE
+    db  $06  ; TRADING_ITEM_MAGNIFIYING_GLASS
 
 InventoryLoad5Handler::
     xor  a                                        ; $5E1A: $AF
@@ -2984,7 +3001,7 @@ InventoryLoad5Handler::
     and  a                                        ; $5E25: $A7
     jr   z, jr_020_5E6D                           ; $5E26: $28 $45
 
-    ld   bc, Data_020_5D61                        ; $5E28: $01 $61 $5D
+    ld   bc, InventoryPalettes                        ; $5E28: $01 $61 $5D
     ld   hl, $DC10                                ; $5E2B: $21 $10 $DC
     di                                            ; $5E2E: $F3
     ld   a, $02                                   ; $5E2F: $3E $02
@@ -3001,7 +3018,7 @@ InventoryLoad5Handler::
     xor  a                                        ; $5E3B: $AF
     ldh  [rSVBK], a                               ; $5E3C: $E0 $70
     ei                                            ; $5E3E: $FB
-    ld   hl, Data_020_5E0B                        ; $5E3F: $21 $0B $5E
+    ld   hl, InventoryTradingItemPaletteIndex                        ; $5E3F: $21 $0B $5E
     ld   a, [wTradeSequenceItem]                  ; $5E42: $FA $0E $DB
     ld   e, a                                     ; $5E45: $5F
     ld   d, $00                                   ; $5E46: $16 $00
@@ -3012,7 +3029,7 @@ InventoryLoad5Handler::
 
     sla  a                                        ; $5E4D: $CB $27
     ld   e, a                                     ; $5E4F: $5F
-    ld   hl, Data_020_5DFD - 2                    ; $5E50: $21 $FB $5D
+    ld   hl, InventoryTradingItemPaletteTable - 2                    ; $5E50: $21 $FB $5D
     add  hl, de                                   ; $5E53: $19
     ld   a, [hl+]                                 ; $5E54: $2A
     ld   h, [hl]                                  ; $5E55: $66

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -1252,7 +1252,7 @@ func_020_4C47::
     ld   [wMagicPowderCount], a                   ; $4C56: $EA $4C $DB
     jr   nz, jr_020_4C6D                          ; $4C59: $20 $12
 
-    ld   hl, wAButtonSlot                         ; $4C5B: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $4C5B: $21 $00 $DB
     ld   a, [hl]                                  ; $4C5E: $7E
     cp   $0C                                      ; $4C5F: $FE $0C
     jr   nz, jr_020_4C65                          ; $4C61: $20 $02
@@ -2799,7 +2799,7 @@ InventoryTileMapPositions::
 func_020_5C9C::
     push de                                       ; $5C9C: $D5
     push bc                                       ; $5C9D: $C5
-    ld   hl, wAButtonSlot                         ; $5C9E: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $5C9E: $21 $00 $DB
     add  hl, bc                                   ; $5CA1: $09
     ld   a, [hl]                                  ; $5CA2: $7E
     ldh  [hScratch1], a                           ; $5CA3: $E0 $D8
@@ -3274,7 +3274,7 @@ jr_020_5FC1:
     and  J_A                                      ; $5FCD: $E6 $10
     jr   z, jr_020_5FED                           ; $5FCF: $28 $1C
 
-    ld   a, [wBButtonSlot]                        ; $5FD1: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $5FD1: $FA $01 $DB
     push af                                       ; $5FD4: $F5
     ld   hl, wInventoryItem1                      ; $5FD5: $21 $02 $DB
     ld   a, [$DBA3]                               ; $5FD8: $FA $A3 $DB
@@ -3284,7 +3284,7 @@ label_020_5FDB:
     ld   b, $00                                   ; $5FDC: $06 $00
     add  hl, bc                                   ; $5FDE: $09
     ld   a, [hl]                                  ; $5FDF: $7E
-    ld   [wBButtonSlot], a                        ; $5FE0: $EA $01 $DB
+    ld   [wAButtonSlot], a                        ; $5FE0: $EA $01 $DB
     pop  af                                       ; $5FE3: $F1
     ld   [hl], a                                  ; $5FE4: $77
     ld   c, $01                                   ; $5FE5: $0E $01
@@ -3297,7 +3297,7 @@ jr_020_5FED:
     and  J_B                                      ; $5FEF: $E6 $20
     jr   z, jr_020_604A                           ; $5FF1: $28 $57
 
-    ld   a, [wAButtonSlot]                        ; $5FF3: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $5FF3: $FA $00 $DB
     push af                                       ; $5FF6: $F5
     ld   hl, wInventoryItem1                      ; $5FF7: $21 $02 $DB
     ld   a, [$DBA3]                               ; $5FFA: $FA $A3 $DB
@@ -3305,7 +3305,7 @@ jr_020_5FED:
     ld   b, $00                                   ; $5FFE: $06 $00
     add  hl, bc                                   ; $6000: $09
     ld   a, [hl]                                  ; $6001: $7E
-    ld   [wAButtonSlot], a                        ; $6002: $EA $00 $DB
+    ld   [wBButtonSlot], a                        ; $6002: $EA $00 $DB
     pop  af                                       ; $6005: $F1
     ld   [hl], a                                  ; $6006: $77
     ld   c, $00                                   ; $6007: $0E $00
@@ -3790,7 +3790,7 @@ func_020_635C::
     ld   d, $0C                                   ; $635C: $16 $0C
 
 jr_020_635E:
-    ld   hl, wAButtonSlot                         ; $635E: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $635E: $21 $00 $DB
     ld   e, $00                                   ; $6361: $1E $00
 
 jr_020_6363:

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -2966,6 +2966,7 @@ InventoryTradingItemPalettes::
 
 InventoryTradingItemPaletteTable::
     ; Pointers to InventoryTradingItemPalettes
+    ; POI: This seems really inefficent compared to just adding the index... but w/e
     dw   InventoryTradingItemPalettes
     dw   InventoryTradingItemPalettes + $04
     dw   InventoryTradingItemPalettes + $08
@@ -3059,11 +3060,24 @@ jr_020_5E6D:
     call func_020_6683                            ; $5E71: $CD $83 $66
     ret                                           ; $5E74: $C9
 
-Data_020_5E75::
-    db   $80, $26, $00, $11, $20, $3A, $E0, $18, $A0, $51, $C0, $20, $08, $7D, $84, $34
-    db   $AD, $7C, $46, $30, $50, $5C, $27, $28, $12, $40, $08, $1C, $15, $30, $09, $14
-    db   $17, $14, $09, $00, $D7, $04, $6A, $04, $37, $05, $8A, $04, $97, $09, $AA, $04
-    db   $F5, $09, $C9, $04, $10, $0A, $E7, $04, $4B, $06, $05, $05, $A0, $02, $20, $01
+InventoryInstrumentCyclingColors::
+    ; Palette colors for the color-cycling the instruments use on the subscreen.
+    dw  $2680, $1100
+    dw  $3A20, $18E0
+    dw  $51A0, $20C0
+    dw  $7D08, $3484
+    dw  $7CAD, $3046
+    dw  $5C50, $2827
+    dw  $4012, $1C08
+    dw  $3015, $1409
+    dw  $1417, $0009
+    dw  $04D7, $046A
+    dw  $0537, $048A
+    dw  $0997, $04AA
+    dw  $09F5, $04C9
+    dw  $0A10, $04E7
+    dw  $064B, $0505
+    dw  $02A0, $0120
 
 func_020_5EB5::
     ldh  a, [hIsGBC]                              ; $5EB5: $F0 $FE
@@ -3088,7 +3102,7 @@ func_020_5EB5::
 
 jr_020_5ED6:
     ld   b, $00                                   ; $5ED6: $06 $00
-    ld   hl, Data_020_5E75                        ; $5ED8: $21 $75 $5E
+    ld   hl, InventoryInstrumentCyclingColors                        ; $5ED8: $21 $75 $5E
     add  hl, bc                                   ; $5EDB: $09
     ld   bc, $DC4A                                ; $5EDC: $01 $4A $DC
     ld   e, $04                                   ; $5EDF: $1E $04

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -2633,7 +2633,7 @@ func_015_5435::
     and  a                                        ; $5438: $A7
     jr   z, jr_015_5465                           ; $5439: $28 $2A
 
-    ld   a, [wAButtonSlot]                        ; $543B: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $543B: $FA $00 $DB
     cp   $0C                                      ; $543E: $FE $0C
     jr   nz, jr_015_5450                          ; $5440: $20 $0E
 
@@ -2646,7 +2646,7 @@ func_015_5435::
     jp   label_015_54A2                           ; $544D: $C3 $A2 $54
 
 jr_015_5450:
-    ld   a, [wBButtonSlot]                        ; $5450: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $5450: $FA $01 $DB
     cp   $0C                                      ; $5453: $FE $0C
     jr   nz, jr_015_5465                          ; $5455: $20 $0E
 

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -1087,13 +1087,13 @@ MermaidStatueState1Handler::
     ret  nc                                       ; $4965: $D0
 
     ld   a, [wTradeSequenceItem]                  ; $4966: $FA $0E $DB
-    cp   $0E                                      ; $4969: $FE $0E
-    ret  z                                        ; $496B: $C8
+    cp   TRADING_ITEM_MAGNIFIYING_GLASS           ; $4969: $FE $0E
+    ret  z                                        ; If you have the magnifying glass, return
 
-    cp   $0D                                      ; $496C: $FE $0D
-    jr   nz, jr_018_498E                          ; $496E: $20 $1E
+    cp   TRADING_ITEM_SCALE                       ; $496C: $FE $0D
+    jr   nz, jr_018_498E                          ; If you don't have the mermaid scale, return
 
-    ld   a, $0E                                   ; $4970: $3E $0E
+    ld   a, TRADING_ITEM_MAGNIFIYING_GLASS        ; $4970: $3E $0E
     ld   [wTradeSequenceItem], a                  ; $4972: $EA $0E $DB
     ld   a, $01                                   ; $4975: $3E $01
     ld   [$DB7F], a                               ; $4977: $EA $7F $DB
@@ -1162,7 +1162,7 @@ ZoraEntityHandler::
     jp   z, func_018_7F08                         ; $49F0: $CA $08 $7F
 
     ld   a, [wTradeSequenceItem]                  ; $49F3: $FA $0E $DB
-    cp   $0E                                      ; $49F6: $FE $0E
+    cp   TRADING_ITEM_MAGNIFIYING_GLASS           ; $49F6: $FE $0E
     jp   nz, func_018_7F08                        ; $49F8: $C2 $08 $7F
 
     ld   a, [$DB7F]                               ; $49FB: $FA $7F $DB
@@ -1413,12 +1413,12 @@ jr_018_4BB5:
 jr_018_4BE4:
     call func_018_7D36                            ; $4BE4: $CD $36 $7D
     ldh  a, [hMapRoom]                            ; $4BE7: $F0 $F6
-    cp   $A8                                      ; $4BE9: $FE $A8
+    cp   $A8                                      ; $A8 = Mr. Write's house
     jp   z, label_018_4C75                        ; $4BEB: $CA $75 $4C
 
     ld   de, Data_018_4B95                        ; $4BEE: $11 $95 $4B
     ld   a, [wTradeSequenceItem]                  ; $4BF1: $FA $0E $DB
-    cp   $09                                      ; $4BF4: $FE $09
+    cp   TRADING_ITEM_LETTER                      ; $4BF4: $FE $09
     jr   nc, jr_018_4BFB                          ; $4BF6: $30 $03
 
     ld   de, Data_018_4B99                        ; $4BF8: $11 $99 $4B
@@ -1454,7 +1454,7 @@ MrWriteState0Handler::
     ret  nc                                       ; $4C2B: $D0
 
     ld   a, [wTradeSequenceItem]                  ; $4C2C: $FA $0E $DB
-    cp   $08                                      ; $4C2F: $FE $08
+    cp   TRADING_ITEM_HIBISCUS                    ; $4C2F: $FE $08
     jr   nz, jr_018_4C3B                          ; $4C31: $20 $08
 
     call_open_dialog $167                         ; $4C33
@@ -1493,7 +1493,7 @@ MrWriteState2Handler::
     call IncrementEntityState                     ; $4C64: $CD $12 $3B
     ld   [hl], b                                  ; $4C67: $70
     call CreateTradingItemEntity                  ; $4C68: $CD $0C $0C
-    ld   a, $09                                   ; $4C6B: $3E $09
+    ld   a, TRADING_ITEM_LETTER                   ; $4C6B: $3E $09
     ld   [wTradeSequenceItem], a                  ; $4C6D: $EA $0E $DB
     ld   a, $0D                                   ; $4C70: $3E $0D
     ldh  [hFFA5], a                               ; $4C72: $E0 $A5
@@ -1517,7 +1517,7 @@ func_018_4C87::
     ret  nc                                       ; $4C8A: $D0
 
     ld   a, [wTradeSequenceItem]                  ; $4C8B: $FA $0E $DB
-    cp   $09                                      ; $4C8E: $FE $09
+    cp   TRADING_ITEM_LETTER                      ; $4C8E: $FE $09
     jr   nz, jr_018_4C9A                          ; $4C90: $20 $08
 
     call_open_dialog $134                         ; $4C92
@@ -1574,7 +1574,7 @@ func_018_4CD1::
     jr   nz, jr_018_4CEC                          ; $4CDD: $20 $0D
 
     call CreateTradingItemEntity                  ; $4CDF: $CD $0C $0C
-    ld   a, $0A                                   ; $4CE2: $3E $0A
+    ld   a, TRADING_ITEM_BROOM                    ; $4CE2: $3E $0A
     ld   [wTradeSequenceItem], a                  ; $4CE4: $EA $0E $DB
     ld   a, $0D                                   ; $4CE7: $3E $0D
     ldh  [hFFA5], a                               ; $4CE9: $E0 $A5
@@ -1626,7 +1626,7 @@ jr_018_4D36:
     xor  a                                        ; $4D39: $AF
     ldh  [hFFE8], a                               ; $4D3A: $E0 $E8
     ld   a, [wTradeSequenceItem]                  ; $4D3C: $FA $0E $DB
-    cp   $0B                                      ; $4D3F: $FE $0B
+    cp   TRADING_ITEM_FISHING_HOOK                ; $4D3F: $FE $0B
     jr   nc, jr_018_4D58                          ; $4D41: $30 $15
 
     ld   a, [wHasInstrument5]                     ; $4D43: $FA $69 $DB
@@ -1634,7 +1634,7 @@ jr_018_4D36:
     jr   nz, jr_018_4D51                          ; $4D48: $20 $07
 
     ld   a, [wTradeSequenceItem]                  ; $4D4A: $FA $0E $DB
-    cp   $0A                                      ; $4D4D: $FE $0A
+    cp   TRADING_ITEM_BROOM                       ; $4D4D: $FE $0A
     jr   c, jr_018_4D58                           ; $4D4F: $38 $07
 
 jr_018_4D51:
@@ -1682,7 +1682,7 @@ GrandmaUlriraState0Handler::
     jr   nz, jr_018_4DA3                          ; $4D93: $20 $0E
 
     ld   a, [wTradeSequenceItem]                  ; $4D95: $FA $0E $DB
-    cp   $0B                                      ; $4D98: $FE $0B
+    cp   TRADING_ITEM_FISHING_HOOK                ; $4D98: $FE $0B
     ld   a, $5A                                   ; $4D9A: $3E $5A
     jr   c, jr_018_4DA0                           ; $4D9C: $38 $02
 
@@ -1693,7 +1693,7 @@ jr_018_4DA0:
 
 jr_018_4DA3:
     ld   a, [wTradeSequenceItem]                  ; $4DA3: $FA $0E $DB
-    cp   $0A                                      ; $4DA6: $FE $0A
+    cp   TRADING_ITEM_BROOM                       ; $4DA6: $FE $0A
     jr   nz, jr_018_4DB5                          ; $4DA8: $20 $0B
 
     ld   [wC167], a                               ; $4DAA: $EA $67 $C1
@@ -1727,7 +1727,7 @@ GrandmaUlriraState2Handler::
     call GetEntityTransitionCountdown             ; $4DDD: $CD $05 $0C
     jr   nz, jr_018_4DF3                          ; $4DE0: $20 $11
 
-    ld   a, $0B                                   ; $4DE2: $3E $0B
+    ld   a, TRADING_ITEM_FISHING_HOOK             ; $4DE2: $3E $0B
     ld   [wTradeSequenceItem], a                  ; $4DE4: $EA $0E $DB
     ld   a, $0D                                   ; $4DE7: $3E $0D
     ldh  [hFFA5], a                               ; $4DE9: $E0 $A5
@@ -1803,10 +1803,10 @@ PapahlsWifeState0Handler::
     ret  nc                                       ; $4E79: $D0
 
     ld   a, [wTradeSequenceItem]                  ; $4E7A: $FA $0E $DB
-    cp   $08                                      ; $4E7D: $FE $08
+    cp   TRADING_ITEM_HIBISCUS                    ; $4E7D: $FE $08
     jr   nc, label_018_4E91                       ; $4E7F: $30 $10
 
-    cp   $01                                      ; $4E81: $FE $01
+    cp   TRADING_ITEM_YOSHI_DOLL                  ; $4E81: $FE $01
     jr   z, jr_018_4E9F                           ; $4E83: $28 $1A
 
     ld   a, [wHasInstrument3]                     ; $4E85: $FA $67 $DB
@@ -1843,7 +1843,7 @@ PapahlsWifeState1Handler::
     and  a                                        ; $4EB1: $A7
     jr   nz, jr_018_4EC5                          ; $4EB2: $20 $11
 
-    ld   a, $02                                   ; $4EB4: $3E $02
+    ld   a, TRADING_ITEM_RIBBON                   ; $4EB4: $3E $02
     ld   [wTradeSequenceItem], a                  ; $4EB6: $EA $0E $DB
     ld   a, $0D                                   ; $4EB9: $3E $0D
     ldh  [hFFA5], a                               ; $4EBB: $E0 $A5
@@ -4609,7 +4609,7 @@ MarinAtTheShoreEntityHandler::
     jp   nz, func_018_7F08                        ; $619B: $C2 $08 $7F
 
     ld   a, [wTradeSequenceItem]                  ; $619E: $FA $0E $DB
-    cp   $07                                      ; $61A1: $FE $07
+    cp   TRADING_ITEM_PINEAPPLE                   ; $61A1: $FE $07
     jp   c, func_018_7F08                         ; $61A3: $DA $08 $7F
 
     ld   de, Data_018_5EB7                        ; $61A6: $11 $B7 $5E

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -56,7 +56,7 @@ jr_018_404A:
     call ClearLinkPositionIncrement               ; $4054: $CD $8E $17
     call ResetSpinAttack                          ; $4057: $CD $AF $0C
     ld   e, $0B                                   ; $405A: $1E $0B
-    ld   hl, wAButtonSlot                         ; $405C: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $405C: $21 $00 $DB
 
 jr_018_405F:
     ld   a, [hl+]                                 ; $405F: $2A
@@ -698,7 +698,7 @@ ManboAndFishesState1Handler::
     jr   nz, jr_018_4581                          ; $456F: $20 $10
 
     ld   e, $0B                                   ; $4571: $1E $0B
-    ld   hl, wAButtonSlot                         ; $4573: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $4573: $21 $00 $DB
 
 jr_018_4576:
     ld   a, [hl+]                                 ; $4576: $2A
@@ -2644,12 +2644,12 @@ jr_018_53ED:
     jr   nc, jr_018_5466                          ; $5403: $30 $61
 
     ld   e, $20                                   ; $5405: $1E $20
-    ld   a, [wAButtonSlot]                        ; $5407: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $5407: $FA $00 $DB
     cp   $03                                      ; $540A: $FE $03
     jr   z, jr_018_5417                           ; $540C: $28 $09
 
     ld   e, $10                                   ; $540E: $1E $10
-    ld   a, [wBButtonSlot]                        ; $5410: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $5410: $FA $01 $DB
     cp   $03                                      ; $5413: $FE $03
     jr   nz, jr_018_5466                          ; $5415: $20 $4F
 

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -73,7 +73,7 @@ LiftableStatueState0Handler::
     and  a                                        ; $408D: $A7
     jp   nz, label_019_411C                       ; $408E: $C2 $1C $41
 
-    ld   a, [wAButtonSlot]                        ; $4091: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $4091: $FA $00 $DB
     cp   $03                                      ; $4094: $FE $03
     jr   nz, jr_019_40A0                          ; $4096: $20 $08
 
@@ -84,7 +84,7 @@ LiftableStatueState0Handler::
     jr   label_019_411C                           ; $409E: $18 $7C
 
 jr_019_40A0:
-    ld   a, [wBButtonSlot]                        ; $40A0: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $40A0: $FA $01 $DB
     cp   $03                                      ; $40A3: $FE $03
     jr   nz, label_019_411C                       ; $40A5: $20 $75
 
@@ -887,7 +887,7 @@ GoriyaState1Handler::
     and  a                                        ; $4699: $A7
     jr   nz, jr_019_46DB                          ; $469A: $20 $3F
 
-    ld   a, [wAButtonSlot]                        ; $469C: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $469C: $FA $00 $DB
     and  a                                        ; $469F: $A7
     jr   z, jr_019_46DB                           ; $46A0: $28 $39
 
@@ -915,7 +915,7 @@ jr_019_46A2:
 
     ld   [$DB7D], a                               ; $46BE: $EA $7D $DB
     ld   a, $0D                                   ; $46C1: $3E $0D
-    ld   [wAButtonSlot], a                        ; $46C3: $EA $00 $DB
+    ld   [wBButtonSlot], a                        ; $46C3: $EA $00 $DB
     ld   hl, wEntitiesPrivateState1Table          ; $46C6: $21 $B0 $C2
     add  hl, bc                                   ; $46C9: $09
     ld   [hl], a                                  ; $46CA: $77
@@ -943,7 +943,7 @@ GoriyaState3Handler::
     and  a                                        ; $46F2: $A7
     jr   nz, jr_019_4725                          ; $46F3: $20 $30
 
-    ld   hl, wAButtonSlot                         ; $46F5: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $46F5: $21 $00 $DB
     ld   de, $00                                  ; $46F8: $11 $00 $00
 
 jr_019_46FB:
@@ -3593,7 +3593,7 @@ jr_019_5922:
     and  a                                        ; $5935: $A7
     ret  nz                                       ; $5936: $C0
 
-    ld   a, [wAButtonSlot]                        ; $5937: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $5937: $FA $00 $DB
     cp   $03                                      ; $593A: $FE $03
     jr   nz, jr_019_5945                          ; $593C: $20 $07
 
@@ -3604,7 +3604,7 @@ jr_019_5922:
     ret                                           ; $5944: $C9
 
 jr_019_5945:
-    ld   a, [wBButtonSlot]                        ; $5945: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $5945: $FA $01 $DB
     cp   $03                                      ; $5948: $FE $03
     ret  nz                                       ; $594A: $C0
 
@@ -3834,7 +3834,7 @@ jr_019_5A9F:
     and  a                                        ; $5AA9: $A7
     ret  nz                                       ; $5AAA: $C0
 
-    ld   a, [wAButtonSlot]                        ; $5AAB: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $5AAB: $FA $00 $DB
     cp   $03                                      ; $5AAE: $FE $03
     jr   nz, jr_019_5AB9                          ; $5AB0: $20 $07
 
@@ -3845,7 +3845,7 @@ jr_019_5A9F:
     ret                                           ; $5AB8: $C9
 
 jr_019_5AB9:
-    ld   a, [wBButtonSlot]                        ; $5AB9: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $5AB9: $FA $01 $DB
     cp   $03                                      ; $5ABC: $FE $03
     ret  nz                                       ; $5ABE: $C0
 

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1239,7 +1239,7 @@ EntityStunnedHandler::
     call func_003_60B3                            ; $4E10: $CD $B3 $60
     call ClearEntitySpeed                         ; $4E13: $CD $7F $3D
     call func_003_6E2B                            ; $4E16: $CD $2B $6E
-    ld   a, [wAButtonSlot]                        ; $4E19: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $4E19: $FA $00 $DB
     cp   INVENTORY_POWER_BRACELET                 ; $4E1C: $FE $03
     jr   nz, jr_003_4E28                          ; $4E1E: $20 $08
 
@@ -1250,7 +1250,7 @@ EntityStunnedHandler::
     jr   jr_003_4E72                              ; $4E26: $18 $4A
 
 jr_003_4E28:
-    ld   a, [wBButtonSlot]                        ; $4E28: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $4E28: $FA $01 $DB
     cp   INVENTORY_POWER_BRACELET                 ; $4E2B: $FE $03
     jr   nz, jr_003_4E72                          ; $4E2D: $20 $43
 
@@ -1767,7 +1767,7 @@ jr_003_50EF:
     jr   func_003_512A                              ; $5123: $18 $05
 
 jr_003_5125:
-    ld   hl, wAButtonSlot                         ; $5125: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $5125: $21 $00 $DB
     add  hl, de                                   ; $5128: $19
     inc  [hl]                                     ; $5129: $34
 
@@ -4682,7 +4682,7 @@ jr_003_6468:
     ld   d, $04                                   ; $6470: $16 $04
 
 func_003_6472::
-    ld   hl, wAButtonSlot                         ; $6472: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $6472: $21 $00 $DB
     ld   e, $0C                                   ; $6475: $1E $0C
 
 jr_003_6477:
@@ -4693,7 +4693,7 @@ jr_003_6477:
     dec  e                                        ; $647B: $1D
     jr   nz, jr_003_6477                          ; $647C: $20 $F9
 
-    ld   hl, wAButtonSlot                         ; $647E: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $647E: $21 $00 $DB
 
 jr_003_6481:
     ld   a, [hl]                                  ; $6481: $7E

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1240,22 +1240,22 @@ EntityStunnedHandler::
     call ClearEntitySpeed                         ; $4E13: $CD $7F $3D
     call func_003_6E2B                            ; $4E16: $CD $2B $6E
     ld   a, [wAButtonSlot]                        ; $4E19: $FA $00 $DB
-    cp   $03                                      ; $4E1C: $FE $03
+    cp   INVENTORY_POWER_BRACELET                 ; $4E1C: $FE $03
     jr   nz, jr_003_4E28                          ; $4E1E: $20 $08
 
     ldh  a, [hJoypadState]                        ; $4E20: $F0 $CC
-    and  $20                                      ; $4E22: $E6 $20
+    and  J_B                                      ; $4E22: $E6 $20
     jr   nz, func_003_4E35                        ; $4E24: $20 $0F
 
     jr   jr_003_4E72                              ; $4E26: $18 $4A
 
 jr_003_4E28:
     ld   a, [wBButtonSlot]                        ; $4E28: $FA $01 $DB
-    cp   $03                                      ; $4E2B: $FE $03
+    cp   INVENTORY_POWER_BRACELET                 ; $4E2B: $FE $03
     jr   nz, jr_003_4E72                          ; $4E2D: $20 $43
 
     ldh  a, [hJoypadState]                        ; $4E2F: $F0 $CC
-    and  $10                                      ; $4E31: $E6 $10
+    and  J_A                                      ; $4E31: $E6 $10
     jr   z, jr_003_4E72                           ; $4E33: $28 $3D
 
 func_003_4E35::

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1401,10 +1401,10 @@ EntityInitSecretSeashell::
     add  hl, bc                                   ; $4EFE: $09
     ld   [hl], $02                                ; $4EFF: $36 $02
     ldh  a, [hMapRoom]                            ; $4F01: $F0 $F6
-    cp   $A4                                      ; $4F03: $FE $A4
+    cp   $A4                                      ; Overworld room A4 (1 east of Mabe's big bush field)
     jr   z, jr_003_4F0B                           ; $4F05: $28 $04
 
-    cp   $D2                                      ; $4F07: $FE $D2
+    cp   $D2                                      ; overworld room D2 (1 west of Tail Cave)
     jr   nz, jr_003_4F0F                          ; $4F09: $20 $04
 
 jr_003_4F0B:
@@ -1437,7 +1437,7 @@ jr_003_4F24:
 
 EntityInitKeyDropPoint::
     ldh  a, [hMapRoom]                            ; $4F2D: $F0 $F6
-    cp   $F8                                      ; $4F2F: $FE $F8
+    cp   $F8                                      ; In the Yarna Desert quicksand pit
     jr   nz, jr_003_4F44                          ; $4F31: $20 $11
 
     ldh  a, [hRoomStatus]                         ; $4F33: $F0 $F8
@@ -1786,7 +1786,7 @@ func_003_5134::
     ldh  a, [hMapRoom]                            ; $513B: $F0 $F6
     ld   e, a                                     ; $513D: $5F
     ldh  a, [hMapId]                              ; $513E: $F0 $F7
-    cp   $FF                                      ; $5140: $FE $FF
+    cp   MAP_COLOR_DUNGEON                        ; $5140: $FE $FF
     jr   nz, jr_003_514B                          ; $5142: $20 $07
 
     ld   d, $00                                   ; $5144: $16 $00
@@ -1794,10 +1794,10 @@ func_003_5134::
     jr   jr_003_5154                              ; $5149: $18 $09
 
 jr_003_514B:
-    cp   $1A                                      ; $514B: $FE $1A
+    cp   $1A                                      ; @TODO MAP_UNKNOWN_1A (?)
     jr   nc, jr_003_5154                          ; $514D: $30 $05
 
-    cp   $06                                      ; $514F: $FE $06
+    cp   $06                                      ; @tODO MAP_EAGLES_TOWER (?)
     jr   c, jr_003_5154                           ; $5151: $38 $01
 
     inc  d                                        ; $5153: $14
@@ -1874,7 +1874,7 @@ jr_003_51B3:
     ld   de, Data_003_515A                        ; $51B9: $11 $5A $51
     ld   b, $0D                                   ; $51BC: $06 $0D
     ldh  a, [hMapRoom]                            ; $51BE: $F0 $F6
-    cp   $C7                                      ; $51C0: $FE $C7
+    cp   $C7                                      ; @TODO Richard's Villa?
     jr   nz, func_003_51C9                        ; $51C2: $20 $05
 
     ld   de, Data_003_5156                        ; $51C4: $11 $56 $51
@@ -2306,7 +2306,7 @@ Data_003_55C7::
 ; Entities random drop tables
 ; Spawn a dropped item when an enemy is destroyed.
 ; The item can be:
-;  - The sword eaten by a Like-Like
+;  - The shield eaten by a Like-Like
 ;  - A specific dropped item defined by the entity
 ;  - A power-up (fragment of power or guardian acorn)
 ;  - A random object set by the drop table
@@ -2324,7 +2324,7 @@ SpawnEnemyDrop::
     and  a                                        ; $55DA: $A7
     jr   z, .likeLikeEnd                          ; $55DB: $28 $05
 
-    ld   a, ENTITY_SWORD                          ; $55DD: $3E $31
+    ld   a, ENTITY_SWORD                          ; @TODO Pretty sure likelikes only eat shields and this entity is both
     jp   .dropEntity                              ; $55DF: $C3 $70 $56
 .likeLikeEnd
 
@@ -2366,17 +2366,17 @@ SpawnEnemyDrop::
     and  a                                        ; $561A: $A7
     ret  z                                        ; $561B: $C8
 
-    ld   e, a                                     ; $561C: $5F
-    ld   d, $1E                                   ; $561D: $16 $1E
-    ld   a, [wMaxHealth]                          ; $561F: $FA $5B $DB
-    cp   $07                                      ; $5622: $FE $07
-    jr   c, .jr_003_562E                          ; $5624: $38 $08
+    ld   e, a                                     ; How many enemies to kill before a Piece of Power drops?
+    ld   d, $1E                                   ; Max HP 0~6: 30
+    ld   a, [wMaxHealth]                          ; 
+    cp   $07                                      ; If max HP <= 6, skip
+    jr   c, .jr_003_562E                          ; 
 
-    ld   d, $23                                   ; $5626: $16 $23
-    cp   $0B                                      ; $5628: $FE $0B
-    jr   c, .jr_003_562E                          ; $562A: $38 $02
+    ld   d, $23                                   ; Max HP 7~10: 35
+    cp   $0B                                      ; 
+    jr   c, .jr_003_562E                          ; If max HP <= 11, skip
 
-    ld   d, $28                                   ; $562C: $16 $28
+    ld   d, $28                                   ; Max HP 11~14: 40
 
 .jr_003_562E
     ld   hl, wPieceOfPowerKillCount               ; $562E: $21 $15 $D4
@@ -2482,10 +2482,10 @@ SpawnEnemyDrop::
     jr   nz, .slimeKeyEnd                         ; $56BA: $20 $15
 
     ldh  a, [hMapRoom]                            ; $56BC: $F0 $F6
-    cp   $58                                      ; $56BE: $FE $58
+    cp   $58                                      ; Overworld Kanalet Castle crow room
     jr   z, .moveKeyTowardsLink                   ; $56C0: $28 $04
 
-    cp   $5A                                      ; $56C2: $FE $5A
+    cp   $5A                                      ; Overwrold Kanalet Castle five-pits room
     jr   nz, .slimeKeyEnd                         ; $56C4: $20 $0B
 
 .moveKeyTowardsLink
@@ -2695,7 +2695,7 @@ Data_003_5823::
 
 MoblinEntityHandler::
     ldh  a, [hMapId]                              ; $5827: $F0 $F7
-    cp   $15                                      ; $5829: $FE $15
+    cp   MAP_BOWWOW_HIDEOUT                       ; $5829: $FE $15
     jr   nz, jr_003_5835                          ; $582B: $20 $08
 
     ld   a, [wIsBowWowFollowingLink]              ; $582D: $FA $56 $DB
@@ -2980,6 +2980,7 @@ EntityInitBrokenHeartContainer::
     ret                                           ; $59D7: $C9
 
 HeartContainerTilesTable::
+    ;   Tile Attr Tile Attr
     db   $AA, $14, $AA, $34
 
 ; Loop run every frame heart container is on screen
@@ -3419,7 +3420,7 @@ KeyDropPointEntityHandler::
 
 jr_003_5C99:
     ldh  a, [hMapRoom]                            ; $5C99: $F0 $F6
-    cp   $80                                      ; $5C9B: $FE $80
+    cp   $80                                      ; @TODO (?) L5 Master Stalfos final room
     jp   z, label_003_5C49                        ; $5C9D: $CA $49 $5C
 
     ld   de, Data_003_5C78                        ; $5CA0: $11 $78 $5C
@@ -3478,7 +3479,7 @@ func_003_5CEA::
     jr   nz, jr_003_5D34                          ; $5CEE: $20 $44
 
     ldh  a, [hMapRoom]                            ; $5CF0: $F0 $F6
-    cp   $CE                                      ; $5CF2: $FE $CE
+    cp   $CE                                      ; Overworld Yarna Desert Lanmola fight
     jr   nz, jr_003_5D34                          ; $5CF4: $20 $3E
 
     ldh  a, [hActiveEntityPosY]                   ; $5CF6: $F0 $EF
@@ -3774,7 +3775,7 @@ func_003_5ED5::
     dec  [hl]                                     ; $5EDF: $35
     call IncrementEntityState                     ; $5EE0: $CD $12 $3B
     ldh  a, [hMapId]                              ; $5EE3: $F0 $F7
-    add  $00                                      ; $5EE5: $C6 $00
+    add  $00                                      ; $5EE5: $C6 $00 (???)
     call OpenDialogInTable1                       ; $5EE7: $CD $73 $23
     ldh  a, [hMapId]                              ; $5EEA: $F0 $F7
     ld   e, a                                     ; $5EEC: $5F
@@ -3942,7 +3943,7 @@ DroppableSeashellEntityHandler::
     jp   nz, UnloadEntityAndReturn                ; $5FDF: $C2 $8D $3F
 
     ldh  a, [hMapRoom]                            ; $5FE2: $F0 $F6
-    cp   $E3                                      ; $5FE4: $FE $E3
+    cp   $E3                                      ; House by the Bay
     jr   nz, jr_003_5FEF                          ; $5FE6: $20 $07
 
     ldh  a, [hRoomStatus]                         ; $5FE8: $F0 $F8
@@ -3978,7 +3979,7 @@ HidingSlimeKeyEntityHandler::
     jr   nz, jr_003_6029                          ; $601C: $20 $0B
 
     ldh  a, [hMapRoom]                            ; $601E: $F0 $F6
-    cp   $C6                                      ; $6020: $FE $C6
+    cp   $C6                                      ; Overworld Pothole Field - Slime Key
     jr   nz, jr_003_6029                          ; $6022: $20 $05
 
     ld   a, $05                                   ; $6024: $3E $05
@@ -4251,8 +4252,8 @@ func_003_61DE::
     jr   nz, jr_003_6243                          ; $61F1: $20 $50
 
     ldh  a, [hActiveEntityType]                   ; $61F3: $F0 $EB
-    cp   $3D                                      ; $61F5: $FE $3D
-    jr   z, jr_003_6200                           ; $61F7: $28 $07
+    cp   ENTITY_DROPPABLE_SECRET_SEASHELL         ; $61F5: $FE $3D
+    jr   z, jr_003_6200                           ; $61F7: $28 $07 (???: If a seashell, jump?)
 
     ld   a, [wIsIndoor]                           ; $61F9: $FA $A5 $DB
     and  a                                        ; $61FC: $A7
@@ -4261,29 +4262,29 @@ func_003_61DE::
 jr_003_6200:
     call func_003_7E0E                            ; $6200: $CD $0E $7E
     ldh  a, [hActiveEntityType]                   ; $6203: $F0 $EB
-    cp   $2D                                      ; $6205: $FE $2D
+    cp   ENTITY_DROPPABLE_HEART                   ; $6205: $FE $2D
     jr   z, jr_003_6227                           ; $6207: $28 $1E
 
-    cp   $3D                                      ; $6209: $FE $3D
+    cp   ENTITY_DROPPABLE_SECRET_SEASHELL         ; $6209: $FE $3D
     jr   nz, jr_003_622F                          ; $620B: $20 $22
 
     ldh  a, [hMapRoom]                            ; $620D: $F0 $F6
-    cp   $DA                                      ; $620F: $FE $DA
+    cp   $DA                                      ; Overworld room one north of fisherman under bridge
     jr   z, jr_003_622F                           ; $6211: $28 $1C
 
-    cp   $A5                                      ; $6213: $FE $A5
+    cp   $A5                                      ; Overworld room two east of Mabe bush field
     jr   z, jr_003_622F                           ; $6215: $28 $18
 
-    cp   $74                                      ; $6217: $FE $74
+    cp   $74                                      ; Overworld room one south of ghost's gravestone (w/zombies)
     jr   z, jr_003_622F                           ; $6219: $28 $14
 
-    cp   $3A                                      ; $621B: $FE $3A
+    cp   $3A                                      ; Overworld room with... no seashell?
     jr   z, jr_003_622F                           ; $621D: $28 $10
 
-    cp   $A8                                      ; $621F: $FE $A8
+    cp   $A8                                      ; Overworld room northeast-ish of Pothole Field
     jr   z, jr_003_622F                           ; $6221: $28 $0C
 
-    cp   $B2                                      ; $6223: $FE $B2
+    cp   $B2                                      ; Overworld room - Mabe village telephone booth (...no seashell???)
     jr   z, jr_003_622F                           ; $6225: $28 $08
 
 jr_003_6227:
@@ -4517,6 +4518,8 @@ label_003_636D:
     ld   hl, wSeashellsCount                      ; $6370: $21 $0F $DB
 
 func_003_6373::
+    ; POI: Adds one to seashell / golden leaves count, preventing overflow if at 99.
+    ; But you can never get anywhere near that! Golden Leaves even stop at 6 (slime key)!
     ld   a, [hl]                                  ; $6373: $7E
     cp   $99                                      ; $6374: $FE $99
     jr   z, jr_003_637C                           ; $6376: $28 $04
@@ -4675,6 +4678,7 @@ PickSword::
     ret                                           ; $6467: $C9
 
 jr_003_6468:
+    ; POI: If sword level > 0, it's a shield instead. Used for Like-Likes?
     ld   hl, wEntitiesPrivateState1Table          ; $6468: $21 $B0 $C2
     add  hl, bc                                   ; $646B: $09
     ld   a, [hl]                                  ; $646C: $7E
@@ -4715,11 +4719,11 @@ jr_003_648E:
 
 PickDroppableKey::
     ldh  a, [hMapRoom]                            ; $648F: $F0 $F6
-    cp   $80                                      ; $6491: $FE $80
+    cp   $80                                      ; L5 Master Stalfos's final fight
     jr   z, jr_003_64A5                           ; $6493: $28 $10
 
     ldh  a, [hMapRoom]                            ; $6495: $F0 $F6
-    cp   $7C                                      ; $6497: $FE $7C
+    cp   $7C                                      ; L4 Side-view room where the key drops
     jr   nz, jr_003_64A0                          ; $6499: $20 $05
 
     ld   hl, $D969                                ; $649B: $21 $69 $D9
@@ -5254,7 +5258,7 @@ jr_003_6878:
     ld   e, a                                     ; $687D: $5F
     ld   d, $00                                   ; $687E: $16 $00
     ldh  a, [hMapId]                              ; $6880: $F0 $F7
-    cp   $FF                                      ; $6882: $FE $FF
+    cp   MAP_COLOR_DUNGEON                        ; $6882: $FE $FF
     jr   nz, jr_003_688B                          ; $6884: $20 $05
 
     ld   hl, wColorDungeonRoomStatus              ; $6886: $21 $E0 $DD

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -3316,7 +3316,7 @@ func_036_54B0::
     and  a                                        ; $54B8: $A7
     ret  z                                        ; $54B9: $C8
 
-    ld   a, [wAButtonSlot]                        ; $54BA: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $54BA: $FA $00 $DB
     cp   $0C                                      ; $54BD: $FE $0C
     jr   nz, jr_036_54C8                          ; $54BF: $20 $07
 
@@ -3327,7 +3327,7 @@ func_036_54B0::
     jr   jr_036_54D3                              ; $54C6: $18 $0B
 
 jr_036_54C8:
-    ld   a, [wBButtonSlot]                        ; $54C8: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $54C8: $FA $01 $DB
     cp   $0C                                      ; $54CB: $FE $0C
     ret  nz                                       ; $54CD: $C0
 
@@ -8107,7 +8107,7 @@ label_036_71AD:
     and  $20                                      ; $71B0: $E6 $20
     jp   nz, label_036_7288                       ; $71B2: $C2 $88 $72
 
-    ld   hl, wAButtonSlot                         ; $71B5: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $71B5: $21 $00 $DB
     ld   e, $0C                                   ; $71B8: $1E $0C
 
 jr_036_71BA:

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -6728,7 +6728,7 @@ jr_004_7839:
 
 jr_004_7845:
     push bc                                       ; $7845: $C5
-    ld   hl, wAButtonSlot                         ; $7846: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $7846: $21 $00 $DB
     ld   c, $0B                                   ; $7849: $0E $0B
 
 jr_004_784B:
@@ -6749,7 +6749,7 @@ jr_004_7859:
     cp   $FF                                      ; $785B: $FE $FF
     jr   nz, jr_004_784B                          ; $785D: $20 $EC
 
-    ld   hl, wAButtonSlot                         ; $785F: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $785F: $21 $00 $DB
     ld   c, $0B                                   ; $7862: $0E $0B
 
 jr_004_7864:
@@ -7007,7 +7007,7 @@ jr_004_79BB:
     cp   $04                                      ; $79BB: $FE $04
     jr   nz, jr_004_79D9                          ; $79BD: $20 $1A
 
-    ld   hl, wAButtonSlot                         ; $79BF: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $79BF: $21 $00 $DB
     ld   d, $0C                                   ; $79C2: $16 $0C
 
 jr_004_79C4:
@@ -7032,7 +7032,7 @@ jr_004_79D9:
     cp   $06                                      ; $79D9: $FE $06
     jr   nz, jr_004_79F7                          ; $79DB: $20 $1A
 
-    ld   hl, wAButtonSlot                         ; $79DD: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $79DD: $21 $00 $DB
     ld   d, $0C                                   ; $79E0: $16 $0C
 
 jr_004_79E2:
@@ -7057,7 +7057,7 @@ jr_004_79F7:
     cp   $03                                      ; $79F7: $FE $03
     jr   nz, jr_004_7A0C                          ; $79F9: $20 $11
 
-    ld   hl, wAButtonSlot                         ; $79FB: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $79FB: $21 $00 $DB
     ld   d, $0C                                   ; $79FE: $16 $0C
 
 jr_004_7A00:

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -1575,7 +1575,7 @@ BossDestructionHandler::
 
 ; Load heart container value to load when boss is killed
 DropHeartContainer::
-    ld   a, $36                                   ; $5751: $3E $36
+    ld   a, ENTITY_HEART_CONTAINER                ; $5751: $3E $36
     call SpawnNewEntity_trampoline                ; $5753: $CD $86 $3B
     ldh  a, [hScratch0]                           ; $5756: $F0 $D7
     cp   $88                                      ; $5758: $FE $88

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -1185,7 +1185,7 @@ Data_004_5501::
 FacadeState2Handler:
     ld   de, Data_004_5501                        ; $5509: $11 $01 $55
     ldh  a, [hMapId]                              ; $550C: $F0 $F7
-    cp   $06                                      ; $550E: $FE $06
+    cp   MAP_EAGLES_TOWER                         ; @TODO ??? Is this right?
     jr   z, jr_004_551C                           ; $5510: $28 $0A
 
     ld   de, Data_004_54F1                        ; $5512: $11 $F1 $54
@@ -2953,7 +2953,7 @@ func_004_6154::
     jr   nz, jr_004_616C                          ; $6158: $20 $12
 
     ldh  a, [hJoypadState]                        ; $615A: $F0 $CC
-    and  $30                                      ; $615C: $E6 $30
+    and  J_A | J_B                                ; $615C: $E6 $30
     jr   z, jr_004_616C                           ; $615E: $28 $0C
 
     call IncrementEntityState                     ; $6160: $CD $12 $3B

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -199,7 +199,7 @@ jr_007_4128:
     and  a                                        ; $413E: $A7
     ret  nz                                       ; $413F: $C0
 
-    ld   a, [wAButtonSlot]                        ; $4140: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $4140: $FA $00 $DB
     cp   $03                                      ; $4143: $FE $03
     jr   nz, jr_007_414E                          ; $4145: $20 $07
 
@@ -210,7 +210,7 @@ jr_007_4128:
     ret                                           ; $414D: $C9
 
 jr_007_414E:
-    ld   a, [wBButtonSlot]                        ; $414E: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $414E: $FA $01 $DB
     cp   $03                                      ; $4151: $FE $03
     ret  nz                                       ; $4153: $C0
 
@@ -3496,7 +3496,7 @@ label_007_5721:
     cp   $40                                      ; $5737: $FE $40
     jr   nc, jr_007_5777                          ; $5739: $30 $3C
 
-    ld   a, [wAButtonSlot]                        ; $573B: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $573B: $FA $00 $DB
     cp   $01                                      ; $573E: $FE $01
     jr   nz, jr_007_574A                          ; $5740: $20 $08
 
@@ -3507,7 +3507,7 @@ label_007_5721:
     jr   jr_007_5777                              ; $5748: $18 $2D
 
 jr_007_574A:
-    ld   a, [wBButtonSlot]                        ; $574A: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $574A: $FA $01 $DB
     cp   $01                                      ; $574D: $FE $01
     jr   nz, jr_007_5777                          ; $574F: $20 $26
 
@@ -5001,7 +5001,7 @@ jr_007_60DD:
     and  a                                        ; $60E5: $A7
     jr   nz, jr_007_6133                          ; $60E6: $20 $4B
 
-    ld   a, [wAButtonSlot]                        ; $60E8: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $60E8: $FA $00 $DB
     cp   $03                                      ; $60EB: $FE $03
     jr   nz, jr_007_60F7                          ; $60ED: $20 $08
 
@@ -5012,7 +5012,7 @@ jr_007_60DD:
     jr   jr_007_6133                              ; $60F5: $18 $3C
 
 jr_007_60F7:
-    ld   a, [wBButtonSlot]                        ; $60F7: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $60F7: $FA $01 $DB
     cp   $03                                      ; $60FA: $FE $03
     jr   nz, jr_007_6133                          ; $60FC: $20 $35
 
@@ -8511,7 +8511,7 @@ label_007_7733:
     and  a                                        ; $773B: $A7
     jr   nz, jr_007_7783                          ; $773C: $20 $45
 
-    ld   a, [wAButtonSlot]                        ; $773E: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $773E: $FA $00 $DB
     cp   $03                                      ; $7741: $FE $03
     jr   nz, jr_007_774D                          ; $7743: $20 $08
 
@@ -8522,7 +8522,7 @@ label_007_7733:
     jr   jr_007_7783                              ; $774B: $18 $36
 
 jr_007_774D:
-    ld   a, [wBButtonSlot]                        ; $774D: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $774D: $FA $01 $DB
     cp   $03                                      ; $7750: $FE $03
     jr   nz, jr_007_7783                          ; $7752: $20 $2F
 

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -1791,7 +1791,7 @@ jr_007_4C32:
 
     ld   e, $CE                                   ; $4C3A: $1E $CE
     ld   a, [wTradeSequenceItem]                  ; $4C3C: $FA $0E $DB
-    cp   $07                                      ; $4C3F: $FE $07
+    cp   TRADING_ITEM_PINEAPPLE                   ; $4C3F: $FE $07
     jr   nz, jr_007_4C45                          ; $4C41: $20 $02
 
 func_007_4C43::
@@ -1816,7 +1816,7 @@ func_007_4C49::
     jp   func_007_4C83                            ; $4C5B: $C3 $83 $4C
 
 jr_007_4C5E:
-    ld   a, $07                                   ; $4C5E: $3E $07
+    ld   a, TRADING_ITEM_PINEAPPLE                ; $4C5E: $3E $07
     ld   [wTradeSequenceItem], a                  ; $4C60: $EA $0E $DB
     ld   a, $0D                                   ; $4C63: $3E $0D
     ldh  [hFFA5], a                               ; $4C65: $E0 $A5

--- a/src/code/entities/bomb.asm
+++ b/src/code/entities/bomb.asm
@@ -41,7 +41,7 @@ jr_003_66BF:
     or   [hl]                                     ; $66D8: $B6
     jr   nz, jr_003_66FA                          ; $66D9: $20 $1F
 
-    ld   a, [wAButtonSlot]                        ; $66DB: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $66DB: $FA $00 $DB
     cp   $02                                      ; $66DE: $FE $02
     jr   nz, jr_003_66EA                          ; $66E0: $20 $08
 
@@ -52,7 +52,7 @@ jr_003_66BF:
     jr   jr_003_66FA                              ; $66E8: $18 $10
 
 jr_003_66EA:
-    ld   a, [wBButtonSlot]                        ; $66EA: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $66EA: $FA $01 $DB
     cp   $02                                      ; $66ED: $FE $02
     jr   nz, jr_003_66FA                          ; $66EF: $20 $09
 

--- a/src/code/entities/cucoo.asm
+++ b/src/code/entities/cucoo.asm
@@ -117,7 +117,7 @@ jr_005_45BF:
     and  a                                        ; $45CD: $A7
     jr   nz, jr_005_4611                          ; $45CE: $20 $41
 
-    ld   a, [wAButtonSlot]                        ; $45D0: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $45D0: $FA $00 $DB
     cp   $03                                      ; $45D3: $FE $03
     jr   nz, jr_005_45DF                          ; $45D5: $20 $08
 
@@ -128,7 +128,7 @@ jr_005_45BF:
     jr   jr_005_4611                              ; $45DD: $18 $32
 
 jr_005_45DF:
-    ld   a, [wBButtonSlot]                        ; $45DF: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $45DF: $FA $01 $DB
     cp   $03                                      ; $45E2: $FE $03
     jr   nz, jr_005_4611                          ; $45E4: $20 $2B
 

--- a/src/code/entities/genie.asm
+++ b/src/code/entities/genie.asm
@@ -291,7 +291,7 @@ jr_004_41AC:
     jr   nc, jr_004_4210                          ; $41CB: $30 $43
 
     call ResetPegasusBoots                                ; $41CD: $CD $B6 $0C
-    ld   a, [wAButtonSlot]                        ; $41D0: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $41D0: $FA $00 $DB
     cp   $03                                      ; $41D3: $FE $03
     jr   nz, jr_004_41DF                          ; $41D5: $20 $08
 
@@ -302,7 +302,7 @@ jr_004_41AC:
     jr   jr_004_4210                              ; $41DD: $18 $31
 
 jr_004_41DF:
-    ld   a, [wBButtonSlot]                        ; $41DF: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $41DF: $FA $01 $DB
     cp   $03                                      ; $41E2: $FE $03
     jr   nz, jr_004_4210                          ; $41E4: $20 $2A
 

--- a/src/code/entities/like_like.asm
+++ b/src/code/entities/like_like.asm
@@ -61,7 +61,7 @@ jr_006_7E27:
     and  a                                        ; $7E30: $A7
     jr   nz, jr_006_7E55                          ; $7E31: $20 $22
 
-    ld   hl, wAButtonSlot                         ; $7E33: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $7E33: $21 $00 $DB
     ld   e, b                                     ; $7E36: $58
 
 jr_006_7E37:

--- a/src/code/entities/marin.asm
+++ b/src/code/entities/marin.asm
@@ -214,7 +214,7 @@ jr_005_4F90:
 
 jr_005_4F95:
     ld   e, $0B                                   ; $4F95: $1E $0B
-    ld   hl, wAButtonSlot                         ; $4F97: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $4F97: $21 $00 $DB
 
 jr_005_4F9A:
     ld   a, [hl+]                                 ; $4F9A: $2A
@@ -259,7 +259,7 @@ jr_005_4FAC:
 jr_005_4FD0:
     push bc                                       ; $4FD0: $C5
     ld   c, $0B                                   ; $4FD1: $0E $0B
-    ld   hl, wAButtonSlot                         ; $4FD3: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $4FD3: $21 $00 $DB
 
 jr_005_4FD6:
     ld   a, [hl+]                                 ; $4FD6: $2A
@@ -781,7 +781,7 @@ func_005_5312::
 
 ; Add item to inventory slot (used for assigning the shield)
 AssignItemToSlot:
-    ld   hl, wAButtonSlot                         ; $5321: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $5321: $21 $00 $DB
     ld   e, $0C                                   ; $5324: $1E $0C
 
     ; Search if a matching item exists in inventory
@@ -793,7 +793,7 @@ AssignItemToSlot:
     dec  e                                        ; $532A: $1D
     jr   nz, .searchLoop                          ; $532B: $20 $F9
 
-    ld   hl, wAButtonSlot                         ; $532D: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $532D: $21 $00 $DB
 
     ; Check for first empty slot, add item to it and return
 .assignLoop

--- a/src/code/entities/marin.asm
+++ b/src/code/entities/marin.asm
@@ -45,7 +45,7 @@ jr_005_4E87:
     jr   nz, jr_005_4E96                          ; $4E8C: $20 $08
 
     ld   a, [wTradeSequenceItem]                  ; $4E8E: $FA $0E $DB
-    cp   $07                                      ; $4E91: $FE $07
+    cp   TRADING_ITEM_PINEAPPLE                   ; $4E91: $FE $07
     jp   nc, func_005_7B4B                        ; $4E93: $D2 $4B $7B
 
 jr_005_4E96:
@@ -602,7 +602,7 @@ Data_005_51CA::
 
 func_005_51CE::
     ld   a, [wTradeSequenceItem]                  ; $51CE: $FA $0E $DB
-    cp   $07                                      ; $51D1: $FE $07
+    cp   TRADING_ITEM_PINEAPPLE                   ; $51D1: $FE $07
     jr   c, jr_005_51FB                           ; $51D3: $38 $26
 
     ld   a, [$D8FD]                               ; $51D5: $FA $FD $D8

--- a/src/code/entities/smasher.asm
+++ b/src/code/entities/smasher.asm
@@ -453,7 +453,7 @@ jr_006_4806:
     and  a                                        ; $480E: $A7
     jr   nz, jr_006_4852                          ; $480F: $20 $41
 
-    ld   a, [wAButtonSlot]                        ; $4811: $FA $00 $DB
+    ld   a, [wBButtonSlot]                        ; $4811: $FA $00 $DB
     cp   $03                                      ; $4814: $FE $03
     jr   nz, jr_006_4820                          ; $4816: $20 $08
 
@@ -464,7 +464,7 @@ jr_006_4806:
     jr   jr_006_4852                              ; $481E: $18 $32
 
 jr_006_4820:
-    ld   a, [wBButtonSlot]                        ; $4820: $FA $01 $DB
+    ld   a, [wAButtonSlot]                        ; $4820: $FA $01 $DB
     cp   $03                                      ; $4823: $FE $03
     jr   nz, jr_006_4852                          ; $4825: $20 $2B
 

--- a/src/code/entities/witch.asm
+++ b/src/code/entities/witch.asm
@@ -89,7 +89,7 @@ func_005_4815::
     and  a                                        ; $4824: $A7
     ret  z                                        ; $4825: $C8
 
-    ld   hl, wAButtonSlot                         ; $4826: $21 $00 $DB
+    ld   hl, wBButtonSlot                         ; $4826: $21 $00 $DB
     ld   a, [hl]                                  ; $4829: $7E
     cp   $0C                                      ; $482A: $FE $0C
     jr   nz, jr_005_483C                          ; $482C: $20 $0E

--- a/src/code/entities/yip_yip.asm
+++ b/src/code/entities/yip_yip.asm
@@ -51,11 +51,11 @@ jr_006_5A1B:
     jr   nz, jr_006_5A33                          ; $5A24: $20 $0D
 
     ldh  a, [hMapRoom]                            ; $5A26: $F0 $F6
-    cp   $B2                                      ; $5A28: $FE $B2
+    cp   $B2                                      ; Inside the dog house
     jr   nz, jr_006_5A36                          ; $5A2A: $20 $0A
 
     ld   a, [wTradeSequenceItem]                  ; $5A2C: $FA $0E $DB
-    cp   $03                                      ; $5A2F: $FE $03
+    cp   TRADING_ITEM_DOG_FOOD                    ; $5A2F: $FE $03
     jr   c, jr_006_5A36                           ; $5A31: $38 $03
 
 jr_006_5A33:
@@ -63,7 +63,7 @@ jr_006_5A33:
 
 jr_006_5A36:
     ld   a, [wGameplayType]                       ; $5A36: $FA $95 $DB
-    cp   $01                                      ; $5A39: $FE $01
+    cp   GAMEPLAY_CREDITS                         ; $5A39: $FE $01
     jr   nz, jr_006_5A43                          ; $5A3B: $20 $06
 
     ldh  a, [hActiveEntitySpriteVariant]          ; $5A3D: $F0 $F1
@@ -102,12 +102,12 @@ jr_006_5A67:
 
     ld   e, $23                                   ; $5A72: $1E $23
     ldh  a, [hMapRoom]                            ; $5A74: $F0 $F6
-    cp   $B2                                      ; $5A76: $FE $B2
+    cp   $B2                                      ; Inside the dog house
     jr   nz, jr_006_5A91                          ; $5A78: $20 $17
 
     ld   e, $80                                   ; $5A7A: $1E $80
     ld   a, [wTradeSequenceItem]                  ; $5A7C: $FA $0E $DB
-    cp   $02                                      ; $5A7F: $FE $02
+    cp   TRADING_ITEM_RIBBON                      ; $5A7F: $FE $02
     jr   nz, jr_006_5A8A                          ; $5A81: $20 $07
 
     call IncrementEntityState                     ; $5A83: $CD $12 $3B
@@ -141,7 +141,7 @@ YipYipState2Handler::
     and  a                                        ; $5AAC: $A7
     jr   nz, jr_006_5AC3                          ; $5AAD: $20 $14
 
-    ld   a, $03                                   ; $5AAF: $3E $03
+    ld   a, TRADING_ITEM_DOG_FOOD                 ; $5AAF: $3E $03
     ld   [wTradeSequenceItem], a                  ; $5AB1: $EA $0E $DB
     ld   a, $0D                                   ; $5AB4: $3E $0D
     ldh  [hFFA5], a                               ; $5AB6: $E0 $A5

--- a/src/code/home/animated_tiles.asm
+++ b/src/code/home/animated_tiles.asm
@@ -559,10 +559,13 @@ label_1DF0::
     jp   CopyDataAndDrawLinkSprite
 
 label_1E01::
+    ; This has something to do with drawing the trading sequence item ...
+    ; changing TRADING_ITEM_RIBBON to 0 changes the order of shown trading items
+    ; @TODO Probably able to figure this out with a few minutes of time
     ld   a, [wTradeSequenceItem]
-    cp   $02
+    cp   TRADING_ITEM_RIBBON
     jp  c, CopyDataAndDrawLinkSprite.drawLinkSprite
-    sub  a, $02
+    sub  a, TRADING_ITEM_RIBBON
     ld   d, a
     ld   e, $00
     sra  d

--- a/src/code/macros.asm
+++ b/src/code/macros.asm
@@ -1,4 +1,7 @@
 
+; GBC palette entry
+; RGB r, g, b
+; values: 0 ~ 31
 RGB: macro
     db (\1) + (\2) << 5 + (\3) << 10
 endm

--- a/src/constants/entities.asm
+++ b/src/constants/entities.asm
@@ -66,7 +66,7 @@ ENTITY_DROPPABLE_HEART               equ $2D
 ENTITY_DROPPABLE_RUPEE               equ $2E
 ENTITY_DROPPABLE_FAIRY               equ $2F
 ENTITY_KEY_DROP_POINT                equ $30
-ENTITY_SWORD                         equ $31
+ENTITY_SWORD                         equ $31 ; Also the shield, sometimes.
 ENTITY_32                            equ $32 ; unknown
 ENTITY_PIECE_OF_POWER                equ $33
 ENTITY_GUARDIAN_ACORN                equ $34

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -1126,10 +1126,10 @@ wIndoorARoomStatus:: ; D900
 wIndoorBRoomStatus:: ; DA00
   ds $100
 
-wAButtonSlot:: ; DB00
+wBButtonSlot:: ; DB00
   ds 1
 
-wBButtonSlot:: ; DB01
+wAButtonSlot:: ; DB01
   ds 1
 
 wInventoryItem1:: ; DB02

--- a/src/constants/sfx.asm
+++ b/src/constants/sfx.asm
@@ -1,6 +1,8 @@
 ;
 ; Constants for audio effects
-;
+
+; @TODO Are these correct? Some of these don't seem to match
+; their actual in-game use (???)
 
 ; Values for hMusicTrack
 MUSIC_NONE                                      equ $00


### PR DESCRIPTION
* Fixes A and B button inventory slots being backwards
* Documents and formats a bunch of inventory subscreen stuff
  * Palettes and tiles for each item are now commented
  * Color-cycling instrument colors also documented
  * Some other related data has also been marked
* Some more numbers across various files have been replaced with the relevant constants
  * Especially relates to trading items and joypad checks
* Some wrongly-disassembled-as-code data fixed, also rebuilds a jump table

A bit of a mixture of random stuff, but that's how it goes sometimes.