### PR TITLE
fix: wIsLinkInTheAir should be C146 instead of C143

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ Thanks to these people for contributing:
 * Xkeeper - https://github.com/Xkeeper0
 * Vextrove - https://github.com/Vextrove
 * daid - https://github.com/daid
+* stephaneseng - https://github.com/stephaneseng

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -1931,7 +1931,7 @@ UseShield::
 
 UseShovel::
     ld   a, [$C1C7]                               ; $12F8: $FA $C7 $C1
-    ld   hl, $C146                                ; $12FB: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $12FB: $21 $46 $C1
     or   [hl]                                     ; $12FE: $B6
     ret  nz                                       ; $12FF: $C0
 
@@ -2229,11 +2229,11 @@ UseRocsFeather::
     ld   a, [$C130]                               ; $14CB: $FA $30 $C1
     cp   $07                                      ; $14CE: $FE $07
     ret  z                                        ; $14D0: $C8
-    ld   a, [$C146]                               ; $14D1: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $14D1: $FA $46 $C1
     and  a                                        ; $14D4: $A7
     ret  nz                                       ; $14D5: $C0
     ld   a, $01                                   ; $14D6: $3E $01
-    ld   [$C146], a                               ; $14D8: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $14D8: $EA $46 $C1
     xor  a                                        ; $14DB: $AF
     ld   [$C152], a                               ; $14DC: $EA $52 $C1
     ld   [$C153], a                               ; $14DF: $EA $53 $C1
@@ -2307,7 +2307,7 @@ label_1535::
     ldh  [hNoiseSfx], a                           ; $1551: $E0 $F4
 
     call func_157C                                ; $1553: $CD $7C $15
-    ld   a, [$C146]                               ; $1556: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $1556: $FA $46 $C1
     and  a                                        ; $1559: $A7
     jr   nz, label_1562                           ; $155A: $20 $06
     call ResetSpinAttack                          ; $155C: $CD $AF $0C
@@ -2605,7 +2605,7 @@ UsePegasusBoots::
     and  a                                        ; $1716: $A7
     ret  nz                                       ; $1717: $C0
     ldh  a, [hLinkPositionZ]                      ; $1718: $F0 $A2
-    ld   hl, $C146                                ; $171A: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $171A: $21 $46 $C1
     or   [hl]                                     ; $171D: $B6
     ret  nz                                       ; $171E: $C0
     ld   a, [wConsecutiveStepsCount]              ; $171F: $FA $20 $C1
@@ -2643,7 +2643,7 @@ func_1756::
     or   [hl]                                     ; $175D: $B6
     ld   hl, hLinkInteractiveMotionBlocked        ; $175E: $21 $A1 $FF
     or   [hl]                                     ; $1761: $B6
-    ld   hl, $C146                                ; $1762: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $1762: $21 $46 $C1
     or   [hl]                                     ; $1765: $B6
     ret  nz                                       ; $1766: $C0
 

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -36,7 +36,7 @@ SpawnChestWithItem::
     ret                                           ; $41FB: $C9
 
 UseOcarina::
-    ld   hl, $C146                                ; $41FC: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $41FC: $21 $46 $C1
     ld   a, [wLinkPlayingOcarinaCountdown]        ; $41FF: $FA $66 $C1
     or   [hl]                                     ; $4202: $B6
     ld   hl, $C1A4                                ; $4203: $21 $A4 $C1
@@ -99,7 +99,7 @@ IF __PATCH_0__
     ret  nz
 ENDC
 
-    ld   a, [$C146]                               ; $4254: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4254: $FA $46 $C1
     and  a                                        ; $4257: $A7
 IF __PATCH_0__
     ret  nz
@@ -414,7 +414,7 @@ jr_002_43F4:
     call ResetSpinAttack                          ; $43FF: $CD $AF $0C
 
 jr_002_4402:
-    ld   a, [$C146]                               ; $4402: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4402: $FA $46 $C1
     and  a                                        ; $4405: $A7
 IF __PATCH_0__
     jr   nz, label_002_4464
@@ -506,7 +506,7 @@ label_002_4464:
     cp   ENTITY_ROOSTER                           ; $4477: $FE $D5
     jr   nz, jr_002_4481                          ; $4479: $20 $06
 
-    ld   a, [$C146]                               ; $447B: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $447B: $FA $46 $C1
     and  a                                        ; $447E: $A7
     jr   nz, jr_002_44A2                          ; $447F: $20 $21
 
@@ -592,7 +592,7 @@ Data_002_44E7::
     db   $00, $F0, $10, $00, $FF, $01
 
 func_002_44ED::
-    ld   a, [$C146]                               ; $44ED: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $44ED: $FA $46 $C1
     and  a                                        ; $44F0: $A7
     jp   z, groundVfxEnd                        ; $44F1: $CA $AC $45
 
@@ -687,7 +687,7 @@ jr_002_456C:
     ldh  [hLinkPositionZ], a                      ; $456F: $E0 $A2
     ld   [$C149], a                               ; $4571: $EA $49 $C1
     ldh  [$FFA3], a                               ; $4574: $E0 $A3
-    ld   [$C146], a                               ; $4576: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $4576: $EA $46 $C1
     ld   [$C152], a                               ; $4579: $EA $52 $C1
     ld   [$C153], a                               ; $457C: $EA $53 $C1
     ld   [wC10A], a                               ; $457F: $EA $0A $C1
@@ -884,7 +884,7 @@ func_002_478C::
     ret                                           ; $47A2: $C9
 
 jr_002_47A3:
-    ld   a, [$C146]                               ; $47A3: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $47A3: $FA $46 $C1
     cp   $01                                      ; $47A6: $FE $01
     jr   nz, jr_002_47E0                          ; $47A8: $20 $36
 
@@ -1188,7 +1188,7 @@ jr_002_49AA:
 
 jr_002_49B6:
     ld   a, $01                                   ; $49B6: $3E $01
-    ld   [$C146], a                               ; $49B8: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $49B8: $EA $46 $C1
     call CheckItemsToUse                          ; $49BB: $CD $77 $11
     call func_002_478C                            ; $49BE: $CD $8C $47
     ld   a, [wSwordAnimationState]                ; $49C1: $FA $37 $C1
@@ -2095,7 +2095,7 @@ ENDC
 jr_002_4F3C:
     call ResetSpinAttack                          ; $4F3C: $CD $AF $0C
     ldh  [hLinkPositionZ], a                      ; $4F3F: $E0 $A2
-    ld   [$C146], a                               ; $4F41: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $4F41: $EA $46 $C1
     ld   [$C19B], a                               ; $4F44: $EA $9B $C1
     ld   [wSwordAnimationState], a                ; $4F47: $EA $37 $C1
     ld   [wC16A], a                               ; $4F4A: $EA $6A $C1
@@ -2457,7 +2457,7 @@ jr_002_515C:
     ld   [$DBC8], a                               ; $515C: $EA $C8 $DB
     call ClearLinkPositionIncrement               ; $515F: $CD $8E $17
     ldh  [$FFA3], a                               ; $5162: $E0 $A3
-    ld   [$C146], a                               ; $5164: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $5164: $EA $46 $C1
     jp   label_C83                                ; $5167: $C3 $83 $0C
 
 jr_002_516A:
@@ -5032,7 +5032,7 @@ Data_002_68B4::
     db   $FF, $00, $01
 
 jp_002_68B7::
-    ld   a, [$C146]                               ; $68B7: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $68B7: $FA $46 $C1
     and  a                                        ; $68BA: $A7
     jr   nz, jr_002_68C7                          ; $68BB: $20 $0A
 
@@ -5102,7 +5102,7 @@ jr_002_692B:
     ld   hl, hLinkDirection                       ; $6932: $21 $9E $FF
     res  1, [hl]                                  ; $6935: $CB $8E
     call ResetPegasusBoots                        ; $6937: $CD $B6 $0C
-    ld   [$C146], a                               ; $693A: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $693A: $EA $46 $C1
     ldh  a, [hFrameCounter]                       ; $693D: $F0 $E7
     and  $01                                      ; $693F: $E6 $01
     jr   nz, jr_002_696E                          ; $6941: $20 $2B
@@ -5182,7 +5182,7 @@ jr_002_699E:
 
 func_002_69A1::
     call ResetPegasusBoots                        ; $69A1: $CD $B6 $0C
-    ld   [$C146], a                               ; $69A4: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $69A4: $EA $46 $C1
     ld   [$C153], a                               ; $69A7: $EA $53 $C1
     ld   [$C152], a                               ; $69AA: $EA $52 $C1
     ldh  a, [hPressedButtonsMask]                 ; $69AD: $F0 $CB
@@ -5255,7 +5255,7 @@ func_002_6A01::
     cp   $F8                                      ; $6A09: $FE $F8
     jr   nz, jr_002_6A24                          ; $6A0B: $20 $17
 
-    ld   a, [$C146]                               ; $6A0D: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $6A0D: $FA $46 $C1
     and  a                                        ; $6A10: $A7
     jr   nz, jr_002_6A24                          ; $6A11: $20 $11
 
@@ -5300,12 +5300,12 @@ jr_002_6A4C:
     and  $08                                      ; $6A55: $E6 $08
     jr   nz, jr_002_6A94                          ; $6A57: $20 $3B
 
-    ld   a, [$C146]                               ; $6A59: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $6A59: $FA $46 $C1
     and  a                                        ; $6A5C: $A7
     jr   nz, jr_002_6A64                          ; $6A5D: $20 $05
 
     ld   a, $01                                   ; $6A5F: $3E $01
-    ld   [$C146], a                               ; $6A61: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $6A61: $EA $46 $C1
 
 jr_002_6A64:
     ld   a, $0A                                   ; $6A64: $3E $0A
@@ -5346,14 +5346,14 @@ jr_002_6A92:
     jr   label_002_6ADB                           ; $6A92: $18 $47
 
 jr_002_6A94:
-    ld   a, [$C146]                               ; $6A94: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $6A94: $FA $46 $C1
     and  a                                        ; $6A97: $A7
     jr   z, jr_002_6AAA                           ; $6A98: $28 $10
 
     ld   a, NOISE_SFX_FOOTSTEP                          ; $6A9A: $3E $07
     ldh  [hNoiseSfx], a                            ; $6A9C: $E0 $F4
     call ResetPegasusBoots                        ; $6A9E: $CD $B6 $0C
-    ld   [$C146], a                               ; $6AA1: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $6AA1: $EA $46 $C1
     ld   [$C152], a                               ; $6AA4: $EA $52 $C1
     ld   [$C153], a                               ; $6AA7: $EA $53 $C1
 
@@ -5905,7 +5905,7 @@ CheckPositionForMapTransition::
     and  a                                        ; $6D7E: $A7
     jr   nz, .jr_002_6D88                         ; $6D7F: $20 $07
 
-    ld   a, [$C146]                               ; $6D81: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $6D81: $FA $46 $C1
     and  a                                        ; $6D84: $A7
     jp   nz, clearIncrementAndReturn              ; $6D85: $C2 $0C $6E
 
@@ -6014,7 +6014,7 @@ ENDC
 
     ; … reset some more position variables.
     ld   a, $02                                   ; $6E00: $3E $02
-    ld   [$C146], a                               ; $6E02: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $6E02: $EA $46 $C1
     ld   a, $08                                   ; $6E05: $3E $08
     ldh  [hLinkPositionZ], a                      ; $6E07: $E0 $A2
 
@@ -6453,7 +6453,7 @@ jr_002_7078:
 
 jr_002_7085:
 IF __PATCH_0__
-    ld   a, [$c146]
+    ld   a, [wIsLinkInTheAir]
     and  a
     jr   nz, label_002_70D8
 ENDC
@@ -6499,7 +6499,7 @@ jr_002_70B5:
     ld   a, $1C                                   ; $70C6: $3E $1C
     ldh  [$FFA3], a                               ; $70C8: $E0 $A3
     ld   a, $01                                   ; $70CA: $3E $01
-    ld   [$C146], a                               ; $70CC: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $70CC: $EA $46 $C1
     ld   a, $01                                   ; $70CF: $3E $01
     ld   [wC10A], a                               ; $70D1: $EA $0A $C1
     ld   a, JINGLE_JUMP_DOWN                      ; $70D4: $3E $08
@@ -6799,7 +6799,7 @@ jr_002_728E:
     jr   nz, jr_002_72FA                          ; $7294: $20 $64
 
     ld   a, [$C13E]                               ; $7296: $FA $3E $C1
-    ld   hl, $C146                                ; $7299: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $7299: $21 $46 $C1
     or   [hl]                                     ; $729C: $B6
     jr   nz, jr_002_72FA                          ; $729D: $20 $5B
 
@@ -7044,7 +7044,7 @@ ENDC
     jr   c, jr_002_742D                           ; $73F1: $38 $3A
 
 IF __PATCH_0__
-    ld   a, [$c146]
+    ld   a, [wIsLinkInTheAir]
     and  a
     jr   nz, collisionEnd
 ENDC
@@ -7231,7 +7231,7 @@ jr_002_74C9:
     ld   a, $18                                   ; $74E0: $3E $18
     ldh  [$FFA3], a                               ; $74E2: $E0 $A3
     ld   a, $02                                   ; $74E4: $3E $02
-    ld   [$C146], a                               ; $74E6: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $74E6: $EA $46 $C1
     ld   a, $20                                   ; $74E9: $3E $20
     ld   [$C157], a                               ; $74EB: $EA $57 $C1
     ldh  a, [hLinkDirection]                      ; $74EE: $F0 $9E
@@ -7297,7 +7297,7 @@ jr_002_7549:
     jr   z, jr_002_7587                           ; $754D: $28 $38
 
 func_002_754F::
-    ld   hl, $C146                                ; $754F: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $754F: $21 $46 $C1
     ld   a, [wIsRunningWithPegasusBoots]          ; $7552: $FA $4A $C1
     or   [hl]                                     ; $7555: $B6
     jr   nz, func_002_755B                        ; $7556: $20 $03
@@ -7429,7 +7429,7 @@ func_002_75F5::
     inc  a                                        ; $7607: $3C
     ldh  [hLinkPositionYIncrement], a             ; $7608: $E0 $9B
     ld   a, $02                                   ; $760A: $3E $02
-    ld   [$C146], a                               ; $760C: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $760C: $EA $46 $C1
     ldh  a, [hIsSideScrolling]                    ; $760F: $F0 $F9
     and  a                                        ; $7611: $A7
     jr   nz, jr_002_761E                          ; $7612: $20 $0A

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -837,7 +837,7 @@ jr_002_4745:
     ld   [$C140], a                               ; $4754: $EA $40 $C1
     ld   a, $18                                   ; $4757: $3E $18
     ld   [$C141], a                               ; $4759: $EA $41 $C1
-    ld   [wIsLinkInTheAir], a                     ; $475C: $EA $43 $C1
+    ld   [$C143], a                               ; $475C: $EA $43 $C1
     ld   a, [$C145]                               ; $475F: $FA $45 $C1
     add  $08                                      ; $4762: $C6 $08
     ld   [$C142], a                               ; $4764: $EA $42 $C1
@@ -1041,7 +1041,7 @@ jr_002_487E:
     ld   hl, Data_002_4606                        ; $48A0: $21 $06 $46
     add  hl, bc                                   ; $48A3: $09
     ld   a, [hl]                                  ; $48A4: $7E
-    ld   [wIsLinkInTheAir], a                     ; $48A5: $EA $43 $C1
+    ld   [$C143], a                               ; $48A5: $EA $43 $C1
     ld   a, $01                                   ; $48A8: $3E $01
     ld   [$C5B0], a                               ; $48AA: $EA $B0 $C5
 

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -1054,7 +1054,7 @@ func_020_4B4A::
     ld   hl, data_020_4B46                        ; $4B6C: $21 $46 $4B
     add  hl, de                                   ; $4B6F: $19
     ld   a, [hl]                                  ; $4B70: $7E
-    ld   [wIsLinkInTheAir], a                     ; $4B71: $EA $43 $C1
+    ld   [$C143], a                               ; $4B71: $EA $43 $C1
     xor  a                                        ; $4B74: $AF
     ld   [$C5B0], a                               ; $4B75: $EA $B0 $C5
     ret                                           ; $4B78: $C9

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -645,7 +645,7 @@ func_020_48CA::
     jr   nz, jr_020_490A                          ; $48FA: $20 $0E
 
 jr_020_48FC:
-    ld   a, [$C146]                               ; $48FC: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $48FC: $FA $46 $C1
     and  a                                        ; $48FF: $A7
     jr   nz, jr_020_4917                          ; $4900: $20 $15
 

--- a/src/code/entities/anti_kirby.asm
+++ b/src/code/entities/anti_kirby.asm
@@ -310,7 +310,7 @@ jr_006_440C:
     ld   a, $20                                   ; $4412: $3E $20
     ld   [wInvincibilityCounter], a               ; $4414: $EA $C7 $DB
     ld   a, $02                                   ; $4417: $3E $02
-    ld   [$C146], a                               ; $4419: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $4419: $EA $46 $C1
     ld   a, $02                                   ; $441C: $3E $02
     ld   [wSubtractHealthBuffer], a               ; $441E: $EA $94 $DB
     ld   a, JINGLE_JUMP_DOWN                      ; $4421: $3E $08

--- a/src/code/entities/armos_knight.asm
+++ b/src/code/entities/armos_knight.asm
@@ -360,7 +360,7 @@ ArmosKnightState6Handler::
     ldh  [hJingle], a                             ; $5500: $E0 $F2
     call GetEntityTransitionCountdown             ; $5502: $CD $05 $0C
     ld   [hl], $30                                ; $5505: $36 $30
-    ld   a, [$C146]                               ; $5507: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $5507: $FA $46 $C1
     and  a                                        ; $550A: $A7
     jr   nz, jr_006_5512                          ; $550B: $20 $05
 

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -591,7 +591,7 @@ func_015_463D::
     cp   $10                                      ; $464D: $FE $10
     jr   nc, jr_015_465F                          ; $464F: $30 $0E
 
-    ld   a, [$C146]                               ; $4651: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4651: $FA $46 $C1
     and  a                                        ; $4654: $A7
     ret  nz                                       ; $4655: $C0
 
@@ -2061,7 +2061,7 @@ FinalNightmareForm1Handler::
 
 ; Final boss dialog related
 func_015_50C2::
-    ld   a, [$C146]                               ; $50C2: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $50C2: $FA $46 $C1
     and  a                                        ; $50C5: $A7
     ret  nz                                       ; $50C6: $C0
 
@@ -6206,7 +6206,7 @@ ENDC
     cp   $10                                      ; $72F0: $FE $10
     jr   nc, jr_015_731D                          ; $72F2: $30 $29
 
-    ld   hl, $C146                                ; $72F4: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $72F4: $21 $46 $C1
     ld   a, [wInvincibilityCounter]               ; $72F7: $FA $C7 $DB
     or   [hl]                                     ; $72FA: $B6
     jr   nz, jr_015_731D                          ; $72FB: $20 $20
@@ -7499,7 +7499,7 @@ ShouldLinkTalkToEntity::
     ld   a, [wDialogState]                        ; $7AE7: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $7AEA: $21 $4F $C1
     or   [hl]                                     ; $7AED: $B6
-    ld   hl, $C146                                ; $7AEE: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $7AEE: $21 $46 $C1
     or   [hl]                                     ; $7AF1: $B6
     ld   hl, $C134                                ; $7AF2: $21 $34 $C1
     or   [hl]                                     ; $7AF5: $B6
@@ -7930,7 +7930,7 @@ func_015_7D01::
     ld   a, $01                                   ; $7D26: $3E $01
     ldh  [hLinkPositionZ], a                      ; $7D28: $E0 $A2
     ld   a, $02                                   ; $7D2A: $3E $02
-    ld   [$C146], a                               ; $7D2C: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $7D2C: $EA $46 $C1
     ld   a, $12                                   ; $7D2F: $3E $12
     ldh  [$FFA3], a                               ; $7D31: $E0 $A3
     ld   a, $0C                                   ; $7D33: $3E $0C
@@ -7966,7 +7966,7 @@ Data_015_7D70::
     db   $98, $42, $98, $50, $99, $90, $99, $82
 
 func_015_7D78::
-    ld   a, [$C146]                               ; $7D78: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $7D78: $FA $46 $C1
     and  a                                        ; $7D7B: $A7
     ret  nz                                       ; $7D7C: $C0
 

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -2927,7 +2927,7 @@ jr_018_558A:
 
     call ResetSpinAttack                          ; $559A: $CD $AF $0C
     call ClearLinkPositionIncrement               ; $559D: $CD $8E $17
-    ld   a, [$C146]                               ; $55A0: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $55A0: $FA $46 $C1
     and  a                                        ; $55A3: $A7
     ret  nz                                       ; $55A4: $C0
 
@@ -8639,7 +8639,7 @@ jr_018_7DC1:
     ld   a, [wDialogState]                        ; $7DC6: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $7DC9: $21 $4F $C1
     or   [hl]                                     ; $7DCC: $B6
-    ld   hl, $C146                                ; $7DCD: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $7DCD: $21 $46 $C1
     or   [hl]                                     ; $7DD0: $B6
     ld   hl, $C134                                ; $7DD1: $21 $34 $C1
     or   [hl]                                     ; $7DD4: $B6

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -324,7 +324,7 @@ WarpEntityHandler::
 
 jr_019_4226:
     call func_019_7D3D                            ; $4226: $CD $3D $7D
-    ld   a, [$C146]                               ; $4229: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4229: $FA $46 $C1
     and  a                                        ; $422C: $A7
     ret  nz                                       ; $422D: $C0
 
@@ -3650,7 +3650,7 @@ jr_019_598B:
 
 func_019_599B::
     call ResetPegasusBoots                        ; $599B: $CD $B6 $0C
-    ld   a, [$C146]                               ; $599E: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $599E: $FA $46 $C1
     and  a                                        ; $59A1: $A7
     jr   nz, jr_019_59B7                          ; $59A2: $20 $13
 
@@ -3720,7 +3720,7 @@ jr_019_5A0D:
     ld   hl, wEntitiesSpeedZTable                 ; $5A1F: $21 $20 $C3
     add  hl, bc                                   ; $5A22: $09
     ld   [hl], $10                                ; $5A23: $36 $10
-    ld   a, [$C146]                               ; $5A25: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $5A25: $FA $46 $C1
     ld   e, a                                     ; $5A28: $5F
     ld   a, [wIsRunningWithPegasusBoots]          ; $5A29: $FA $4A $C1
     or   e                                        ; $5A2C: $B3
@@ -3866,7 +3866,7 @@ jr_019_5AC4:
     ld   [hl], $01                                ; $5AEE: $36 $01
     ld   a, $02                                   ; $5AF0: $3E $02
     ldh  [hLinkPositionZ], a                      ; $5AF2: $E0 $A2
-    ld   [$C146], a                               ; $5AF4: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $5AF4: $EA $46 $C1
     ret                                           ; $5AF7: $C9
 
 Data_019_5AF8::
@@ -3926,7 +3926,7 @@ label_019_5B3C:
     add  e                                        ; $5B48: $83
     call SetEntitySpriteVariant                   ; $5B49: $CD $0C $3B
     ld   a, $02                                   ; $5B4C: $3E $02
-    ld   [$C146], a                               ; $5B4E: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $5B4E: $EA $46 $C1
     xor  a                                        ; $5B51: $AF
     ldh  [$FFA3], a                               ; $5B52: $E0 $A3
     ldh  a, [hFrameCounter]                       ; $5B54: $F0 $E7
@@ -6706,7 +6706,7 @@ jr_019_7255:
 SeashellMansionState1Handler::
     ld   a, $01                                   ; $7256: $3E $01
     ld   [wC167], a                               ; $7258: $EA $67 $C1
-    ld   a, [$C146]                               ; $725B: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $725B: $FA $46 $C1
     and  a                                        ; $725E: $A7
     jp   z, IncrementEntityState                  ; $725F: $CA $12 $3B
 
@@ -8044,7 +8044,7 @@ func_019_7D16::
     ld   a, [wDialogState]                        ; $7D1B: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $7D1E: $21 $4F $C1
     or   [hl]                                     ; $7D21: $B6
-    ld   hl, $C146                                ; $7D22: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $7D22: $21 $46 $C1
     or   [hl]                                     ; $7D25: $B6
     ld   hl, $C134                                ; $7D26: $21 $34 $C1
     or   [hl]                                     ; $7D29: $B6

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -6140,7 +6140,7 @@ ApplyLinkCollisionWithEnemy::
     call IncrementEntityState                     ; $6CE3: $CD $12 $3B
     ld   [hl], ENTITY_STATUS_ACTIVE               ; $6CE6: $36 $05
     ld   a, $02                                   ; $6CE8: $3E $02
-    ld   [$C146], a                               ; $6CEA: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $6CEA: $EA $46 $C1
     ld   a, $F0                                   ; $6CED: $3E $F0
     ldh  [hLinkPositionYIncrement], a             ; $6CEF: $E0 $9B
     call ClearEntitySpeed                         ; $6CF1: $CD $7F $3D
@@ -6157,7 +6157,7 @@ ApplyLinkCollisionWithEnemy::
     cp   ENTITY_GOOMBA                            ; $6CFB: $FE $9F
     jr   nz, .goombaEnd                           ; $6CFD: $20 $3E
 
-    ld   a, [$C146]                               ; $6CFF: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $6CFF: $FA $46 $C1
     and  a                                        ; $6D02: $A7
     jr   z, .goombaEnd                            ; $6D03: $28 $38
 

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -6453,7 +6453,7 @@ jr_003_6E8E:
     pop  hl                                       ; $6E8E: $E1
     push af                                       ; $6E8F: $F5
     inc  hl                                       ; $6E90: $23
-    ld   a, [wIsLinkInTheAir]                     ; $6E91: $FA $43 $C1
+    ld   a, [$C143]                               ; $6E91: $FA $43 $C1
     add  [hl]                                     ; $6E94: $86
     ld   e, a                                     ; $6E95: $5F
     pop  af                                       ; $6E96: $F1
@@ -7466,7 +7466,7 @@ jr_003_7440:
     pop  hl                                       ; $7440: $E1
     push af                                       ; $7441: $F5
     inc  hl                                       ; $7442: $23
-    ld   a, [wIsLinkInTheAir]                     ; $7443: $FA $43 $C1
+    ld   a, [$C143]                               ; $7443: $FA $43 $C1
     add  [hl]                                     ; $7446: $86
     ld   e, a                                     ; $7447: $5F
     pop  af                                       ; $7448: $F1

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -329,7 +329,7 @@ func_036_41DF::
     ld   a, $70                                   ; $41DF: $3E $70
     ldh  [hLinkPositionZ], a                      ; $41E1: $E0 $A2
     ld   a, $02                                   ; $41E3: $3E $02
-    ld   [$C146], a                               ; $41E5: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $41E5: $EA $46 $C1
     ld   a, $E0                                   ; $41E8: $3E $E0
     ldh  [$FFB3], a                               ; $41EA: $E0 $B3
     ld   [$C145], a                               ; $41EC: $EA $45 $C1
@@ -673,7 +673,7 @@ jr_036_4429:
     ld   a, $77                                   ; $4432: $3E $77
     ldh  [hLinkPositionY], a                      ; $4434: $E0 $99
     ld   [wMapEntrancePositionY], a               ; $4436: $EA $9E $DB
-    ld   a, [$C146]                               ; $4439: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4439: $FA $46 $C1
     and  a                                        ; $443C: $A7
     ret  nz                                       ; $443D: $C0
 
@@ -2603,7 +2603,7 @@ jr_036_4FB1:
     call SetEntitySpriteVariant                   ; $4FE4: $CD $0C $3B
     call func_036_6A62                            ; $4FE7: $CD $62 $6A
     call func_036_5000                            ; $4FEA: $CD $00 $50
-    ld   a, [$C146]                               ; $4FED: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4FED: $FA $46 $C1
     and  a                                        ; $4FF0: $A7
     jr   z, jr_036_4FFB                           ; $4FF1: $28 $08
 
@@ -5048,7 +5048,7 @@ jr_036_5EDC:
     ret                                           ; $5F14: $C9
 
 AvalaunchStateAHandler::
-    ld   a, [$C146]                               ; $5F15: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $5F15: $FA $46 $C1
     and  a                                        ; $5F18: $A7
     jr   nz, jr_036_5F26                          ; $5F19: $20 $0B
 
@@ -7073,7 +7073,7 @@ jr_036_6AC5:
     ld   a, [wDialogState]                        ; $6ACA: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $6ACD: $21 $4F $C1
     or   [hl]                                     ; $6AD0: $B6
-    ld   hl, $C146                                ; $6AD1: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $6AD1: $21 $46 $C1
     or   [hl]                                     ; $6AD4: $B6
     ld   hl, $C134                                ; $6AD5: $21 $34 $C1
     or   [hl]                                     ; $6AD8: $B6

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -432,7 +432,7 @@ jr_004_4F14:
     ld   [$C157], a                               ; $4F30: $EA $57 $C1
     ld   a, JINGLE_HUGE_BUMP                      ; $4F33: $3E $0B
     ldh  [hJingle], a                             ; $4F35: $E0 $F2
-    ld   a, [$C146]                               ; $4F37: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4F37: $FA $46 $C1
     and  a                                        ; $4F3A: $A7
     jr   nz, jr_004_4F49                          ; $4F3B: $20 $0C
 
@@ -4190,7 +4190,7 @@ jr_004_6884:
     cp   ENTITY_TRACTOR_DEVICE                    ; $689A: $FE $52
     jp   nz, label_004_68E4                       ; $689C: $C2 $E4 $68
 
-    ld   a, [$C146]                               ; $689F: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $689F: $FA $46 $C1
     and  a                                        ; $68A2: $A7
     jr   nz, jr_004_68D4                          ; $68A3: $20 $2F
 
@@ -7497,7 +7497,7 @@ func_004_7C4B::
     ld   a, [wDialogState]                        ; $7C4B: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $7C4E: $21 $4F $C1
     or   [hl]                                     ; $7C51: $B6
-    ld   hl, $C146                                ; $7C52: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $7C52: $21 $46 $C1
     or   [hl]                                     ; $7C55: $B6
     ld   hl, $C134                                ; $7C56: $21 $34 $C1
     or   [hl]                                     ; $7C59: $B6

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -138,7 +138,7 @@ func_006_645D::
     ld   a, [wDialogState]                        ; $64A4: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $64A7: $21 $4F $C1
     or   [hl]                                     ; $64AA: $B6
-    ld   hl, $C146                                ; $64AB: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $64AB: $21 $46 $C1
     or   [hl]                                     ; $64AE: $B6
     ld   hl, $C134                                ; $64AF: $21 $34 $C1
     or   [hl]                                     ; $64B2: $B6

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -7595,7 +7595,7 @@ func_007_7090::
     jp   label_007_7034                           ; $70B4: $C3 $34 $70
 
 func_007_70B7::
-    ld   hl, $C146                                ; $70B7: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $70B7: $21 $46 $C1
     ld   a, [wInvincibilityCounter]               ; $70BA: $FA $C7 $DB
     or   [hl]                                     ; $70BD: $B6
     jr   nz, jr_007_7111                          ; $70BE: $20 $51
@@ -7637,7 +7637,7 @@ jr_007_70E0:
     ldh  a, [hScratch1]                           ; $70F6: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $70F8: $E0 $9A
     ld   a, $02                                   ; $70FA: $3E $02
-    ld   [$C146], a                               ; $70FC: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $70FC: $EA $46 $C1
     ld   a, $13                                   ; $70FF: $3E $13
     ldh  [$FFA3], a                               ; $7101: $E0 $A3
     ld   a, $08                                   ; $7103: $3E $08
@@ -9377,7 +9377,7 @@ jr_007_7D6F:
     ld   a, [wDialogState]                        ; $7D74: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $7D77: $21 $4F $C1
     or   [hl]                                     ; $7D7A: $B6
-    ld   hl, $C146                                ; $7D7B: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $7D7B: $21 $46 $C1
     or   [hl]                                     ; $7D7E: $B6
     ld   hl, $C134                                ; $7D7F: $21 $34 $C1
     or   [hl]                                     ; $7D82: $B6

--- a/src/code/entities/cue_ball.asm
+++ b/src/code/entities/cue_ball.asm
@@ -34,7 +34,7 @@ jr_006_4B98:
     call DecrementEntityIgnoreHitsCountdown       ; $4BAB: $CD $56 $0C
     call label_3B44                               ; $4BAE: $CD $44 $3B
     call func_006_6541                            ; $4BB1: $CD $41 $65
-    ld   a, [$C146]                               ; $4BB4: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4BB4: $FA $46 $C1
     and  a                                        ; $4BB7: $A7
     jr   nz, jr_006_4BE1                          ; $4BB8: $20 $27
 

--- a/src/code/entities/evil_eagle.asm
+++ b/src/code/entities/evil_eagle.asm
@@ -760,7 +760,7 @@ jr_005_5E59:
     jr   nz, jr_005_5E8A                          ; $5E5F: $20 $29
 
 jr_005_5E61:
-    ld   a, [$C146]                               ; $5E61: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $5E61: $FA $46 $C1
     and  a                                        ; $5E64: $A7
 
 jr_005_5E65:

--- a/src/code/entities/hinox.asm
+++ b/src/code/entities/hinox.asm
@@ -265,7 +265,7 @@ jr_006_5157:
     ld   a, $10                                   ; $5159: $3E $10
     ldh  [$FFA3], a                               ; $515B: $E0 $A3
     ld   a, $02                                   ; $515D: $3E $02
-    ld   [$C146], a                               ; $515F: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $515F: $EA $46 $C1
     ld   a, JINGLE_JUMP_DOWN                      ; $5162: $3E $08
     ldh  [hJingle], a                             ; $5164: $E0 $F2
     ld   a, $08                                   ; $5166: $3E $08
@@ -309,7 +309,7 @@ jr_006_5179:
     ld   a, [hl]                                  ; $51A4: $7E
     ldh  [hLinkPositionZ], a                      ; $51A5: $E0 $A2
     ld   a, $02                                   ; $51A7: $3E $02
-    ld   [$C146], a                               ; $51A9: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $51A9: $EA $46 $C1
     ldh  a, [hActiveEntityPosY]                   ; $51AC: $F0 $EF
     ldh  [hLinkPositionY], a                      ; $51AE: $E0 $99
 

--- a/src/code/entities/like_like.asm
+++ b/src/code/entities/like_like.asm
@@ -97,7 +97,7 @@ jr_006_7E55:
     ldh  a, [hActiveEntityPosY]                   ; $7E5F: $F0 $EF
     ldh  [hLinkPositionY], a                      ; $7E61: $E0 $99
     xor  a                                        ; $7E63: $AF
-    ld   [$C146], a                               ; $7E64: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $7E64: $EA $46 $C1
     ldh  [hLinkPositionZ], a                      ; $7E67: $E0 $A2
     call func_006_7F05                            ; $7E69: $CD $05 $7F
     jp   func_006_7F05                            ; $7E6C: $C3 $05 $7F

--- a/src/code/entities/marin.asm
+++ b/src/code/entities/marin.asm
@@ -755,7 +755,7 @@ func_005_52DB::
     ld   a, $01                                   ; $52F2: $3E $01
     ldh  [hLinkPositionZ], a                      ; $52F4: $E0 $A2
     ld   a, $02                                   ; $52F6: $3E $02
-    ld   [$C146], a                               ; $52F8: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $52F8: $EA $46 $C1
     ld   a, $12                                   ; $52FB: $3E $12
     ldh  [$FFA3], a                               ; $52FD: $E0 $A3
     ld   a, $0C                                   ; $52FF: $3E $0C

--- a/src/code/entities/raft_owner.asm
+++ b/src/code/entities/raft_owner.asm
@@ -338,7 +338,7 @@ jr_005_5544:
     ld   a, [wDialogState]                        ; $5549: $FA $9F $C1
     ld   hl, wInventoryAppearing                  ; $554C: $21 $4F $C1
     or   [hl]                                     ; $554F: $B6
-    ld   hl, $C146                                ; $5550: $21 $46 $C1
+    ld   hl, wIsLinkInTheAir                      ; $5550: $21 $46 $C1
     or   [hl]                                     ; $5553: $B6
     ld   hl, $C134                                ; $5554: $21 $34 $C1
     or   [hl]                                     ; $5557: $B6

--- a/src/code/entities/slime_eye.asm
+++ b/src/code/entities/slime_eye.asm
@@ -149,7 +149,7 @@ jr_004_4A41:
     call GetEntityTransitionCountdown                 ; $4A54: $CD $05 $0C
     ld   [hl], $40                                ; $4A57: $36 $40
     call PlayBombExplosionSfx                                ; $4A59: $CD $4B $0C
-    ld   a, [$C146]                               ; $4A5C: $FA $46 $C1
+    ld   a, [wIsLinkInTheAir]                     ; $4A5C: $FA $46 $C1
     and  a                                        ; $4A5F: $A7
     jr   nz, jr_004_4A67                          ; $4A60: $20 $05
 

--- a/src/code/world_handler.asm
+++ b/src/code/world_handler.asm
@@ -156,7 +156,7 @@ GameplayWorldSubtype1Handler::
     and  a                                        ; $444A: $A7
     jr   z, jr_001_4452                           ; $444B: $28 $05
     ld   a, $02                                   ; $444D: $3E $02
-    ld   [$C146], a                               ; $444F: $EA $46 $C1
+    ld   [wIsLinkInTheAir], a                     ; $444F: $EA $46 $C1
 
 jr_001_4452::
     ld   a, $04                                   ; $4452: $3E $04

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -199,7 +199,14 @@ wIsLinkPushing:: ; C144
   ds 1
 
 ; Unlabeled
-ds $5
+ds $1
+
+wIsLinkInTheAir:: ; C146
+  ; Is Link in the air (jumping with the feather, flying with roaster, etc)?
+  ds 1
+
+; Unlabeled
+ds $3
 
 wIsRunningWithPegasusBoots:: ; C14A
   ds 1

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -193,11 +193,7 @@ wRandomSeed:: ; C13D
   ds 1
 
 ; Unlabeled
-ds $5
-
-wIsLinkInTheAir:: ; C143
-  ; Is Link in the air (jumping with the feather, flying with roaster, etc)?
-  ds 1
+ds $6
 
 wIsLinkPushing:: ; C144
   ds 1


### PR DESCRIPTION
wIsLinkInTheAir has been introduced in https://github.com/zladx/LADX-Disassembly/pull/77, with https://web.archive.org/web/20180404215104/http://spiraster.x10host.com/LADXWiki/index.php/RAM_addresses cited as a reference.

However, this reference maps "Link's aerial flag" to C146 instead of C143.

This can be confirmed with the following capture:
![2020-07-14-LADX-Disassembly-PR-275](https://user-images.githubusercontent.com/2598210/87415344-454f1680-c5cd-11ea-8e83-689688e960f6.gif)
