### PR TITLE
audio_macros.asm: Add "Assertions"

### DIFF
--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -106,7 +106,7 @@ endm
 ; Play a note. Can pass multiple notes to this.
 note: macro
     REPT _NARG
-        if \1 < $2 || \1 > $90 || (\1 % 2) != 0
+        if \1 < $2 || \1 > $90
             fail "note: Invalid note value \1"
         endc
         db \1

--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -75,12 +75,8 @@ endm
 ;
 ; The opcode's 3 bytes are written to D3x6, D3x7, D3x8 (x = channel number).
 set_envelope_duty: macro
-    if \3 >= 4
-        fail "set_envelope_duty: Invalid duty cycle value \3"
-    endc
-    if \4 >= $40
-        fail "set_envelope_duty: Note length must be less than 0x40, got \4"
-    endc
+    ASSERT \3 < 4, "set_envelope_duty: Invalid duty cycle value \3"
+    ASSERT \4 < $40, fail "set_envelope_duty: Note length must be less than 0x40, got \4"
     db $9d, \1, \2, ((\3<<6) | \4)
 endm
 
@@ -97,18 +93,14 @@ endm
 
 ; Sets the length of subsequent notes.
 notelen: macro
-    if \1 > $f
-        fail "notelen: Length must be less than or equal to $f, got \1"
-    endc
+    ASSERT \1 <= $f, "notelen: Length must be less than or equal to $f, got \1"
     db $a0 + \1
 endm
 
 ; Play a note. Can pass multiple notes to this.
 note: macro
     REPT _NARG
-        if \1 < $1 || (\1 > $90 && \1 < $ff)
-            fail "note: Invalid note value \1"
-        endc
+        ASSERT \1 >= $1 && \1 <= $90 || \1 == $ff, "note: Invalid note value \1"
         db \1
         SHIFT
     ENDR

--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -76,7 +76,7 @@ endm
 ; The opcode's 3 bytes are written to D3x6, D3x7, D3x8 (x = channel number).
 set_envelope_duty: macro
     ASSERT \3 < 4, "set_envelope_duty: Invalid duty cycle value \3"
-    ASSERT \4 < $40, fail "set_envelope_duty: Note length must be less than 0x40, got \4"
+    ASSERT \4 < $40, "set_envelope_duty: Note length must be less than 0x40, got \4"
     db $9d, \1, \2, ((\3<<6) | \4)
 endm
 

--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -100,7 +100,7 @@ endm
 ; Play a note. Can pass multiple notes to this.
 note: macro
     REPT _NARG
-        ASSERT \1 >= $1 && \1 <= $90 || \1 == $ff, "note: Invalid note value \1"
+        ASSERT (\1 >= $1 && \1 <= $90) || \1 == $ff, "note: Invalid note value \1"
         db \1
         SHIFT
     ENDR

--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -106,7 +106,7 @@ endm
 ; Play a note. Can pass multiple notes to this.
 note: macro
     REPT _NARG
-        if \1 < $1 || \1 > $90
+        if \1 < $1 || (\1 > $90 && \1 < $ff)
             fail "note: Invalid note value \1"
         endc
         db \1

--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -75,9 +75,12 @@ endm
 ;
 ; The opcode's 3 bytes are written to D3x6, D3x7, D3x8 (x = channel number).
 set_envelope_duty: macro
-    ; Assertions:
-    ;   - \3 < 4
-    ;   - \4 < 0x40
+    if \3 >= 4
+        fail "set_envelope_duty: Invalid duty cycle value \3"
+    endc
+    if \4 >= $40
+        fail "set_envelope_duty: Note length must be less than 0x40, got \4"
+    endc
     db $9d, \1, \2, ((\3<<6) | \4)
 endm
 
@@ -94,14 +97,18 @@ endm
 
 ; Sets the length of subsequent notes.
 notelen: macro
-    ; If someone figures out how to "assert \1 <= $f" please add it here!
+    if \1 > $f
+        fail "notelen: Length must be less than or equal to $f, got \1"
+    endc
     db $a0 + \1
 endm
 
 ; Play a note. Can pass multiple notes to this.
 note: macro
     REPT _NARG
-        ; Desired assertion: \1 >= $02 && \1 <= $90 && (\1 % 2) == 0
+        if \1 < $2 || \1 > $90 || (\1 % 2) != 0
+            fail "note: Invalid note value \1"
+        endc
         db \1
         SHIFT
     ENDR

--- a/src/code/audio_macros.asm
+++ b/src/code/audio_macros.asm
@@ -106,7 +106,7 @@ endm
 ; Play a note. Can pass multiple notes to this.
 note: macro
     REPT _NARG
-        if \1 < $2 || \1 > $90
+        if \1 < $1 || \1 > $90
             fail "note: Invalid note value \1"
         endc
         db \1


### PR DESCRIPTION
Assembly will fail if `set_envelope_duty`, `notelen`, or `note` comes across an invalid argument.