### PR TITLE
CI: use rgbds v0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: kemenaran/rgbds:0.3.10
+      - image: kemenaran/rgbds:0.4.0
     steps:
       - checkout
       - run:

--- a/.circleci/images/rgbds/Dockerfile
+++ b/.circleci/images/rgbds/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y build-essential byacc flex pkg-config libpng-dev
 # Retrieve rgbds
 RUN git clone https://github.com/rednex/rgbds.git && \
   cd rgbds && \
-  git fetch --tags && git checkout v0.3.8
+  git fetch --tags && git checkout v0.4.0
 
 # Build rgbds
 RUN cd rgbds && make install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MD5 - 07C211479386825042EFB4AD31BB525F
 
 ## Usage
 
-1. Install [rgbds](https://github.com/rednex/rgbds#1-installing-rgbds) (version >= 0.3.10 required).
+1. Install [rgbds](https://github.com/rednex/rgbds#1-installing-rgbds) (version >= 0.4.0 required).
 2. `make all`
 
 ## How to contribute


### PR DESCRIPTION
Nesting sections in ifdef requires rgbds 0.4.0 – and it is useful for the different localizations (cc @marijnvdwerf).

