### PR TITLE
Few constants replaced, and 2 extra memory locations documented.

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -1419,13 +1419,13 @@ WorldDefaultHandler::
 
 .normalFlow
 
-    ; If $DBC7 > 0, decrement it
-    ld   hl, $DBC7
+    ; If wInvincibilityCounter > 0, decrement it
+    ld   hl, wInvincibilityCounter
     ld   a, [hl]
     and  a
-    jr   z, .DBC7End
+    jr   z, .wInvincibilityAtZero
     dec  [hl]
-.DBC7End
+.wInvincibilityAtZero
 
     ; Copy Link's position into Link's final position
     ldh  a, [hLinkPositionX]
@@ -1649,7 +1649,7 @@ InitGotItemSequence::
     ld   a, $10
     ld   [$C3CC], a
     xor  a
-    ld   [$DBC7], a
+    ld   [wInvincibilityCounter], a
     ldh  [$FF9C], a
     ld   [$DDD6], a
     ld   [$DDD7], a

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -18,7 +18,7 @@ label_40D6::
     ld   [wMapEntrancePositionY], a
     call LoadSavedFile
     ld   a, $80
-    ld   [$DBC7], a
+    ld   [wInvincibilityCounter], a
     ret
 
 jr_001_40F9::

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -2640,7 +2640,7 @@ jr_002_52B5:
 
 label_002_52B9:
     ld   a, $40                                   ; $52B9: $3E $40
-    ld   [$DBC7], a                               ; $52BB: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $52BB: $EA $C7 $DB
     ld   a, [wLinkMapEntryPositionX]              ; $52BE: $FA $B1 $DB
     ldh  [hLinkPositionX], a                      ; $52C1: $E0 $98
     ldh  [hLinkFinalPositionX], a                 ; $52C3: $E0 $9F
@@ -4824,7 +4824,7 @@ jr_002_63A3:
     add  $80                                      ; $63B5: $C6 $80
     ld   [wAddHealthBuffer], a                    ; $63B7: $EA $93 $DB
     ld   a, $A0                                   ; $63BA: $3E $A0
-    ld   [$DBC7], a                               ; $63BC: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $63BC: $EA $C7 $DB
     ld   a, [wRequests]                           ; $63BF: $FA $00 $D6
     ld   e, a                                     ; $63C2: $5F
     ld   d, $00                                   ; $63C3: $16 $00
@@ -5036,7 +5036,7 @@ func_002_6910::
     ld   a, WAVE_SFX_LINK_HURT                    ; $6921: $3E $03
     ldh  [hWaveSfx], a                            ; $6923: $E0 $F3
     ld   a, $80                                   ; $6925: $3E $80
-    ld   [$DBC7], a                               ; $6927: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $6927: $EA $C7 $DB
     ret                                           ; $692A: $C9
 
 jr_002_692B:
@@ -5380,7 +5380,7 @@ jr_002_6AFC:
     and  a                                        ; $6B11: $A7
     jr   nz, jr_002_6B26                          ; $6B12: $20 $12
 
-    ld   a, [$DBC7]                               ; $6B14: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $6B14: $FA $C7 $DB
     and  a                                        ; $6B17: $A7
     jr   nz, jr_002_6B1F                          ; $6B18: $20 $05
 
@@ -7064,7 +7064,7 @@ jr_002_7472:
     ld   a, $05                                   ; $747E: $3E $05
     ld   [wLinkMotionState], a                    ; $7480: $EA $1C $C1
     call ClearLinkPositionIncrement               ; $7483: $CD $8E $17
-    ld   [$DBC7], a                               ; $7486: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $7486: $EA $C7 $DB
     ld   [$C198], a                               ; $7489: $EA $98 $C1
     ldh  [hLinkPositionZ], a                      ; $748C: $E0 $A2
     ldh  [$FFA3], a                               ; $748E: $E0 $A3
@@ -7312,7 +7312,7 @@ jr_002_75E7:
     jr   nz, jr_002_7635                          ; $75F3: $20 $40
 
 func_002_75F5::
-    ld   a, [$DBC7]                               ; $75F5: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $75F5: $FA $C7 $DB
     and  a                                        ; $75F8: $A7
     jr   nz, jr_002_7634                          ; $75F9: $20 $39
 
@@ -7341,7 +7341,7 @@ jr_002_761E:
     ld   a, $10                                   ; $761E: $3E $10
     ld   [$C13E], a                               ; $7620: $EA $3E $C1
     ld   a, $30                                   ; $7623: $3E $30
-    ld   [$DBC7], a                               ; $7625: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $7625: $EA $C7 $DB
     ld   a, [wSubtractHealthBuffer]               ; $7628: $FA $94 $DB
     add  $04                                      ; $762B: $C6 $04
     ld   [wSubtractHealthBuffer], a               ; $762D: $EA $94 $DB

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -1030,7 +1030,7 @@ CreditsWindFishHandler::
     ld   a, $92                                   ; $4C70: $3E $92
     ldh  [hMapRoom], a                            ; $4C72: $E0 $F6
     ld   a, $FF                                   ; $4C74: $3E $FF
-    ld   [$DBC7], a                               ; $4C76: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $4C76: $EA $C7 $DB
     call AnimateEntitiesAndRestoreBank17          ; $4C79: $CD $ED $0E
     ld   a, [wCreditsSubscene]                    ; $4C7C: $FA $0E $D0
     JP_TABLE                                      ; $4C7F: $C7

--- a/src/code/entities/anti_kirby.asm
+++ b/src/code/entities/anti_kirby.asm
@@ -308,7 +308,7 @@ jr_006_440C:
     ld   a, $10                                   ; $440E: $3E $10
     ldh  [$FFA3], a                               ; $4410: $E0 $A3
     ld   a, $20                                   ; $4412: $3E $20
-    ld   [$DBC7], a                               ; $4414: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $4414: $EA $C7 $DB
     ld   a, $02                                   ; $4417: $3E $02
     ld   [$C146], a                               ; $4419: $EA $46 $C1
     ld   a, $02                                   ; $441C: $3E $02

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -1148,7 +1148,7 @@ func_015_499C::
     ld   a, $28                                   ; $49AB: $3E $28
     ld   [$C13E], a                               ; $49AD: $EA $3E $C1
     ld   a, $40                                   ; $49B0: $3E $40
-    ld   [$DBC7], a                               ; $49B2: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $49B2: $EA $C7 $DB
     ld   a, [wSubtractHealthBuffer]               ; $49B5: $FA $94 $DB
     add  $08                                      ; $49B8: $C6 $08
     ld   [wSubtractHealthBuffer], a               ; $49BA: $EA $94 $DB
@@ -1591,12 +1591,12 @@ label_015_4DB5:
     call func_015_7B0D                            ; $4DC8: $CD $0D $7B
     call DecrementEntityIgnoreHitsCountdown       ; $4DCB: $CD $56 $0C
     call label_3B70                               ; $4DCE: $CD $70 $3B
-    ld   a, [$DBC7]                               ; $4DD1: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $4DD1: $FA $C7 $DB
     push af                                       ; $4DD4: $F5
     call CheckLinkCollisionWithEnemy_trampoline   ; $4DD5: $CD $5A $3B
     pop  af                                       ; $4DD8: $F1
     ld   e, a                                     ; $4DD9: $5F
-    ld   a, [$DBC7]                               ; $4DDA: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $4DDA: $FA $C7 $DB
     cp   e                                        ; $4DDD: $BB
     jr   z, jr_015_4DF2                           ; $4DDE: $28 $12
 
@@ -1604,7 +1604,7 @@ label_015_4DB5:
     jr   c, jr_015_4DF2                           ; $4DE2: $38 $0E
 
     ld   a, $1F                                   ; $4DE4: $3E $1F
-    ld   [$DBC7], a                               ; $4DE6: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $4DE6: $EA $C7 $DB
     ld   a, $30                                   ; $4DE9: $3E $30
     call GetVectorTowardsLink_trampoline          ; $4DEB: $CD $B5 $3B
     ldh  a, [hScratch0]                           ; $4DEE: $F0 $D7
@@ -6186,7 +6186,7 @@ func_015_72CF::
     jr   nc, jr_015_731D                          ; $72F2: $30 $29
 
     ld   hl, $C146                                ; $72F4: $21 $46 $C1
-    ld   a, [$DBC7]                               ; $72F7: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $72F7: $FA $C7 $DB
     or   [hl]                                     ; $72FA: $B6
     jr   nz, jr_015_731D                          ; $72FB: $20 $20
 
@@ -6201,7 +6201,7 @@ func_015_72CF::
     ld   a, $10                                   ; $730F: $3E $10
     ld   [$C13E], a                               ; $7311: $EA $3E $C1
     ld   a, $30                                   ; $7314: $3E $30
-    ld   [$DBC7], a                               ; $7316: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $7316: $EA $C7 $DB
     ld   a, $03                                   ; $7319: $3E $03
     ldh  [hWaveSfx], a                            ; $731B: $E0 $F3
 

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -7678,7 +7678,7 @@ jr_018_76C9:
     push hl                                       ; $76CF: $E5
     ld   de, Data_018_7666                        ; $76D0: $11 $66 $76
     call RenderActiveEntitySpritesPair            ; $76D3: $CD $C0 $3B
-    ld   a, [$DBC7]                               ; $76D6: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $76D6: $FA $C7 $DB
     and  a                                        ; $76D9: $A7
     jr   nz, jr_018_7717                          ; $76DA: $20 $3B
 
@@ -7712,7 +7712,7 @@ jr_018_76FE:
     ld   a, $18                                   ; $7704: $3E $18
     ld   [$C13E], a                               ; $7706: $EA $3E $C1
     ld   a, $10                                   ; $7709: $3E $10
-    ld   [$DBC7], a                               ; $770B: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $770B: $EA $C7 $DB
     ld   a, $08                                   ; $770E: $3E $08
     ld   [wSubtractHealthBuffer], a               ; $7710: $EA $94 $DB
     ld   a, $03                                   ; $7713: $3E $03

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -822,39 +822,25 @@ Data_019_4634::
     call func_019_7CFB                            ; $4634: $CD $FB $7C
     ret  nc                                       ; $4637: $D0
 
-    ld   a, [$DB7D]                               ; $4638: $FA $7D $DB
+    ld   a, [wBoomerangTradedItem]                ; $4638: $FA $7D $DB
     cp   $00                                      ; $463B: $FE $00
     jr   z, jr_019_4643                           ; $463D: $28 $04
 
     cp   $0D                                      ; $463F: $FE $0D
-    jr   nz, @+$22                                ; $4641: $20 $20
+    jr   nz, jr_019_4663                          ; $4641: $20 $20
 
 jr_019_4643:
     call_open_dialog $221                         ; $4643
     jp   IncrementEntityState                     ; $4648: $C3 $12 $3B
 
-    di                                            ; $464B: $F3
-    ld   d, c                                     ; $464C: $51
-    ld   h, a                                     ; $464D: $67
-    jr   z, jr_019_4643                           ; $464E: $28 $F3
+Data_019_454B::
+    db   $F3, $51, $67, $28, $F3, $51, $67, $28, $D9, $11, $CE, $10, $17, $14, $08, $10
+    db   $D9, $11, $CE, $10, $F3, $51, $67, $28
 
-    ld   d, c                                     ; $4650: $51
-    ld   h, a                                     ; $4651: $67
-    jr   z, @-$25                                 ; $4652: $28 $D9
-
-    ld   de, $10CE                                ; $4654: $11 $CE $10
-    rla                                           ; $4657: $17
-    inc  d                                        ; $4658: $14
-    ld   [$D910], sp                              ; $4659: $08 $10 $D9
-    ld   de, $10CE                                ; $465C: $11 $CE $10
-    di                                            ; $465F: $F3
-    ld   d, c                                     ; $4660: $51
-    ld   h, a                                     ; $4661: $67
-    jr   z, jr_019_46A2                           ; $4662: $28 $3E
-
-    dec  h                                        ; $4664: $25
+jr_019_4663:
+    ld   a, $25                                   ; $4663: $3E $25
     call OpenDialogInTable2                       ; $4665: $CD $7C $23
-    ld   a, [$DB7D]                               ; $4668: $FA $7D $DB
+    ld   a, [wBoomerangTradedItem]                ; $4668: $FA $7D $DB
     sla  a                                        ; $466B: $CB $27
     sla  a                                        ; $466D: $CB $27
     ld   e, a                                     ; $466F: $5F
@@ -913,7 +899,7 @@ jr_019_46A2:
     cp   $05                                      ; $46BA: $FE $05
     jr   z, jr_019_46E1                           ; $46BC: $28 $23
 
-    ld   [$DB7D], a                               ; $46BE: $EA $7D $DB
+    ld   [wBoomerangTradedItem], a                ; $46BE: $EA $7D $DB
     ld   a, $0D                                   ; $46C1: $3E $0D
     ld   [wBButtonSlot], a                        ; $46C3: $EA $00 $DB
     ld   hl, wEntitiesPrivateState1Table          ; $46C6: $21 $B0 $C2
@@ -958,13 +944,13 @@ jr_019_46FB:
     jr   nz, jr_019_46FB                          ; $4705: $20 $F4
 
 jr_019_4707:
-    ld   a, [$DB7D]                               ; $4707: $FA $7D $DB
+    ld   a, [wBoomerangTradedItem]                ; $4707: $FA $7D $DB
     ld   [hl], a                                  ; $470A: $77
     ld   hl, wEntitiesPrivateState1Table          ; $470B: $21 $B0 $C2
     add  hl, bc                                   ; $470E: $09
     ld   [hl], a                                  ; $470F: $77
     ld   a, $0D                                   ; $4710: $3E $0D
-    ld   [$DB7D], a                               ; $4712: $EA $7D $DB
+    ld   [wBoomerangTradedItem], a                ; $4712: $EA $7D $DB
     call GetEntityTransitionCountdown             ; $4715: $CD $05 $0C
     ld   [hl], $80                                ; $4718: $36 $80
     ld   a, $01                                   ; $471A: $3E $01

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -438,7 +438,7 @@ Data_019_42F1::
 WarpState3Handler::
     call ResetSpinAttack                          ; $42F5: $CD $AF $0C
     ld   [wSubtractHealthBuffer], a               ; $42F8: $EA $94 $DB
-    ld   [$DBC7], a                               ; $42FB: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $42FB: $EA $C7 $DB
     ld   [$C13E], a                               ; $42FE: $EA $3E $C1
     ld   [wSwordAnimationState], a                ; $4301: $EA $37 $C1
     ld   [wC16A], a                               ; $4304: $EA $6A $C1

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -2352,14 +2352,14 @@ SpawnEnemyDrop::
     and  a                                        ; $55EA: $A7
     jp   nz, .dropEntity                          ; $55EB: $C2 $70 $56
 
-    ld   a, [$D471]                               ; $55EE: $FA $71 $D4
+    ld   a, [wGuardianAcornCounter]               ; $55EE: $FA $71 $D4
     inc  a                                        ; $55F1: $3C
-    ld   [$D471], a                               ; $55F2: $EA $71 $D4
+    ld   [wGuardianAcornCounter], a               ; $55F2: $EA $71 $D4
     cp   $0C                                      ; $55F5: $FE $0C
     jr   c, .jr_003_560F                          ; $55F7: $38 $16
 
     xor  a                                        ; $55F9: $AF
-    ld   [$D471], a                               ; $55FA: $EA $71 $D4
+    ld   [wGuardianAcornCounter], a               ; $55FA: $EA $71 $D4
     ld   a, [wInBossBattle]                       ; $55FD: $FA $BE $C1
     ld   hl, wActivePowerUp                       ; $5600: $21 $7C $D4
     or   [hl]                                     ; $5603: $B6
@@ -2367,7 +2367,7 @@ SpawnEnemyDrop::
     or   [hl]                                     ; $5607: $B6
     jr   nz, .jr_003_560F                         ; $5608: $20 $05
 
-    ld   a, $34                                   ; $560A: $3E $34
+    ld   a, ENTITY_GUARDIAN_ACORN                 ; $560A: $3E $34
     jp   .dropEntity                              ; $560C: $C3 $70 $56
 
 .jr_003_560F
@@ -6111,7 +6111,7 @@ jr_003_6D5D:
     ret                                           ; $6D72: $C9
 
 jr_003_6D73:
-    ld   a, [$DBC7]                               ; $6D73: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $6D73: $FA $C7 $DB
     ld   hl, $C1C6                                ; $6D76: $21 $C6 $C1
     or   [hl]                                     ; $6D79: $B6
     ld   hl, wLinkPlayingOcarinaCountdown         ; $6D7A: $21 $66 $C1
@@ -6159,9 +6159,9 @@ jr_003_6D73:
     add  e                                        ; $6DAE: $83
     ld   [wSubtractHealthBuffer], a               ; $6DAF: $EA $94 $DB
     ld   a, $50                                   ; $6DB2: $3E $50
-    ld   [$DBC7], a                               ; $6DB4: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $6DB4: $EA $C7 $DB
     xor  a                                        ; $6DB7: $AF
-    ld   [$D471], a                               ; $6DB8: $EA $71 $D4
+    ld   [wGuardianAcornCounter], a               ; $6DB8: $EA $71 $D4
     ld   a, [wActivePowerUp]                      ; $6DBB: $FA $7C $D4
     and  a                                        ; $6DBE: $A7
     jr   z, func_003_6DDF                         ; $6DBF: $28 $1E
@@ -7486,7 +7486,7 @@ jr_003_752D:
     cp   e                                        ; $7535: $BB
     jr   nc, jr_003_7570                          ; $7536: $30 $38
 
-    ld   a, [$DBC7]                               ; $7538: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $7538: $FA $C7 $DB
     and  a                                        ; $753B: $A7
     jr   nz, jr_003_7570                          ; $753C: $20 $32
 

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -3366,8 +3366,8 @@ SwordState3Handler::
     jr   nz, jr_003_5C37                          ; $5C22: $20 $13
 
     ld   [wC167], a                               ; $5C24: $EA $67 $C1
-    ld   d, $01                                   ; $5C27: $16 $01
-    call GiveInventoryItem                            ; $5C29: $CD $72 $64
+    ld   d, INVENTORY_SWORD                       ; $5C27: $16 $01
+    call GiveInventoryItem                        ; $5C29: $CD $72 $64
     ld   a, $01                                   ; $5C2C: $3E $01
     ld   [wSwordLevel], a                         ; $5C2E: $EA $4E $DB
     call func_003_512A                            ; $5C31: $CD $2A $51
@@ -3386,7 +3386,7 @@ jr_003_5C37:
 jr_003_5C46:
     ret                                           ; $5C46: $C9
 
-Data_003_5C47::
+HookshotSpriteData::
     db   $8A, $14
 
 label_003_5C49:
@@ -3394,7 +3394,7 @@ label_003_5C49:
     and  $10                                      ; $5C4B: $E6 $10
     jp   nz, UnloadEntityAndReturn                ; $5C4D: $C2 $8D $3F
 
-    ld   de, Data_003_5C47                        ; $5C50: $11 $47 $5C
+    ld   de, HookshotSpriteData                   ; $5C50: $11 $47 $5C
     call RenderActiveEntitySprite                 ; $5C53: $CD $77 $3C
     call GetEntityTransitionCountdown             ; $5C56: $CD $05 $0C
     jp   z, label_003_60AA                        ; $5C59: $CA $AA $60
@@ -3410,8 +3410,8 @@ jr_003_5C67:
     dec  a                                        ; $5C67: $3D
     jr   nz, jr_003_5C75                          ; $5C68: $20 $0B
 
-    ld   d, $06                                   ; $5C6A: $16 $06
-    call GiveInventoryItem                            ; $5C6C: $CD $72 $64
+    ld   d, INVENTORY_HOOKSHOT                    ; $5C6A: $16 $06
+    call GiveInventoryItem                        ; $5C6C: $CD $72 $64
     call func_003_512A                            ; $5C6F: $CD $2A $51
     jp   UnloadEntityAndReturn                    ; $5C72: $C3 $8D $3F
 
@@ -3577,8 +3577,8 @@ jr_003_5D6C:
 
     ld   a, $0A                                   ; $5D6F: $3E $0A
     ldh  [hFFA5], a                               ; $5D71: $E0 $A5
-    ld   d, $0C                                   ; $5D73: $16 $0C
-    call GiveInventoryItem                            ; $5D75: $CD $72 $64
+    ld   d, INVENTORY_MAGIC_POWDER                ; $5D73: $16 $0C
+    call GiveInventoryItem                        ; $5D75: $CD $72 $64
     ld   a, $01                                   ; $5D78: $3E $01
     ld   [wHasToadstool], a                       ; $5D7A: $EA $4B $DB
     jp   UnloadEntityAndReturn                    ; $5D7D: $C3 $8D $3F

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -6755,7 +6755,7 @@ jr_004_7845:
     ld   c, $0B                                   ; $7849: $0E $0B
 
 jr_004_784B:
-    ld   a, [$DB7D]                               ; $784B: $FA $7D $DB
+    ld   a, [wBoomerangTradedItem]                ; $784B: $FA $7D $DB
     cp   $0B                                      ; $784E: $FE $0B
     jr   z, jr_004_7857                           ; $7850: $28 $05
 
@@ -6776,7 +6776,7 @@ jr_004_7859:
     ld   c, $0B                                   ; $7862: $0E $0B
 
 jr_004_7864:
-    ld   a, [$DB7D]                               ; $7864: $FA $7D $DB
+    ld   a, [wBoomerangTradedItem]]               ; $7864: $FA $7D $DB
     cp   $05                                      ; $7867: $FE $05
     jr   z, jr_004_7870                           ; $7869: $28 $05
 

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -6776,7 +6776,7 @@ jr_004_7859:
     ld   c, $0B                                   ; $7862: $0E $0B
 
 jr_004_7864:
-    ld   a, [wBoomerangTradedItem]]               ; $7864: $FA $7D $DB
+    ld   a, [wBoomerangTradedItem]                ; $7864: $FA $7D $DB
     cp   $05                                      ; $7867: $FE $05
     jr   z, jr_004_7870                           ; $7869: $28 $05
 

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -4930,7 +4930,7 @@ label_004_6D0F:
     jr   nc, jr_004_6D5C                          ; $6D31: $30 $29
 
     call func_004_6D7A                            ; $6D33: $CD $7A $6D
-    ld   a, [$DBC7]                               ; $6D36: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $6D36: $FA $C7 $DB
     and  a                                        ; $6D39: $A7
     jr   nz, jr_004_6D5C                          ; $6D3A: $20 $20
 

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -9567,10 +9567,10 @@ func_007_7ED6::
     jr   nz, jr_007_7F13                          ; $7ED9: $20 $38
 
     ldh  a, [hActiveEntityType]                   ; $7EDB: $F0 $EB
-    cp   $5F                                      ; $7EDD: $FE $5F
+    cp   ENTITY_MASTER_STALFOS                    ; $7EDD: $FE $5F
     jr   nz, jr_007_7F0A                          ; $7EDF: $20 $29
 
-    ld   a, $30                                   ; $7EE1: $3E $30
+    ld   a, ENTITY_KEY_DROP_POINT                 ; $7EE1: $3E $30
     call SpawnNewEntity_trampoline                ; $7EE3: $CD $86 $3B
     ldh  a, [hScratch0]                           ; $7EE6: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7EE8: $21 $00 $C2

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -7505,7 +7505,7 @@ func_007_7090::
 
 func_007_70B7::
     ld   hl, $C146                                ; $70B7: $21 $46 $C1
-    ld   a, [$DBC7]                               ; $70BA: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $70BA: $FA $C7 $DB
     or   [hl]                                     ; $70BD: $B6
     jr   nz, jr_007_7111                          ; $70BE: $20 $51
 
@@ -7552,7 +7552,7 @@ jr_007_70E0:
     ld   a, $08                                   ; $7103: $3E $08
     ld   [wSubtractHealthBuffer], a               ; $7105: $EA $94 $DB
     ld   a, $20                                   ; $7108: $3E $20
-    ld   [$DBC7], a                               ; $710A: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $710A: $EA $C7 $DB
     ld   a, $03                                   ; $710D: $3E $03
     ldh  [hWaveSfx], a                            ; $710F: $E0 $F3
 

--- a/src/code/entities/slime_eel.asm
+++ b/src/code/entities/slime_eel.asm
@@ -1015,7 +1015,7 @@ func_005_7425::
     and  a                                        ; $7437: $A7
     jr   z, jr_005_7478                           ; $7438: $28 $3E
 
-    ld   a, [$DBC7]                               ; $743A: $FA $C7 $DB
+    ld   a, [wInvincibilityCounter]               ; $743A: $FA $C7 $DB
     and  a                                        ; $743D: $A7
     jr   nz, jr_005_7478                          ; $743E: $20 $38
 

--- a/src/code/game_over.asm
+++ b/src/code/game_over.asm
@@ -186,7 +186,7 @@ jr_001_42FB::
     ld   a, $01                                   ; $4321: $3E $01
     call ClearFileMenuBG_trampoline               ; $4323: $CD $FA $08
     ld   a, $80                                   ; $4326: $3E $80
-    ld   [$DBC7], a                               ; $4328: $EA $C7 $DB
+    ld   [wInvincibilityCounter], a               ; $4328: $EA $C7 $DB
     ret                                           ; $432B: $C9
 
 jr_001_432C::

--- a/src/code/home/animated_tiles.asm
+++ b/src/code/home/animated_tiles.asm
@@ -425,14 +425,14 @@ DrawLinkSpriteAndReturn::
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_1D42
-    ld   a, [$DBC7]
+    ld   a, [wInvincibilityCounter]
     and  $04
     jr   z, label_1D49
     ld   a, $04
     jr   label_1D49
 
 label_1D42::
-    ld   a, [$DBC7]
+    ld   a, [wInvincibilityCounter]
     rla
     rla
     and  $10
@@ -463,7 +463,7 @@ label_1D49::
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_1DA1
-    ld   a, [$DBC7]
+    ld   a, [wInvincibilityCounter]
     and  $04
     jr   nz, label_1DA1
     ldh  a, [hLinkAnimationState]
@@ -512,7 +512,7 @@ label_1DA1::
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_1DE7
-    ld   a, [$DBC7]
+    ld   a, [wInvincibilityCounter]
     and  $04
     jr   nz, label_1DE7
     ldh  a, [hLinkAnimationState]

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -1025,7 +1025,11 @@ wBossDefeated:: ; D46C
   ds 1
 
 ; Unlabeled
-ds $5
+ds $4
+
+wGuardianAcornCounter:: ; D471
+  ; Increases on each kill. Reset to 0 when hit, or when it hits 12 a guardian acorn is spawned.
+  ds 1
 
 wMazeSignpostGoal:: ; D472
   ; Signpost maze: current goal
@@ -1509,7 +1513,13 @@ wKillCount2:: ; DBB5
 
 ; Unlabeled
 wDBB6 equ $DBB6
-  ds $13
+  ds $11
+
+wInvincibilityCounter:: ; DBC7
+  ds 1
+
+; Unlabeled
+  ds 1
 
 wTorchesCount:: ; DBC9
   ds 1

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -1405,8 +1405,16 @@ wIsRoosterFollowingLink:: ; DB7B
   ds 1
 
 ; Unlabeled
-wDB7C equ $DB7C
-  ds $13
+  ds 1
+
+wBoomerangTradedItem:: ; DB7D
+  ; Stores the inventory item that you traded for the boomerang.
+  ; Initially this value is zero, indicating no trade. But after you traded the boomerang
+  ; back it will be INVENTORY_BOOMERANG
+  ds 1
+
+; Unlabeled
+  ds $11
 
 wAddRupeeBufferHigh:: ; DB8F
   ; Higher digits of the amount of rupees to be added to your wallet (high digits)


### PR DESCRIPTION
While discovering how master stalfos (in dungeon 5) drops the hookshot, I updated a few constants. Nothing fancy.
In case you didn't know, it uses the "dropped key" entity.

Also ran into the guardian acorn code by chance, and noticed 2 undocumented memory locations. The guardian acorn kill counter was pretty obvious. The invincibility counter I tested by setting it to a fixed value in an emulator and noticing I could no longer take any damage.