### PR TITLE
Annotate a few things, and replace all the direct room status memory …

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -1130,7 +1130,7 @@ LoadRoomTiles::
     ld   a, e
     cp   $23
     jr   nz, .label_DCE
-    ld   a, [$D8C9]
+    ld   a, [wOverworldRoomStatus + $C9]
     and  $20
     jr   z, .label_DCE
     inc  e
@@ -1139,7 +1139,7 @@ LoadRoomTiles::
     ld   a, e
     cp   $21
     jr   nz, .label_DDB
-    ld   a, [$D8FD]
+    ld   a, [wOverworldRoomStatus + $FD]
     and  $20
     jr   z, .label_DDB
     inc  e
@@ -5656,7 +5656,7 @@ LoadRoom::
     ldh  a, [hMapRoom]
     cp   $0E
     jr   nz, .endEaglesTowerAlt
-    ld   a, [$D80E]
+    ld   a, [wOverworldRoomStatus + $0E]
     and  ROOM_STATUS_CHANGED
     jr   z, .altRoomsEnd
     ld   bc, Overworld0EAlt ; Eagle's Tower open
@@ -5665,7 +5665,7 @@ LoadRoom::
 
     cp   $8C
     jr   nz, .endSouthFaceShrineAlt
-    ld   a, [$D88C]
+    ld   a, [wOverworldRoomStatus + $8C]
     and  ROOM_STATUS_CHANGED
     jr   z, .altRoomsEnd
     ld   bc, Overworld8CAlt ; South Face Shrine open
@@ -5674,7 +5674,7 @@ LoadRoom::
 
     cp   $79
     jr   nz, .endUpperTalTalHeightsAlt
-    ld   a, [$D879]
+    ld   a, [wOverworldRoomStatus + $79]
     and  ROOM_STATUS_CHANGED
     jr   z, .altRoomsEnd
     ld   bc, Overworld79Alt ; Kanalet Castle open
@@ -5683,7 +5683,7 @@ LoadRoom::
 
     cp   $06
     jr   nz, .endWindfishsEggAlt
-    ld   a, [$D806]
+    ld   a, [wOverworldRoomStatus + $06]
     and  ROOM_STATUS_CHANGED
     jr   z, .altRoomsEnd
     ld   bc, Overworld06Alt ; Windfish's Egg open
@@ -5692,7 +5692,7 @@ LoadRoom::
 
     cp   $1B
     jr   nz, .endTalTalHeightsAlt
-    ld   a, [$D82B]
+    ld   a, [wOverworldRoomStatus + $2B]
     and  ROOM_STATUS_CHANGED
     jr   z, .altRoomsEnd
     ld   bc, Overworld1BAlt ; Angler's Tunnel upper water dry
@@ -5701,7 +5701,7 @@ LoadRoom::
 
     cp   $2B
     jr   nz, .altRoomsEnd
-    ld   a, [$D82B]
+    ld   a, [wOverworldRoomStatus + $2B]
     and  ROOM_STATUS_CHANGED
     jr   z, .altRoomsEnd
     ld   bc, Overworld2BAlt ; Angler's Tunnel open
@@ -6760,7 +6760,7 @@ LoadObject_OpenDoorTop::
 ; Set hRoomStatus depending on the map and room
 label_36C4::
     push af
-    ld   hl, $D900
+    ld   hl, wIndoorARoomStatus
     ldh  a, [hMapRoom]
     ld   e, a
     ld   d, $00

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -470,7 +470,7 @@ jr_001_52C7::
     ld   c, [hl]
     inc  hl
     ld   b, [hl]
-    ld   hl, $D800
+    ld   hl, wOverworldRoomStatus
     ld   de, $0380
 
 jr_001_52D9::
@@ -978,7 +978,7 @@ jr_001_5678::
     and  a
     ld   a, $00
     jr   nz, jr_001_56D9
-    ld   hl, $D800
+    ld   hl, wOverworldRoomStatus
     add  hl, de
     ld   a, [hl]
     and  $20
@@ -1055,7 +1055,7 @@ jr_001_5731::
     push de
     ld   a, [$DBB4]
     ld   e, a
-    ld   hl, $D800
+    ld   hl, wOverworldRoomStatus
     add  hl, de
     pop  de
     ld   a, [hl]
@@ -1423,7 +1423,7 @@ jr_001_5AA0::
     jr   z, label_001_5B3F
     ld   e, a
     ld   d, $00
-    ld   hl, $D800
+    ld   hl, wOverworldRoomStatus
     add  hl, de
     ld   a, [$C5A2]
     and  a
@@ -1456,7 +1456,7 @@ jr_001_5AF5::
     ld   a, [$C5A2]
     and  a
     jr   nz, jr_001_5B30
-    ld   hl, $D800
+    ld   hl, wOverworldRoomStatus
     add  hl, de
     ld   a, [hl]
     and  $20
@@ -1876,7 +1876,7 @@ func_001_5DE6::
     ld   a, [hli]
     ld   h, [hl]
     ld   l, a
-    ld   bc, $D800
+    ld   bc, wOverworldRoomStatus
     ld   de, $0380
 
 jr_001_5E12::

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -4317,7 +4317,7 @@ jr_002_5D21:
     and  a                                        ; $5D27: $A7
     jr   z, jr_002_5D36                           ; $5D28: $28 $0C
 
-    ld   hl, $D900                                ; $5D2A: $21 $00 $D9
+    ld   hl, wIndoorARoomStatus                                ; $5D2A: $21 $00 $D9
     ldh  a, [hMapId]                         ; $5D2D: $F0 $F7
     cp   MAP_COLOR_DUNGEON                                      ; $5D2F: $FE $FF
     jr   nz, jr_002_5D36                          ; $5D31: $20 $03
@@ -7671,7 +7671,7 @@ jr_002_77F7:
     cp   $C3                                      ; $782A: $FE $C3
     jr   nz, jr_002_7833                          ; $782C: $20 $05
 
-    ld   hl, $D879                                ; $782E: $21 $79 $D8
+    ld   hl, wOverworldRoomStatus + $79                                ; $782E: $21 $79 $D8
     set  4, [hl]                                  ; $7831: $CB $E6
 
 jr_002_7833:

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5185,7 +5185,7 @@ LoadRoomObjectsAttributes::
     cp   $0E                                      ; $6DB6: $FE $0E
     jr   nz, .jr_020_6DC6                         ; $6DB8: $20 $0C
 
-    ld   a, [$D80E]                               ; $6DBA: $FA $0E $D8
+    ld   a, [wOverworldRoomStatus + $0E]                               ; $6DBA: $FA $0E $D8
     and  $10                                      ; $6DBD: $E6 $10
     jr   z, .jr_020_6E1A                          ; $6DBF: $28 $59
 
@@ -5196,7 +5196,7 @@ LoadRoomObjectsAttributes::
     cp   $8C                                      ; $6DC6: $FE $8C
     jr   nz, .jr_020_6DD6                         ; $6DC8: $20 $0C
 
-    ld   a, [$D88C]                               ; $6DCA: $FA $8C $D8
+    ld   a, [wOverworldRoomStatus + $8C]                               ; $6DCA: $FA $8C $D8
     and  $10                                      ; $6DCD: $E6 $10
     jr   z, .jr_020_6E1A                          ; $6DCF: $28 $49
 
@@ -5207,7 +5207,7 @@ LoadRoomObjectsAttributes::
     cp   $79                                      ; $6DD6: $FE $79
     jr   nz, .jr_020_6DE6                         ; $6DD8: $20 $0C
 
-    ld   a, [$D879]                               ; $6DDA: $FA $79 $D8
+    ld   a, [wOverworldRoomStatus + $79]                               ; $6DDA: $FA $79 $D8
     and  $10                                      ; $6DDD: $E6 $10
     jr   z, .jr_020_6E1A                          ; $6DDF: $28 $39
 
@@ -5218,7 +5218,7 @@ LoadRoomObjectsAttributes::
     cp   $06                                      ; $6DE6: $FE $06
     jr   nz, .jr_020_6DF6                         ; $6DE8: $20 $0C
 
-    ld   a, [$D806]                               ; $6DEA: $FA $06 $D8
+    ld   a, [wOverworldRoomStatus + $06]                               ; $6DEA: $FA $06 $D8
     and  $10                                      ; $6DED: $E6 $10
     jr   z, .jr_020_6E1A                          ; $6DEF: $28 $29
 
@@ -5229,7 +5229,7 @@ LoadRoomObjectsAttributes::
     cp   $1B                                      ; $6DF6: $FE $1B
     jr   nz, .jr_020_6E06                         ; $6DF8: $20 $0C
 
-    ld   a, [$D82B]                               ; $6DFA: $FA $2B $D8
+    ld   a, [wOverworldRoomStatus + $2B]                               ; $6DFA: $FA $2B $D8
     and  $10                                      ; $6DFD: $E6 $10
     jr   z, .jr_020_6E1A                          ; $6DFF: $28 $19
 
@@ -5240,7 +5240,7 @@ LoadRoomObjectsAttributes::
     cp   $2B                                      ; $6E06: $FE $2B
     jr   nz, .jr_020_6E1A                         ; $6E08: $20 $10
 
-    ld   a, [$D82B]                               ; $6E0A: $FA $2B $D8
+    ld   a, [wOverworldRoomStatus + $2B]                               ; $6E0A: $FA $2B $D8
     and  $10                                      ; $6E0D: $E6 $10
     jr   z, .jr_020_6E1A                          ; $6E0F: $28 $09
 

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -2067,7 +2067,7 @@ func_015_50C2::
 
     ld   a, MUSIC_FINAL_BOSS_DIALOG               ; $50C7: $3E $5D
     ld   [wMusicTrackToPlay], a                   ; $50C9: $EA $68 $D3
-    ld   hl, $DA74                                ; $50CC: $21 $74 $DA
+    ld   hl, wIndoorBRoomStatus + $74                                ; $50CC: $21 $74 $DA
     set  6, [hl]                                  ; $50CF: $CB $F6
     call_open_dialog $0F5                         ; $50D1
     call GetEntityTransitionCountdown             ; $50D6: $CD $05 $0C

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -2815,7 +2815,7 @@ WalrusEntityHandler::
     and  a                                        ; $5506: $A7
     jp   nz, label_018_54BD                       ; $5507: $C2 $BD $54
 
-    ld   a, [$D8FD]                               ; $550A: $FA $FD $D8
+    ld   a, [wOverworldRoomStatus + $FD]                               ; $550A: $FA $FD $D8
     and  $20                                      ; $550D: $E6 $20
     jp   nz, label_018_589A                       ; $550F: $C2 $9A $58
 
@@ -4504,7 +4504,7 @@ jr_018_60A3:
 
     xor  a                                        ; $60B8: $AF
     ld   [wC167], a                               ; $60B9: $EA $67 $C1
-    ld   hl, $D808                                ; $60BC: $21 $08 $D8
+    ld   hl, wOverworldRoomStatus + $08                                ; $60BC: $21 $08 $D8
     set  4, [hl]                                  ; $60BF: $CB $E6
     ld   a, [hl]                                  ; $60C1: $7E
     ldh  [hRoomStatus], a                         ; $60C2: $E0 $F8
@@ -4618,7 +4618,7 @@ MarinAtTheShoreEntityHandler::
     and  a                                        ; $6194: $A7
     ret  nz                                       ; $6195: $C0
 
-    ld   a, [$D8FD]                               ; $6196: $FA $FD $D8
+    ld   a, [wOverworldRoomStatus + $FD]                               ; $6196: $FA $FD $D8
     and  $20                                      ; $6199: $E6 $20
     jp   nz, func_018_7F08                        ; $619B: $C2 $08 $7F
 
@@ -7236,7 +7236,7 @@ jr_018_7363:
     and  a                                        ; $7371: $A7
     jr   nz, jr_018_737D                          ; $7372: $20 $09
 
-    ld   hl, $D810                                ; $7374: $21 $10 $D8
+    ld   hl, wOverworldRoomStatus + $10                                ; $7374: $21 $10 $D8
     set  5, [hl]                                  ; $7377: $CB $EE
     ld   a, $02                                   ; $7379: $3E $02
     ldh  [hJingle], a                             ; $737B: $E0 $F2

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -1851,7 +1851,7 @@ label_019_4CFF:
     ret                                           ; $4D19: $C9
 
 jr_019_4D1A:
-    ld   hl, $D806                                ; $4D1A: $21 $06 $D8
+    ld   hl, wOverworldRoomStatus + $06                                ; $4D1A: $21 $06 $D8
     set  4, [hl]                                  ; $4D1D: $CB $E6
     ld   a, [hl]                                  ; $4D1F: $7E
     ldh  [hRoomStatus], a                         ; $4D20: $E0 $F8
@@ -4438,7 +4438,7 @@ GhostState2Handler::
     ld   [wIsGhostFollowingLink], a               ; $5F4B: $EA $79 $DB
     ld   [wGhostSeeksGrave], a                    ; $5F4E: $EA $7A $DB
     ld   [wC167], a                               ; $5F51: $EA $67 $C1
-    ld   hl, $D9E3                                ; $5F54: $21 $E3 $D9
+    ld   hl, wIndoorARoomStatus + $E3                                ; $5F54: $21 $E3 $D9
     set  6, [hl]                                  ; $5F57: $CB $F6
     jp   ClearEntityStatus_19                            ; $5F59: $C3 $61 $7E
 
@@ -6087,7 +6087,7 @@ BananasSchuleState0Handler::
     jr   nz, jr_019_6D63                          ; $6D47: $20 $1A
 
     ld   e, $CC                                   ; $6D49: $1E $CC
-    ld   a, [$DAFE]                               ; $6D4B: $FA $FE $DA
+    ld   a, [wIndoorBRoomStatus + $FE]                               ; $6D4B: $FA $FE $DA
     and  $20                                      ; $6D4E: $E6 $20
     jr   nz, jr_019_6D63                          ; $6D50: $20 $11
 
@@ -6782,7 +6782,7 @@ label_019_72BF:
     ret                                           ; $72C8: $C9
 
 jr_019_72C9:
-    ld   hl, $DAE9                                ; $72C9: $21 $E9 $DA
+    ld   hl, wIndoorBRoomStatus + $E9                                ; $72C9: $21 $E9 $DA
     cp   $05                                      ; $72CC: $FE $05
     jr   nz, jr_019_72E0                          ; $72CE: $20 $10
 
@@ -7250,9 +7250,9 @@ jr_019_76D6:
     ld   a, MUSIC_TOOL_ACQUIRED                   ; $76E1: $3E $10
     ld   [wMusicTrackToPlay], a                   ; $76E3: $EA $68 $D3
     call_open_dialog $09F                         ; $76E6
-    ld   a, [$DAE9]                               ; $76EB: $FA $E9 $DA
+    ld   a, [wIndoorBRoomStatus + $E9]                               ; $76EB: $FA $E9 $DA
     or   $10                                      ; $76EE: $F6 $10
-    ld   [$DAE9], a                               ; $76F0: $EA $E9 $DA
+    ld   [wIndoorBRoomStatus + $E9], a                               ; $76F0: $EA $E9 $DA
     ldh  [hRoomStatus], a                         ; $76F3: $E0 $F8
     ld   a, $02                                   ; $76F5: $3E $02
     ld   [wSwordLevel], a                         ; $76F7: $EA $4E $DB
@@ -7413,7 +7413,7 @@ jr_019_7898:
     ld   a, $01                                   ; $78A9: $3E $01
     ldh  [hWaveSfx], a                            ; $78AB: $E0 $F3
     call ClearEntityStatus_19                            ; $78AD: $CD $61 $7E
-    ld   hl, $DAE9                                ; $78B0: $21 $E9 $DA
+    ld   hl, wIndoorBRoomStatus + $E9                                ; $78B0: $21 $E9 $DA
     ld   a, [wSeashellsCount]                     ; $78B3: $FA $0F $DB
 
 jr_019_78B6:

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -276,16 +276,16 @@ EntityInitHandler::
     cp   $84                                      ; $48D7: $FE $84
     jr   z, .jr_003_48E2                          ; $48D9: $28 $07
 
-    ld   a, [$D984]                               ; $48DB: $FA $84 $D9
+    ld   a, [wIndoorARoomStatus + $84]                               ; $48DB: $FA $84 $D9
     and  $30                                      ; $48DE: $E6 $30
     jr   z, MasterStalfosDefeated                 ; $48E0: $28 $CB
 
 .jr_003_48E2
-    ld   a, [$D992]                               ; $48E2: $FA $92 $D9
+    ld   a, [wIndoorARoomStatus + $92]                               ; $48E2: $FA $92 $D9
     and  $30                                      ; $48E5: $E6 $30
     jr   z, MasterStalfosDefeated                 ; $48E7: $28 $C4
 
-    ld   a, [$D995]                               ; $48E9: $FA $95 $D9
+    ld   a, [wIndoorARoomStatus + $95]                               ; $48E9: $FA $95 $D9
     and  $30                                      ; $48EC: $E6 $30
     jr   z, MasterStalfosDefeated                 ; $48EE: $28 $BD
 .masterStalfosEnd
@@ -1444,6 +1444,7 @@ EntityInitKeyDropPoint::
     cp   $F8                                      ; In the Yarna Desert quicksand pit
     jr   nz, jr_003_4F44                          ; $4F31: $20 $11
 
+    ; check if the angler key has dropped, and not dropped down the hole yet
     ldh  a, [hRoomStatus]                         ; $4F33: $F0 $F8
     bit  4, a                                     ; $4F35: $CB $67
     jp   nz, UnloadEntityAndReturn                ; $4F37: $C2 $8D $3F
@@ -1455,6 +1456,7 @@ EntityInitKeyDropPoint::
     jp   SetEntitySpriteVariant                   ; $4F41: $C3 $0C $3B
 
 jr_003_4F44:
+    ; Handle the sprite change for the bird key
     cp   $7A                                      ; $4F44: $FE $7A
     jr   nz, jr_003_4F54                          ; $4F46: $20 $0C
 
@@ -1466,10 +1468,12 @@ jr_003_4F44:
     jp   SetEntitySpriteVariant                   ; $4F51: $C3 $0C $3B
 
 jr_003_4F54:
+    ; handle the key in the sidescroll room in dungeon 4 where
+    ; the key drops in the hole down into the sidescrolling room with water
     cp   $7C                                      ; $4F54: $FE $7C
     jr   nz, jr_003_4F67                          ; $4F56: $20 $0F
 
-    ld   a, [$D969]                               ; $4F58: $FA $69 $D9
+    ld   a, [wIndoorARoomStatus + $69]            ; $4F58: $FA $69 $D9
     and  $10                                      ; $4F5B: $E6 $10
     jp   z, UnloadEntityAndReturn                 ; $4F5D: $CA $8D $3F
 
@@ -3009,7 +3013,7 @@ HeartContainerEntityHandler::
 
     ; Start of when item is picked up
     dec  a                                        ; $59E8: $3D
-    jr   nz, func_003_5A17                        ; $59E9: $20 $2C
+    jr   nz, HoldEntityAboveLink                  ; $59E9: $20 $2C
 
     ld   a, MUSIC_BOSS_DEFEATED                   ; $59EB: $3E $18
     ld   [wMusicTrackToPlay], a                   ; $59ED: $EA $68 $D3
@@ -3053,7 +3057,7 @@ HeartContainerEntityHandler::
     ; Finished setting status bits for rooms, delete this
     jp   UnloadEntityAndReturn
 
-func_003_5A17::
+HoldEntityAboveLink::
     ldh  a, [hLinkPositionX]                      ; $5A17: $F0 $98
     ld   hl, wEntitiesPosXTable                   ; $5A19: $21 $00 $C2
     add  hl, bc                                   ; $5A1C: $09
@@ -3106,7 +3110,7 @@ HeartPieceEntityHandler::
 ._08 dw HeartPieceState8Handler                   ; $5A6B
 
 HeartPieceState1Handler::
-    call func_003_5A17                            ; $5A6D: $CD $17 $5A
+    call HoldEntityAboveLink                      ; $5A6D: $CD $17 $5A
     call GetEntityTransitionCountdown             ; $5A70: $CD $05 $0C
     ret  nz                                       ; $5A73: $C0
 
@@ -3132,7 +3136,7 @@ HeartPieceState4Handler::
     ret                                           ; $5A97: $C9
 
 HeartPieceState5Handler::
-    call func_003_5A17                            ; $5A98: $CD $17 $5A
+    call HoldEntityAboveLink                      ; $5A98: $CD $17 $5A
     ld   de, Data_003_5A4D                        ; $5A9B: $11 $4D $5A
     call RenderActiveEntitySpritesPair            ; $5A9E: $CD $C0 $3B
     call func_003_5B2B                            ; $5AA1: $CD $2B $5B
@@ -3154,7 +3158,7 @@ jr_003_5ABA:
     ret                                           ; $5ABA: $C9
 
 HeartPieceState6Handler::
-    call func_003_5A17                            ; $5ABB: $CD $17 $5A
+    call HoldEntityAboveLink                      ; $5ABB: $CD $17 $5A
     ld   de, Data_003_5A4D                        ; $5ABE: $11 $4D $5A
     call RenderActiveEntitySpritesPair            ; $5AC1: $CD $C0 $3B
     xor  a                                        ; $5AC4: $AF
@@ -3187,7 +3191,7 @@ jr_003_5AED:
     jp   IncrementEntityState                     ; $5AED: $C3 $12 $3B
 
 HeartPieceState7Handler::
-    call func_003_5A17                            ; $5AF0: $CD $17 $5A
+    call HoldEntityAboveLink                      ; $5AF0: $CD $17 $5A
     ld   de, Data_003_5A4D                        ; $5AF3: $11 $4D $5A
     call RenderActiveEntitySpritesPair            ; $5AF6: $CD $C0 $3B
     ld   a, [wDialogState]                        ; $5AF9: $FA $9F $C1
@@ -3329,10 +3333,10 @@ jr_003_5BCB:
     call IncrementEntityState                     ; $5BDE: $CD $12 $3B
 
 jr_003_5BE1:
-    jp   func_003_5A17                            ; $5BE1: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5BE1: $C3 $17 $5A
 
 SwordState1Handler::
-    call func_003_5A17                            ; $5BE4: $CD $17 $5A
+    call HoldEntityAboveLink                      ; $5BE4: $CD $17 $5A
     call GetEntityDropTimer                       ; $5BE7: $CD $FB $0B
     ret  nz                                       ; $5BEA: $C0
 
@@ -3356,7 +3360,7 @@ SwordState2Handler::
     jp   IncrementEntityState                     ; $5C0C: $C3 $12 $3B
 
 SwordState3Handler::
-    call func_003_5A17                            ; $5C0F: $CD $17 $5A
+    call HoldEntityAboveLink                      ; $5C0F: $CD $17 $5A
     ld   a, $6B                                   ; $5C12: $3E $6B
     ldh  [hLinkAnimationState], a                 ; $5C14: $E0 $9D
     ld   hl, wEntitiesPosXTable                   ; $5C16: $21 $00 $C2
@@ -3418,21 +3422,28 @@ jr_003_5C67:
     jp   UnloadEntityAndReturn                    ; $5C72: $C3 $8D $3F
 
 jr_003_5C75:
-    jp   func_003_5A17                            ; $5C75: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5C75: $C3 $17 $5A
 
-Data_003_5C78::
-    db   $CA, $17, $C0, $17, $C2, $14, $C4, $17, $C6, $14, $CA, $17
+KeyDropSpriteTable:
+    db   $CA, $17
+    db   $C0, $17
+    db   $C2, $14
+    db   $C4, $17
+    db   $C6, $14
+    db   $CA, $17
 
-Data_003_5C84::
+KeyCollectDialogTable::
     db   $00, $A3, $A4, $A5, $00
 
 KeyDropPointEntityHandler::
-    call func_003_5CEA                            ; $5C89: $CD $EA $5C
+    call CheckForEntityFallingDownQuicksandHole   ; $5C89: $CD $EA $5C
     jr   nc, jr_003_5C99                          ; $5C8C: $30 $0B
 
-    ld   hl, $D8CE                                ; $5C8E: $21 $CE $D8
+    ; If dropped in the quicksand mark the angler key
+    ; as available in the quicksand cave by setting the room flags.
+    ld   hl, wOverworldRoomStatus + $CE           ; $5C8E: $21 $CE $D8
     set  4, [hl]                                  ; $5C91: $CB $E6
-    ld   hl, $D9F8                                ; $5C93: $21 $F8 $D9
+    ld   hl, wIndoorARoomStatus + $F8             ; $5C93: $21 $F8 $D9
     set  5, [hl]                                  ; $5C96: $CB $EE
     ret                                           ; $5C98: $C9
 
@@ -3441,7 +3452,7 @@ jr_003_5C99:
     cp   $80                                      ; @TODO (?) L5 Master Stalfos final room
     jp   z, label_003_5C49                        ; $5C9D: $CA $49 $5C
 
-    ld   de, Data_003_5C78                        ; $5CA0: $11 $78 $5C
+    ld   de, KeyDropSpriteTable                   ; $5CA0: $11 $78 $5C
     call RenderActiveEntitySprite                 ; $5CA3: $CD $77 $3C
     call GetEntityTransitionCountdown             ; $5CA6: $CD $05 $0C
     jp   z, label_003_5CD6                        ; $5CA9: $CA $D6 $5C
@@ -3454,7 +3465,7 @@ jr_003_5C99:
     dec  a                                        ; $5CB3: $3D
     ld   e, a                                     ; $5CB4: $5F
     ld   d, b                                     ; $5CB5: $50
-    ld   hl, Data_003_5C84                        ; $5CB6: $21 $84 $5C
+    ld   hl, KeyCollectDialogTable                ; $5CB6: $21 $84 $5C
     add  hl, de                                   ; $5CB9: $19
     ld   a, [hl]                                  ; $5CBA: $7E
     call OpenDialog                               ; $5CBB: $CD $85 $23
@@ -3475,7 +3486,7 @@ jr_003_5CCD:
     jp   UnloadEntityAndReturn                    ; $5CD0: $C3 $8D $3F
 
 jr_003_5CD3:
-    jp   func_003_5A17                            ; $5CD3: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5CD3: $C3 $17 $5A
 
 label_003_5CD6:
     call func_003_7F78                            ; $5CD6: $CD $78 $7F
@@ -3491,7 +3502,9 @@ label_003_5CD6:
 jr_003_5CE7:
     jp   func_003_60B3                            ; $5CE7: $C3 $B3 $60
 
-func_003_5CEA::
+CheckForEntityFallingDownQuicksandHole::
+    ; This is called from the bomb code as well.
+    ; Checks if the entity is at the center of the quicksand room and makes it drop.
     ld   a, [wIsIndoor]                           ; $5CEA: $FA $A5 $DB
     and  a                                        ; $5CED: $A7
     jr   nz, jr_003_5D34                          ; $5CEE: $20 $44
@@ -3533,7 +3546,7 @@ func_003_5CEA::
     ld   [hl], $48                                ; $5D27: $36 $48
     call GetEntityTransitionCountdown             ; $5D29: $CD $05 $0C
     ld   [hl], $2F                                ; $5D2C: $36 $2F
-    ld   a, $18                                   ; $5D2E: $3E $18
+    ld   a, JINGLE_ITEM_FALLING                   ; $5D2E: $3E $18
     ldh  [hJingle], a                             ; $5D30: $E0 $F2
     scf                                           ; $5D32: $37
     ret                                           ; $5D33: $C9
@@ -3586,7 +3599,7 @@ jr_003_5D6C:
     jp   UnloadEntityAndReturn                    ; $5D7D: $C3 $8D $3F
 
 jr_003_5D80:
-    jp   func_003_5A17                            ; $5D80: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5D80: $C3 $17 $5A
 
 Data_003_5D83::
     db   $70, $01, $72, $01, $74, $01, $76, $01, $78, $01, $7A, $01, $7C, $01, $7E, $01
@@ -3814,7 +3827,7 @@ jr_003_5EFE:
     jr   nz, jr_003_5F01                          ; $5EFF: $20 $00
 
 jr_003_5F01:
-    jp   func_003_5A17                            ; $5F01: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5F01: $C3 $17 $5A
 
 InstrumentMusicTable::
     db   MUSIC_INSTRUMENT_FULL_MOON_CELLO
@@ -3847,7 +3860,7 @@ func_003_5F0C::
     ld   [hl], $FF                                ; $5F2A: $36 $FF
 
 jr_003_5F2C:
-    jp   func_003_5A17                            ; $5F2C: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5F2C: $C3 $17 $5A
 
 Data_003_5F2F::
     db   $0A, $FA
@@ -3936,10 +3949,10 @@ jr_003_5F5F:
     pop  bc                                       ; $5FB8: $C1
 
 jr_003_5FB9:
-    jp   func_003_5A17                            ; $5FB9: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5FB9: $C3 $17 $5A
 
 func_003_5FBC::
-    jp   func_003_5A17                            ; $5FBC: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $5FBC: $C3 $17 $5A
 
 func_003_5FBF::
     ret                                           ; $5FBF: $C9
@@ -4039,7 +4052,7 @@ jr_003_604C:
     jp   UnloadEntityAndReturn                    ; $604F: $C3 $8D $3F
 
 jr_003_6052:
-    jp   func_003_5A17                            ; $6052: $C3 $17 $5A
+    jp   HoldEntityAboveLink                      ; $6052: $C3 $17 $5A
 
 Data_003_6055::
     db   $8E, $16
@@ -4769,7 +4782,7 @@ PickDroppableKey::
     cp   $7C                                      ; L4 Side-view room where the key drops
     jr   nz, jr_003_64A0                          ; $6499: $20 $05
 
-    ld   hl, $D969                                ; $649B: $21 $69 $D9
+    ld   hl, wIndoorARoomStatus + $69                                ; $649B: $21 $69 $D9
     set  4, [hl]                                  ; $649E: $CB $E6
 
 jr_003_64A0:

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -8148,7 +8148,7 @@ jr_036_71C7:
     jp   label_036_728B                           ; $71F7: $C3 $8B $72
 
 label_036_71FA:
-    ld   a, [$D879]                               ; $71FA: $FA $79 $D8
+    ld   a, [wOverworldRoomStatus + $79]                               ; $71FA: $FA $79 $D8
     and  $10                                      ; $71FD: $E6 $10
     jp   nz, label_036_7288                       ; $71FF: $C2 $88 $72
 

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -3862,7 +3862,7 @@ func_004_6689::
     ldh  a, [hMapRoom]                            ; $66AF: $F0 $F6
     ld   e, a                                     ; $66B1: $5F
     ld   d, $01                                   ; $66B2: $16 $01
-    ld   hl, $D900                                ; $66B4: $21 $00 $D9
+    ld   hl, wIndoorARoomStatus                                ; $66B4: $21 $00 $D9
     add  hl, de                                   ; $66B7: $19
     ld   a, [hl]                                  ; $66B8: $7E
     or   $10                                      ; $66B9: $F6 $10
@@ -5406,7 +5406,7 @@ func_004_6FC6::
     cp   $6C                                      ; $6FD3: $FE $6C
     jr   c, jr_004_6FE2                           ; $6FD5: $38 $0B
 
-    ld   hl, $DAA0                                ; $6FD7: $21 $A0 $DA
+    ld   hl, wIndoorBRoomStatus + $A0                                ; $6FD7: $21 $A0 $DA
     set  4, [hl]                                  ; $6FDA: $CB $E6
     ld   a, $6B                                   ; $6FDC: $3E $6B
     ldh  [hLinkPositionX], a                      ; $6FDE: $E0 $98

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -1773,7 +1773,7 @@ func_007_4C16::
     ret  nc                                       ; $4C19: $D0
 
     ld   e, $D3                                   ; $4C1A: $1E $D3
-    ld   a, [$D8FD]                               ; $4C1C: $FA $FD $D8
+    ld   a, [wOverworldRoomStatus + $FD]                               ; $4C1C: $FA $FD $D8
     and  $30                                      ; $4C1F: $E6 $30
     jr   nz, jr_007_4C45                          ; $4C21: $20 $22
 
@@ -2264,7 +2264,7 @@ func_007_4F1F::
 
     ld   a, $02                                   ; $4F2E: $3E $02
     ld   [$DB7F], a                               ; $4F30: $EA $7F $DB
-    ld   hl, $D887                                ; $4F33: $21 $87 $D8
+    ld   hl, wOverworldRoomStatus + $87                                ; $4F33: $21 $87 $D8
     set  6, [hl]                                  ; $4F36: $CB $F6
     call GetEntityTransitionCountdown             ; $4F38: $CD $05 $0C
     ld   [hl], $A0                                ; $4F3B: $36 $A0
@@ -3165,7 +3165,7 @@ TradingItemEntityHandler::
     jr   nz, jr_007_552E                          ; $5526: $20 $06
 
 jr_007_5528:
-    ld   a, [$D87B]                               ; $5528: $FA $7B $D8
+    ld   a, [wOverworldRoomStatus + $7B]                               ; $5528: $FA $7B $D8
     and  $10                                      ; $552B: $E6 $10
     ret  z                                        ; $552D: $C8
 
@@ -3879,9 +3879,9 @@ jr_007_59A1:
 
     ld   a, $02                                   ; $59A3: $3E $02
     ldh  [hJingle], a                             ; $59A5: $E0 $F2
-    ld   a, [$D87B]                               ; $59A7: $FA $7B $D8
+    ld   a, [wOverworldRoomStatus + $7B]                               ; $59A7: $FA $7B $D8
     or   $10                                      ; $59AA: $F6 $10
-    ld   [$D87B], a                               ; $59AC: $EA $7B $D8
+    ld   [wOverworldRoomStatus + $7B], a                               ; $59AC: $EA $7B $D8
     ld   a, $01                                   ; $59AF: $3E $01
     ld   [$DB7F], a                               ; $59B1: $EA $7F $DB
     ld   a, $63                                   ; $59B4: $3E $63

--- a/src/code/entities/bomb.asm
+++ b/src/code/entities/bomb.asm
@@ -29,7 +29,7 @@ jr_003_66AD:
 
 jr_003_66BF:
     call func_003_6711                            ; $66BF: $CD $11 $67
-    call func_003_5CEA                            ; $66C2: $CD $EA $5C
+    call CheckForEntityFallingDownQuicksandHole   ; $66C2: $CD $EA $5C
     call func_003_7F78                            ; $66C5: $CD $78 $7F
     call func_003_60B3                            ; $66C8: $CD $B3 $60
     ld   hl, $C300                                ; $66CB: $21 $00 $C3
@@ -42,22 +42,22 @@ jr_003_66BF:
     jr   nz, jr_003_66FA                          ; $66D9: $20 $1F
 
     ld   a, [wBButtonSlot]                        ; $66DB: $FA $00 $DB
-    cp   $02                                      ; $66DE: $FE $02
+    cp   INVENTORY_BOMBS                          ; $66DE: $FE $02
     jr   nz, jr_003_66EA                          ; $66E0: $20 $08
 
     ldh  a, [hJoypadState]                        ; $66E2: $F0 $CC
-    and  $20                                      ; $66E4: $E6 $20
+    and  J_B                                      ; $66E4: $E6 $20
     jr   nz, jr_003_66F7                          ; $66E6: $20 $0F
 
     jr   jr_003_66FA                              ; $66E8: $18 $10
 
 jr_003_66EA:
     ld   a, [wAButtonSlot]                        ; $66EA: $FA $01 $DB
-    cp   $02                                      ; $66ED: $FE $02
+    cp   INVENTORY_BOMBS                          ; $66ED: $FE $02
     jr   nz, jr_003_66FA                          ; $66EF: $20 $09
 
     ldh  a, [hJoypadState]                        ; $66F1: $F0 $CC
-    and  $10                                      ; $66F3: $E6 $10
+    and  J_A                                      ; $66F3: $E6 $10
     jr   z, jr_003_66FA                           ; $66F5: $28 $03
 
 jr_003_66F7:

--- a/src/code/entities/kid_70_73.asm
+++ b/src/code/entities/kid_70_73.asm
@@ -56,7 +56,7 @@ jr_006_6265:
     cp   $92                                      ; $6267: $FE $92
     jr   nz, jr_006_6277                          ; $6269: $20 $0C
 
-    ld   a, [$D8FD]                               ; $626B: $FA $FD $D8
+    ld   a, [wOverworldRoomStatus + $FD]                               ; $626B: $FA $FD $D8
     and  $30                                      ; $626E: $E6 $30
     jr   nz, jr_006_6277                          ; $6270: $20 $05
 
@@ -67,7 +67,7 @@ jr_006_6277:
     and  $02                                      ; $627A: $E6 $02
     jr   z, jr_006_6290                           ; $627C: $28 $12
 
-    ld   a, [$DABE]                               ; $627E: $FA $BE $DA
+    ld   a, [wIndoorBRoomStatus + $BE]                               ; $627E: $FA $BE $DA
     and  $10                                      ; $6281: $E6 $10
     jr   nz, jr_006_6290                          ; $6283: $20 $0B
 

--- a/src/code/entities/marin.asm
+++ b/src/code/entities/marin.asm
@@ -40,7 +40,7 @@ MarinEntityHandler::
     jr   jr_005_4E96                              ; $4E85: $18 $0F
 
 jr_005_4E87:
-    ld   a, [$D808]                               ; $4E87: $FA $08 $D8
+    ld   a, [wOverworldRoomStatus + $08]                               ; $4E87: $FA $08 $D8
     and  $10                                      ; $4E8A: $E6 $10
     jr   nz, jr_005_4E96                          ; $4E8C: $20 $08
 
@@ -190,11 +190,11 @@ jr_005_4F6F:
     call func_005_5506                            ; $4F6F: $CD $06 $55
     ret  nc                                       ; $4F72: $D0
 
-    ld   a, [$D808]                               ; $4F73: $FA $08 $D8
+    ld   a, [wOverworldRoomStatus + $08]                               ; $4F73: $FA $08 $D8
     and  $10                                      ; $4F76: $E6 $10
     jr   z, jr_005_4FA7                           ; $4F78: $28 $2D
 
-    ld   hl, $D892                                ; $4F7A: $21 $92 $D8
+    ld   hl, wOverworldRoomStatus + $92                                ; $4F7A: $21 $92 $D8
     ld   a, [hl]                                  ; $4F7D: $7E
     and  $40                                      ; $4F7E: $E6 $40
     jr   nz, jr_005_4F89                          ; $4F80: $20 $07
@@ -605,7 +605,7 @@ func_005_51CE::
     cp   TRADING_ITEM_PINEAPPLE                   ; $51D1: $FE $07
     jr   c, jr_005_51FB                           ; $51D3: $38 $26
 
-    ld   a, [$D8FD]                               ; $51D5: $FA $FD $D8
+    ld   a, [wOverworldRoomStatus + $FD]                               ; $51D5: $FA $FD $D8
     and  $30                                      ; $51D8: $E6 $30
     jp   nz, func_005_7B4B                        ; $51DA: $C2 $4B $7B
 

--- a/src/code/entities/owl_event.asm
+++ b/src/code/entities/owl_event.asm
@@ -5,7 +5,7 @@ OwlEventEntityHandler::
     cp   $64                        ; Ghost's gravestone
     jr   nz, jr_006_680D                          ; $67FD: $20 $0E
 
-    ld   a, [$D9E3]                               ; $67FF: $FA $E3 $D9
+    ld   a, [wIndoorARoomStatus + $E3]                               ; $67FF: $FA $E3 $D9
     and  $40                                      ; $6802: $E6 $40
     ret  z                                        ; $6804: $C8
 
@@ -72,7 +72,7 @@ jr_006_6853:
     and  $02                                      ; $685C: $E6 $02
     jp   nz, ClearEntityStatus_06                 ; $685E: $C2 $DB $65
 
-    ld   a, [$D808]                               ; $6861: $FA $08 $D8
+    ld   a, [wOverworldRoomStatus + $08]                               ; $6861: $FA $08 $D8
     and  $10                                      ; $6864: $E6 $10
     ret  z                                        ; $6866: $C8
 
@@ -89,7 +89,7 @@ jr_006_6872:
     cp   $06                        ; Wind Fish's Egg
     jr   nz, jr_006_687E                          ; $6874: $20 $08
 
-    ld   a, [$D806]                               ; $6876: $FA $06 $D8
+    ld   a, [wOverworldRoomStatus + $06]                               ; $6876: $FA $06 $D8
     and  $10                                      ; $6879: $E6 $10
     ret  z                                        ; $687B: $C8
 

--- a/src/code/entities/richard.asm
+++ b/src/code/entities/richard.asm
@@ -72,7 +72,7 @@ jr_006_4083:
     ldh  a, [hRoomStatus]                         ; $4083: $F0 $F8
     or   $10                                      ; $4085: $F6 $10
     ldh  [hRoomStatus], a                         ; $4087: $E0 $F8
-    ld   [$DAC7], a                               ; $4089: $EA $C7 $DA
+    ld   [wIndoorBRoomStatus + $C7], a                               ; $4089: $EA $C7 $DA
     call_open_dialog $13A                         ; $408C
     ld   a, [wDB55]                               ; $4091: $FA $55 $DB
     cp   $02                                      ; $4094: $FE $02

--- a/src/code/entities/telephone.asm
+++ b/src/code/entities/telephone.asm
@@ -27,7 +27,7 @@ TelephoneEntityHandler::
 
 jr_006_6AA9:
     ld   e, $41                                   ; $6AA9: $1E $41
-    ld   a, [$DAA9]                               ; $6AAB: $FA $A9 $DA
+    ld   a, [wIndoorBRoomStatus + $A9]                               ; $6AAB: $FA $A9 $DA
     and  $20                                      ; $6AAE: $E6 $20
     jp   z, label_006_6BAD                        ; $6AB0: $CA $AD $6B
 
@@ -108,7 +108,7 @@ jr_006_6B09:
     jr   z, jr_006_6B3F                           ; $6B34: $28 $09
 
     ld   e, $4B                                   ; $6B36: $1E $4B
-    ld   a, [$D9E3]                               ; $6B38: $FA $E3 $D9
+    ld   a, [wIndoorARoomStatus + $E3]                               ; $6B38: $FA $E3 $D9
     and  $40                                      ; $6B3B: $E6 $40
     jr   z, label_006_6BAD                        ; $6B3D: $28 $6E
 
@@ -153,7 +153,7 @@ jr_006_6B6E:
 
 jr_006_6B7C:
     ld   e, $4F                                   ; $6B7C: $1E $4F
-    ld   a, [$D810]                               ; $6B7E: $FA $10 $D8
+    ld   a, [wOverworldRoomStatus + $10]                               ; $6B7E: $FA $10 $D8
     and  $30                                      ; $6B81: $E6 $30
     jr   z, label_006_6BAD                        ; $6B83: $28 $28
 
@@ -163,12 +163,12 @@ jr_006_6B7C:
     jr   z, label_006_6BB3                        ; $6B8C: $28 $25
 
     ld   e, $42                                   ; $6B8E: $1E $42
-    ld   a, [$D806]                               ; $6B90: $FA $06 $D8
+    ld   a, [wOverworldRoomStatus + $06]                               ; $6B90: $FA $06 $D8
     and  $30                                      ; $6B93: $E6 $30
     jr   z, label_006_6BB3                        ; $6B95: $28 $1C
 
     ld   e, $43                                   ; $6B97: $1E $43
-    ld   a, [$DA74]                               ; $6B99: $FA $74 $DA
+    ld   a, [wIndoorBRoomStatus + $74]                               ; $6B99: $FA $74 $DA
     and  $40                                      ; $6B9C: $E6 $40
     jr   z, label_006_6BB3                        ; $6B9E: $28 $13
 
@@ -190,6 +190,6 @@ label_006_6BB3:
     call OpenDialogInTable2                       ; $6BB4: $CD $7C $23
 
 jr_006_6BB7:
-    ld   hl, $DAA9                                ; $6BB7: $21 $A9 $DA
+    ld   hl, wIndoorBRoomStatus + $A9                                ; $6BB7: $21 $A9 $DA
     set  5, [hl]                                  ; $6BBA: $CB $EE
     ret                                           ; $6BBC: $C9

--- a/src/code/events.asm
+++ b/src/code/events.asm
@@ -202,7 +202,7 @@ jr_002_5E2E:
     ld   d, $00                                   ; $5E47: $16 $00
     ldh  a, [hMapRoom]                           ; $5E49: $F0 $F6
     ld   e, a                                     ; $5E4B: $5F
-    ld   hl, $D900                                ; $5E4C: $21 $00 $D9
+    ld   hl, wIndoorARoomStatus                                ; $5E4C: $21 $00 $D9
     ldh  a, [hMapId]                         ; $5E4F: $F0 $F7
     cp   MAP_COLOR_DUNGEON                                      ; $5E51: $FE $FF
     jr   nz, jr_002_5E5A                          ; $5E53: $20 $05
@@ -459,11 +459,11 @@ CheckKillSidescrollBossTrigger::
     cp   MAP_EAGLES_TOWER                         ; $5FC8: $FE $06
     jr   nz, jr_002_5FD1                          ; $5FCA: $20 $05
 
-    ld   a, [$DAE8]                               ; $5FCC: $FA $E8 $DA
+    ld   a, [wIndoorBRoomStatus + $E8]                               ; $5FCC: $FA $E8 $DA
     jr   jr_002_5FD4                              ; $5FCF: $18 $03
 
 jr_002_5FD1:
-    ld   a, [$D9FF]                               ; $5FD1: $FA $FF $D9
+    ld   a, [wIndoorARoomStatus + $FF]                               ; $5FD1: $FA $FF $D9
 
 jr_002_5FD4:
     and  $20                                      ; $5FD4: $E6 $20


### PR DESCRIPTION
…addresses with the name that defines the start of this memory.

The code quite often looks into room flags of other rooms for special conditions, this makes it easier to spot those checks.

Also annotated a few other things in the dropped key code.