### PR TITLE
Improve Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Building
-          command: make build
+          command: make build-all
       - run:
           name: Testing checksum
-          command: make test
+          command: make test-all

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ default: build test
 asm_files = $(shell find src     -type f -name '*.asm')
 gfx_files = $(shell find src/gfx -type f -name '*.png')
 bin_files = $(shell find src     -type f -name '*.bin')
-
+# Add files from the different revisions
+# FIXME: add these files only when building the relevant targets
 asm_files += $(shell find revisions -type f -name '*.asm')
 gfx_files += $(shell find revisions -type f -name '*.png')
 
@@ -36,9 +37,7 @@ deps = $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
 # Then we link them to create a playable image.
 # This also spits out game.sym, which lets you use labels in bgb.
 
-
 src/main.o: $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
-
 
 #
 # Japanese

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,6 @@ gfx_files += $(shell find revisions -type f -name '*.png')
 
 deps = $(asm_files) $(gfx_files:.png=.2bpp)
 
-# Then we link them to create a playable image.
-# This also spits out game.sym, which lets you use labels in bgb.
-
-src/main.o: $(asm_files) $(gfx_files:.png=.2bpp)
-
 #
 # Japanese
 #

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
 .POSIX:
 
-2BPP   := rgbgfx
-ASM    := rgbasm -E
-LINKER := rgblink
-FIXER  := rgbfix \
+#
+# Dev tools binaries and options
+#
+2BPP    := rgbgfx
+
+ASM     := rgbasm
+ASFLAGS := --export-all
+
+LD      := rgblink
+LDFLAGS :=
+
+FX      := rgbfix
+FXFLAGS := \
   --color-compatible \
   --sgb-compatible \
   --ram-size 0x03 \
@@ -46,26 +55,26 @@ src/main.o: $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
 games += azlj.gbc
 j0_obj = src/main.azlj.o
 src/main.azlj.o: src/main.asm $(deps)
-	$(ASM) -DLANG=JP -DVERSION=0 -i revisions/J0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=JP -DVERSION=0 -i revisions/J0/src/ -i src/ -o $@ $<
 azlj.gbc: $(j0_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 0 --title "ZELDA" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 0 --title "ZELDA" $@
 
 games += azlj-r1.gbc
 j1_obj = src/main.azlj-1.o
 src/main.azlj-1.o: src/main.asm $(deps)
-	$(ASM) -DLANG=JP -DVERSION=1 -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=JP -DVERSION=1 -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r1.gbc: $(j1_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 1 --title "ZELDA" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 1 --title "ZELDA" $@
 
 games += azlj-r2.gbc
 j2_obj = src/main.azlj-2.o
 src/main.azlj-2.o: src/main.asm $(deps)
-	$(ASM) -DLANG=JP -DVERSION=2 -i revisions/J2/src/ -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=JP -DVERSION=2 -i revisions/J2/src/ -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r2.gbc: $(j2_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 2 --title "ZELDA" --game-id "AZLJ" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 2 --title "ZELDA" --game-id "AZLJ" $@
 
 #
 # German
@@ -74,18 +83,18 @@ azlj-r2.gbc: $(j2_obj)
 games += azlg.gbc
 g0_obj = src/main.azlg.o
 src/main.azlg.o: src/main.asm $(deps)
-	$(ASM) -DLANG=DE -DVERSION=0 -i revisions/G0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=DE -DVERSION=0 -i revisions/G0/src/ -i src/ -o $@ $<
 azlg.gbc: $(g0_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 0 --non-japanese --title "ZELDA" $@
 
 games += azlg-r1.gbc
 g1_obj = src/main.azlg-1.o
 src/main.azlg-1.o: src/main.asm $(deps)
-	$(ASM) -DLANG=DE -DVERSION=1 -i revisions/G1/src/ -i revisions/G0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=DE -DVERSION=1 -i revisions/G1/src/ -i revisions/G0/src/ -i src/ -o $@ $<
 azlg-r1.gbc: $(g1_obj) azlj-r2.gbc
-	$(LINKER) -O "azlj-r2.gbc" -n $*.sym -o $@ $<
-	$(FIXER) --rom-version 1 -j --title "ZELDA" --game-id "AZLD" $@
+	$(LD) $(LDFLAGS) -O "azlj-r2.gbc" -n $*.sym -o $@ $<
+	$(FX) $(FXFLAGS) --rom-version 1 --non-japanese --title "ZELDA" --game-id "AZLD" $@
 
 #
 # French
@@ -94,18 +103,18 @@ azlg-r1.gbc: $(g1_obj) azlj-r2.gbc
 games += azlf.gbc
 f0_obj = src/main.azlf.o
 src/main.azlf.o: src/main.asm $(deps)
-	$(ASM) -DLANG=FR -DVERSION=0 -i revisions/F0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=FR -DVERSION=0 -i revisions/F0/src/ -i src/ -o $@ $<
 azlf.gbc: $(f0_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 0 --non-japanese --title "ZELDA" $@
 
 games += azlf-r1.gbc
 f1_obj = src/main.azlf-1.o
 src/main.azlf-1.o: src/main.asm $(deps)
-	$(ASM) -DLANG=FR -DVERSION=1 -i revisions/F1/src/ -i revisions/F0/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=FR -DVERSION=1 -i revisions/F1/src/ -i revisions/F0/src/ -i src/ -o $@ $<
 azlf-r1.gbc: $(f1_obj) azlg-r1.gbc
-	$(LINKER) -O "azlg-r1.gbc" -n $*.sym -o $@ $<
-	$(FIXER) --rom-version 1 -j --title "ZELDA" --game-id "AZLF" $@
+	$(LD) $(LDFLAGS) -O "azlg-r1.gbc" -n $*.sym -o $@ $<
+	$(FX) $(FXFLAGS) --rom-version 1 --non-japanese --title "ZELDA" --game-id "AZLF" $@
 
 #
 # English
@@ -114,26 +123,26 @@ azlf-r1.gbc: $(f1_obj) azlg-r1.gbc
 games += azle.gbc
 e0_obj = src/main.azle.o
 src/main.azle.o: src/main.asm $(deps)
-	$(ASM) -DLANG=EN -DVERSION=0 -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=EN -DVERSION=0 -i src/ -o $@ $<
 azle.gbc: $(e0_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 0 --non-japanese --title "ZELDA" $@
 
 games += azle-r1.gbc
 e1_obj = src/main.azle-1.o
 src/main.azle-1.o: src/main.asm $(deps)
-	$(ASM) -DLANG=EN -DVERSION=1 -i revisions/E1/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=EN -DVERSION=1 -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r1.gbc: $(e1_obj)
-	$(LINKER) -n $*.sym -o $@ $^
-	$(FIXER) --rom-version 1 -j --title "ZELDA" $@
+	$(LD) $(LDFLAGS) -n $*.sym -o $@ $^
+	$(FX) $(FXFLAGS) --rom-version 1 --non-japanese --title "ZELDA" $@
 
 games += azle-r2.gbc
 e2_obj = src/main.azle-2.o
 src/main.azle-2.o: src/main.asm $(deps)
-	$(ASM) -DLANG=EN -DVERSION=2 -i revisions/E2/src/ -i revisions/E1/src/ -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) -DLANG=EN -DVERSION=2 -i revisions/E2/src/ -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r2.gbc: $(e2_obj) azlf-r1.gbc
-	$(LINKER) -O "azlf-r1.gbc" -n $*.sym -o $@ $<
-	$(FIXER) --rom-version 2 -j --title "ZELDA" --game-id "AZLE" $@
+	$(LD) $(LDFLAGS) -O "azlf-r1.gbc" -n $*.sym -o $@ $<
+	$(FX) $(FXFLAGS) --rom-version 2 --non-japanese --title "ZELDA" --game-id "AZLE" $@
 
 #
 # General rules

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,6 @@ all: build test
 test: build
 	@tools/md5sum.sh -c ladx.md5
 
-clean:
-	rm -f $(obj)
-	rm -f game.{gbc,sym,map}
-	find . -iname '*.2bpp' -exec rm {} +
 
 # Objects are assembled from source.
 # src/main.o is built from src/main.asm.
@@ -136,3 +132,11 @@ azle-r2.gbc: $(e2_obj) azlf-r1.gbc
 	rgbfix  -c -n 2 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -i "AZLE" -v $@
 
 build: $(games)
+
+clean:
+	rm -f $(obj)
+	rm -f $(games)
+	rm -f $(games:.gbc=.o)
+	rm -f $(games:.gbc=.map)
+	rm -f $(games:.gbc=.sym)
+	find . -iname '*.2bpp' -exec rm {} +

--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,5 @@ clean:
 	rm -f $(games:.gbc=.map)
 	rm -f $(games:.gbc=.sym)
 	find . -iname '*.2bpp' -exec rm {} +
+
+.PHONY: default build build-all test test-all all clean

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 2BPP   := rgbgfx
 ASM    := rgbasm -E
+LINKER := rgblink
+FIXER  := rgbfix -c -r 0x03 -s -l 0x33 -k "01" -m 0x1B -p 0xFF
 
 .SUFFIXES: .asm .o .gbc .png .2bpp
 
@@ -41,24 +43,24 @@ j0_obj = src/main.azlj.o
 src/main.azlj.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=0 -i revisions/J0/src/ -i src/ -o $@ $<
 azlj.gbc: $(j0_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 0 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -p 0xFF -t "ZELDA" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 0 -t "ZELDA" -v $@
 
 games += azlj-r1.gbc
 j1_obj = src/main.azlj-1.o
 src/main.azlj-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=1 -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r1.gbc: $(j1_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 1 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -p 0xFF -t "ZELDA" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 1 -t "ZELDA" -v $@
 
 games += azlj-r2.gbc
 j2_obj = src/main.azlj-2.o
 src/main.azlj-2.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=2 -i revisions/J2/src/ -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r2.gbc: $(j2_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 2 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -p 0xFF -t "ZELDA" -i "AZLJ" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 2 -t "ZELDA" -i "AZLJ" -v $@
 
 #
 # German
@@ -69,16 +71,16 @@ g0_obj = src/main.azlg.o
 src/main.azlg.o: src/main.asm $(deps)
 	$(ASM) -DLANG=DE -DVERSION=0 -i revisions/G0/src/ -i src/ -o $@ $<
 azlg.gbc: $(g0_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 0 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 0 -j -t "ZELDA" -v $@
 
 games += azlg-r1.gbc
 g1_obj = src/main.azlg-1.o
 src/main.azlg-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=DE -DVERSION=1 -i revisions/G1/src/ -i revisions/G0/src/ -i src/ -o $@ $<
 azlg-r1.gbc: $(g1_obj) azlj-r2.gbc
-	rgblink -O "azlj-r2.gbc" -n $*.sym -m $*.map -o $@ $<
-	rgbfix  -c -n 1 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -i "AZLD" -v $@
+	$(LINKER) -O "azlj-r2.gbc" -n $*.sym -m $*.map -o $@ $<
+	$(FIXER) -n 1 -j -t "ZELDA" -i "AZLD" -v $@
 
 #
 # French
@@ -89,16 +91,16 @@ f0_obj = src/main.azlf.o
 src/main.azlf.o: src/main.asm $(deps)
 	$(ASM) -DLANG=FR -DVERSION=0 -i revisions/F0/src/ -i src/ -o $@ $<
 azlf.gbc: $(f0_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 0 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 0 -j -t "ZELDA" -v $@
 
 games += azlf-r1.gbc
 f1_obj = src/main.azlf-1.o
 src/main.azlf-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=FR -DVERSION=1 -i revisions/F1/src/ -i revisions/F0/src/ -i src/ -o $@ $<
 azlf-r1.gbc: $(f1_obj) azlg-r1.gbc
-	rgblink -O "azlg-r1.gbc" -n $*.sym -m $*.map -o $@ $<
-	rgbfix  -c -n 1 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -i "AZLF" -v $@
+	$(LINKER) -O "azlg-r1.gbc" -n $*.sym -m $*.map -o $@ $<
+	$(FIXER) -n 1 -j -t "ZELDA" -i "AZLF" -v $@
 
 #
 # English
@@ -109,24 +111,24 @@ e0_obj = src/main.azle.o
 src/main.azle.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=0 -i src/ -o $@ $<
 azle.gbc: $(e0_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 0 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 0 -j -t "ZELDA" -v $@
 
 games += azle-r1.gbc
 e1_obj = src/main.azle-1.o
 src/main.azle-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=1 -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r1.gbc: $(e1_obj)
-	rgblink -n $*.sym -m $*.map -o $@ $^
-	rgbfix  -c -n 1 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -v $@
+	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(FIXER) -n 1 -j -t "ZELDA" -v $@
 
 games += azle-r2.gbc
 e2_obj = src/main.azle-2.o
 src/main.azle-2.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=2 -i revisions/E2/src/ -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r2.gbc: $(e2_obj) azlf-r1.gbc
-	rgblink -O "azlf-r1.gbc" -n $*.sym -m $*.map -o $@ $<
-	rgbfix  -c -n 2 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -i "AZLE" -v $@
+	$(LINKER) -O "azlf-r1.gbc" -n $*.sym -m $*.map -o $@ $<
+	$(FIXER) -n 2 -j -t "ZELDA" -i "AZLE" -v $@
 
 #
 # General rules

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ default: build test
 # src/main.o is built from src/main.asm.
 asm_files = $(shell find src     -type f -name '*.asm')
 gfx_files = $(shell find src/gfx -type f -name '*.png')
-bin_files = $(shell find src     -type f -name '*.bin')
 # Add files from the different revisions
 # FIXME: add these files only when building the relevant targets
 asm_files += $(shell find revisions -type f -name '*.asm')
@@ -41,12 +40,12 @@ gfx_files += $(shell find revisions -type f -name '*.png')
 %.2bpp: %.png
 	$(2BPP) -o $@ $<
 
-deps = $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
+deps = $(asm_files) $(gfx_files:.png=.2bpp)
 
 # Then we link them to create a playable image.
 # This also spits out game.sym, which lets you use labels in bgb.
 
-src/main.o: $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
+src/main.o: $(asm_files) $(gfx_files:.png=.2bpp)
 
 #
 # Japanese

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,9 @@ ASM    := rgbasm -E
 
 .SUFFIXES: .asm .o .gbc .png .2bpp
 
-# Default target
-all: build test
-
-test: build
-	@tools/md5sum.sh -c ladx.md5
-
+# Default target: build and test only the US 1.0 revision.
+# (Use `make all` to build and test all targets)
+default: build test
 
 # Objects are assembled from source.
 # src/main.o is built from src/main.asm.
@@ -131,7 +128,25 @@ azle-r2.gbc: $(e2_obj) azlf-r1.gbc
 	rgblink -O "azlf-r1.gbc" -n $*.sym -m $*.map -o $@ $<
 	rgbfix  -c -n 2 -r 0x03 -s -l 0x33 -k "01" -m 0x1B -j -p 0xFF -t "ZELDA" -i "AZLE" -v $@
 
-build: $(games)
+#
+# General rules
+#
+
+# By default, build the US 1.0 revision.
+build: azle.gbc
+
+# Build all revisions.
+build-all: $(games)
+
+# Test the default revision.
+test: build
+	@tools/md5sum.sh -c ladx.md5
+
+# Test all revisions.
+test-all: build-all
+	@tools/md5sum.sh -c ladx.md5
+
+all: build-all test-all
 
 clean:
 	rm -f $(obj)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,15 @@
 2BPP   := rgbgfx
 ASM    := rgbasm -E
 LINKER := rgblink
-FIXER  := rgbfix -c -r 0x03 -s -l 0x33 -k "01" -m 0x1B -p 0xFF
+FIXER  := rgbfix \
+  --color-compatible \
+  --sgb-compatible \
+  --ram-size 0x03 \
+  --old-licensee 0x33 \
+  --new-licensee "01" \
+  --mbc-type 0x1B \
+  --pad-value 0xFF \
+  --validate
 
 .SUFFIXES: .asm .o .gbc .png .2bpp
 
@@ -44,7 +52,7 @@ src/main.azlj.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=0 -i revisions/J0/src/ -i src/ -o $@ $<
 azlj.gbc: $(j0_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 0 -t "ZELDA" -v $@
+	$(FIXER) --rom-version 0 --title "ZELDA" $@
 
 games += azlj-r1.gbc
 j1_obj = src/main.azlj-1.o
@@ -52,7 +60,7 @@ src/main.azlj-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=1 -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r1.gbc: $(j1_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 1 -t "ZELDA" -v $@
+	$(FIXER) --rom-version 1 --title "ZELDA" $@
 
 games += azlj-r2.gbc
 j2_obj = src/main.azlj-2.o
@@ -60,7 +68,7 @@ src/main.azlj-2.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=2 -i revisions/J2/src/ -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r2.gbc: $(j2_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 2 -t "ZELDA" -i "AZLJ" -v $@
+	$(FIXER) --rom-version 2 --title "ZELDA" --game-id "AZLJ" $@
 
 #
 # German
@@ -72,7 +80,7 @@ src/main.azlg.o: src/main.asm $(deps)
 	$(ASM) -DLANG=DE -DVERSION=0 -i revisions/G0/src/ -i src/ -o $@ $<
 azlg.gbc: $(g0_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 0 -j -t "ZELDA" -v $@
+	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
 
 games += azlg-r1.gbc
 g1_obj = src/main.azlg-1.o
@@ -80,7 +88,7 @@ src/main.azlg-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=DE -DVERSION=1 -i revisions/G1/src/ -i revisions/G0/src/ -i src/ -o $@ $<
 azlg-r1.gbc: $(g1_obj) azlj-r2.gbc
 	$(LINKER) -O "azlj-r2.gbc" -n $*.sym -m $*.map -o $@ $<
-	$(FIXER) -n 1 -j -t "ZELDA" -i "AZLD" -v $@
+	$(FIXER) --rom-version 1 -j --title "ZELDA" --game-id "AZLD" $@
 
 #
 # French
@@ -92,7 +100,7 @@ src/main.azlf.o: src/main.asm $(deps)
 	$(ASM) -DLANG=FR -DVERSION=0 -i revisions/F0/src/ -i src/ -o $@ $<
 azlf.gbc: $(f0_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 0 -j -t "ZELDA" -v $@
+	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
 
 games += azlf-r1.gbc
 f1_obj = src/main.azlf-1.o
@@ -100,7 +108,7 @@ src/main.azlf-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=FR -DVERSION=1 -i revisions/F1/src/ -i revisions/F0/src/ -i src/ -o $@ $<
 azlf-r1.gbc: $(f1_obj) azlg-r1.gbc
 	$(LINKER) -O "azlg-r1.gbc" -n $*.sym -m $*.map -o $@ $<
-	$(FIXER) -n 1 -j -t "ZELDA" -i "AZLF" -v $@
+	$(FIXER) --rom-version 1 -j --title "ZELDA" --game-id "AZLF" $@
 
 #
 # English
@@ -112,7 +120,7 @@ src/main.azle.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=0 -i src/ -o $@ $<
 azle.gbc: $(e0_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 0 -j -t "ZELDA" -v $@
+	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
 
 games += azle-r1.gbc
 e1_obj = src/main.azle-1.o
@@ -120,7 +128,7 @@ src/main.azle-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=1 -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r1.gbc: $(e1_obj)
 	$(LINKER) -n $*.sym -m $*.map -o $@ $^
-	$(FIXER) -n 1 -j -t "ZELDA" -v $@
+	$(FIXER) --rom-version 1 -j --title "ZELDA" $@
 
 games += azle-r2.gbc
 e2_obj = src/main.azle-2.o
@@ -128,7 +136,7 @@ src/main.azle-2.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=2 -i revisions/E2/src/ -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r2.gbc: $(e2_obj) azlf-r1.gbc
 	$(LINKER) -O "azlf-r1.gbc" -n $*.sym -m $*.map -o $@ $<
-	$(FIXER) -n 2 -j -t "ZELDA" -i "AZLE" -v $@
+	$(FIXER) --rom-version 2 -j --title "ZELDA" --game-id "AZLE" $@
 
 #
 # General rules

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ FIXER  := rgbfix \
 .SUFFIXES: .asm .o .gbc .png .2bpp
 
 # Default target: build and test only the US 1.0 revision.
-# (Use `make all` to build and test all targets)
+# (Use `make all` to build and test all targets.)
 default: build test
 
 # Objects are assembled from source.
@@ -35,8 +35,6 @@ deps = $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
 
 # Then we link them to create a playable image.
 # This also spits out game.sym, which lets you use labels in bgb.
-# Generating a mapfile is required thanks to a bug in rgblink.
-
 
 
 src/main.o: $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
@@ -51,7 +49,7 @@ j0_obj = src/main.azlj.o
 src/main.azlj.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=0 -i revisions/J0/src/ -i src/ -o $@ $<
 azlj.gbc: $(j0_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 0 --title "ZELDA" $@
 
 games += azlj-r1.gbc
@@ -59,7 +57,7 @@ j1_obj = src/main.azlj-1.o
 src/main.azlj-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=1 -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r1.gbc: $(j1_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 1 --title "ZELDA" $@
 
 games += azlj-r2.gbc
@@ -67,7 +65,7 @@ j2_obj = src/main.azlj-2.o
 src/main.azlj-2.o: src/main.asm $(deps)
 	$(ASM) -DLANG=JP -DVERSION=2 -i revisions/J2/src/ -i revisions/J1/src/ -i revisions/J0/src/ -i src/ -o $@ $<
 azlj-r2.gbc: $(j2_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 2 --title "ZELDA" --game-id "AZLJ" $@
 
 #
@@ -79,7 +77,7 @@ g0_obj = src/main.azlg.o
 src/main.azlg.o: src/main.asm $(deps)
 	$(ASM) -DLANG=DE -DVERSION=0 -i revisions/G0/src/ -i src/ -o $@ $<
 azlg.gbc: $(g0_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
 
 games += azlg-r1.gbc
@@ -87,7 +85,7 @@ g1_obj = src/main.azlg-1.o
 src/main.azlg-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=DE -DVERSION=1 -i revisions/G1/src/ -i revisions/G0/src/ -i src/ -o $@ $<
 azlg-r1.gbc: $(g1_obj) azlj-r2.gbc
-	$(LINKER) -O "azlj-r2.gbc" -n $*.sym -m $*.map -o $@ $<
+	$(LINKER) -O "azlj-r2.gbc" -n $*.sym -o $@ $<
 	$(FIXER) --rom-version 1 -j --title "ZELDA" --game-id "AZLD" $@
 
 #
@@ -99,7 +97,7 @@ f0_obj = src/main.azlf.o
 src/main.azlf.o: src/main.asm $(deps)
 	$(ASM) -DLANG=FR -DVERSION=0 -i revisions/F0/src/ -i src/ -o $@ $<
 azlf.gbc: $(f0_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
 
 games += azlf-r1.gbc
@@ -107,7 +105,7 @@ f1_obj = src/main.azlf-1.o
 src/main.azlf-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=FR -DVERSION=1 -i revisions/F1/src/ -i revisions/F0/src/ -i src/ -o $@ $<
 azlf-r1.gbc: $(f1_obj) azlg-r1.gbc
-	$(LINKER) -O "azlg-r1.gbc" -n $*.sym -m $*.map -o $@ $<
+	$(LINKER) -O "azlg-r1.gbc" -n $*.sym -o $@ $<
 	$(FIXER) --rom-version 1 -j --title "ZELDA" --game-id "AZLF" $@
 
 #
@@ -119,7 +117,7 @@ e0_obj = src/main.azle.o
 src/main.azle.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=0 -i src/ -o $@ $<
 azle.gbc: $(e0_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 0 -j --title "ZELDA" $@
 
 games += azle-r1.gbc
@@ -127,7 +125,7 @@ e1_obj = src/main.azle-1.o
 src/main.azle-1.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=1 -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r1.gbc: $(e1_obj)
-	$(LINKER) -n $*.sym -m $*.map -o $@ $^
+	$(LINKER) -n $*.sym -o $@ $^
 	$(FIXER) --rom-version 1 -j --title "ZELDA" $@
 
 games += azle-r2.gbc
@@ -135,7 +133,7 @@ e2_obj = src/main.azle-2.o
 src/main.azle-2.o: src/main.asm $(deps)
 	$(ASM) -DLANG=EN -DVERSION=2 -i revisions/E2/src/ -i revisions/E1/src/ -i src/ -o $@ $<
 azle-r2.gbc: $(e2_obj) azlf-r1.gbc
-	$(LINKER) -O "azlf-r1.gbc" -n $*.sym -m $*.map -o $@ $<
+	$(LINKER) -O "azlf-r1.gbc" -n $*.sym -o $@ $<
 	$(FIXER) --rom-version 2 -j --title "ZELDA" --game-id "AZLE" $@
 
 #


### PR DESCRIPTION
- `make clean`: clean files from all revisions
- Build and test only the US 1.0 version by default
- Specify phony rules
- Regroup arguments for rgblink and rgbfix
- Expand out rgbfix arguments
- Remove the requirement to build a `.map` file
- Add a FIXME to slim the target files later

@marijnvdwerf what do you think?
