### PR TITLE
README: add Vextrove to the list of contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Thanks to these people for contributing:
 * Marijn van der Werf - https://github.com/marijnvdwerf
 * samuel-flynn - https://github.com/samuel-flynn
 * Xkeeper - https://github.com/Xkeeper0 
+* Vextrove - https://github.com/Vextrove


### PR DESCRIPTION
Add @Vextrove to the list of contributors in the README file.