### PR TITLE
Document entity speed and vector towards Link

### DIFF
--- a/src/code/bank27.asm
+++ b/src/code/bank27.asm
@@ -753,7 +753,7 @@ func_027_7B25::
     push af                                       ; $7B2D: $F5
     swap a                                        ; $7B2E: $CB $37
     and  $F0                                      ; $7B30: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7B32: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7B32: $21 $60 $C2
     add  hl, bc                                   ; $7B35: $09
     add  [hl]                                     ; $7B36: $86
     ld   [hl], a                                  ; $7B37: $77

--- a/src/code/bank27.asm
+++ b/src/code/bank27.asm
@@ -711,7 +711,7 @@ jr_027_7AE8:
     inc  [hl]                                     ; $7AFC: $34
 
 jr_027_7AFD:
-    call func_027_7B18                            ; $7AFD: $CD $18 $7B
+    call UpdateEntityPosWithSpeed_27              ; $7AFD: $CD $18 $7B
     ldh  a, [hActiveEntityPosX]                   ; $7B00: $F0 $EE
     cp   $B0                                      ; $7B02: $FE $B0
     jp   nc, label_027_7B51                       ; $7B04: $D2 $51 $7B

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -6629,7 +6629,7 @@ jr_017_7E42:
     push af                                       ; $7E42: $F5
     swap a                                        ; $7E43: $CB $37
     and  $F0                                      ; $7E45: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7E47: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7E47: $21 $60 $C2
     add  hl, bc                                   ; $7E4A: $09
     add  [hl]                                     ; $7E4B: $86
     ld   [hl], a                                  ; $7E4C: $77
@@ -6665,7 +6665,7 @@ jr_017_7E65:
     push af                                       ; $7E6E: $F5
     swap a                                        ; $7E6F: $CB $37
     and  $F0                                      ; $7E71: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7E73: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7E73: $21 $30 $C3
     add  hl, bc                                   ; $7E76: $09
     add  [hl]                                     ; $7E77: $86
     ld   [hl], a                                  ; $7E78: $77

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -4328,7 +4328,7 @@ jr_017_6C15:
     ld   bc, $00                                  ; $6C21: $01 $00 $00
     ld   a, [wEntitiesPosXTable]                  ; $6C24: $FA $00 $C2
     push af                                       ; $6C27: $F5
-    call func_017_7E3A                            ; $6C28: $CD $3A $7E
+    call AddEntitySpeedToPos_17                   ; $6C28: $CD $3A $7E
     ld   a, [wEntitiesPosXTable]                  ; $6C2B: $FA $00 $C2
     ldh  [hBaseScrollY], a                        ; $6C2E: $E0 $97
     and  $F8                                      ; $6C30: $E6 $F8
@@ -5078,7 +5078,7 @@ jr_017_71AC:
     ld   hl, wEntitiesSpeedYTable                 ; $71B8: $21 $50 $C2
     add  hl, bc                                   ; $71BB: $09
     ld   [hl], $FF                                ; $71BC: $36 $FF
-    call func_017_7E2D                            ; $71BE: $CD $2D $7E
+    call UpdateEntityPosWithSpeed_17              ; $71BE: $CD $2D $7E
     ldh  a, [$FFEE]                               ; $71C1: $F0 $EE
     cp   $A8                                      ; $71C3: $FE $A8
     ret  c                                        ; $71C5: $D8
@@ -5157,7 +5157,7 @@ func_017_725F::
     call label_3DA0                               ; $7290: $CD $A0 $3D
 
 jr_017_7293:
-    call func_017_7E2D                            ; $7293: $CD $2D $7E
+    call UpdateEntityPosWithSpeed_17              ; $7293: $CD $2D $7E
     ldh  a, [hFrameCounter]                       ; $7296: $F0 $E7
     and  $0F                                      ; $7298: $E6 $0F
     jr   nz, jr_017_72A6                          ; $729A: $20 $0A
@@ -5430,7 +5430,7 @@ func_017_75AA::
     ld   hl, wEntitiesSpeedYTable                 ; $75C3: $21 $50 $C2
     add  hl, bc                                   ; $75C6: $09
     ld   [hl], $FE                                ; $75C7: $36 $FE
-    call func_017_7E30                            ; $75C9: $CD $30 $7E
+    call UpdateEntityYPosWithSpeed_17             ; $75C9: $CD $30 $7E
     ldh  a, [hActiveEntityState]                               ; $75CC: $F0 $F0
     cp   $02                                      ; $75CE: $FE $02
     jr   nc, jr_017_75E0                          ; $75D0: $30 $0E
@@ -5608,7 +5608,7 @@ jr_017_7784:
 jr_017_7798:
     ld   de, Data_017_7766                        ; $7798: $11 $66 $77
     call RenderActiveEntitySprite                 ; $779B: $CD $77 $3C
-    call func_017_7E3A                            ; $779E: $CD $3A $7E
+    call AddEntitySpeedToPos_17                   ; $779E: $CD $3A $7E
     ldh  a, [hActiveEntityPosX]                   ; $77A1: $F0 $EE
     cp   $B0                                      ; $77A3: $FE $B0
     jp   nc, label_017_7CC2                       ; $77A5: $D2 $C2 $7C
@@ -5873,7 +5873,7 @@ jr_017_793E:
     inc  [hl]                                     ; $7952: $34
 
 jr_017_7953:
-    call func_017_7E2D                            ; $7953: $CD $2D $7E
+    call UpdateEntityPosWithSpeed_17              ; $7953: $CD $2D $7E
     ldh  a, [hActiveEntityPosX]                   ; $7956: $F0 $EE
     cp   $B0                                      ; $7958: $FE $B0
     jp   nc, label_017_7CC2                       ; $795A: $D2 $C2 $7C
@@ -5933,7 +5933,7 @@ func_017_79A7::
     call GetEntityDropTimer                       ; $79B9: $CD $FB $0B
     ret  z                                        ; $79BC: $C8
 
-    call func_017_7E2D                            ; $79BD: $CD $2D $7E
+    call UpdateEntityPosWithSpeed_17              ; $79BD: $CD $2D $7E
     ret                                           ; $79C0: $C9
 
 Data_017_79C1::
@@ -6082,7 +6082,7 @@ func_017_7AC1::
     ld   hl, wEntitiesSpeedYTable                 ; $7AC8: $21 $50 $C2
     add  hl, bc                                   ; $7ACB: $09
     ld   [hl], $08                                ; $7ACC: $36 $08
-    call func_017_7E30                            ; $7ACE: $CD $30 $7E
+    call UpdateEntityYPosWithSpeed_17             ; $7ACE: $CD $30 $7E
     ld   hl, wEntitiesPosYTable                   ; $7AD1: $21 $10 $C2
     add  hl, bc                                   ; $7AD4: $09
     ld   a, [hl]                                  ; $7AD5: $7E
@@ -6305,7 +6305,7 @@ func_017_7C4D::
     call GetEntityTransitionCountdown             ; $7C4D: $CD $05 $0C
     jr   nz, jr_017_7C6A                          ; $7C50: $20 $18
 
-    call func_017_7E30                            ; $7C52: $CD $30 $7E
+    call UpdateEntityYPosWithSpeed_17             ; $7C52: $CD $30 $7E
     ldh  a, [hFrameCounter]                       ; $7C55: $F0 $E7
     and  $03                                      ; $7C57: $E6 $03
     jr   nz, jr_017_7C6A                          ; $7C59: $20 $0F
@@ -6606,72 +6606,88 @@ jr_017_7E24:
     ld   [$C003], a                               ; $7E29: $EA $03 $C0
     ret                                           ; $7E2C: $C9
 
-func_017_7E2D::
-    call func_017_7E3A                            ; $7E2D: $CD $3A $7E
+UpdateEntityPosWithSpeed_17::
+    call AddEntitySpeedToPos_17                   ; $7E2D: $CD $3A $7E
 
-func_017_7E30::
+UpdateEntityYPosWithSpeed_17::
     push bc                                       ; $7E30: $C5
     ld   a, c                                     ; $7E31: $79
     add  $10                                      ; $7E32: $C6 $10
     ld   c, a                                     ; $7E34: $4F
-    call func_017_7E3A                            ; $7E35: $CD $3A $7E
+    call AddEntitySpeedToPos_17                   ; $7E35: $CD $3A $7E
     pop  bc                                       ; $7E38: $C1
     ret                                           ; $7E39: $C9
 
-func_017_7E3A::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_17::
     ld   hl, wEntitiesSpeedXTable                 ; $7E3A: $21 $40 $C2
     add  hl, bc                                   ; $7E3D: $09
     ld   a, [hl]                                  ; $7E3E: $7E
     and  a                                        ; $7E3F: $A7
-    jr   z, jr_017_7E65                           ; $7E40: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7E40: $28 $23
 
-jr_017_7E42:
     push af                                       ; $7E42: $F5
+    ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $7E43: $CB $37
     and  $F0                                      ; $7E45: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7E47: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7E47: $21 $60 $C2
     add  hl, bc                                   ; $7E4A: $09
     add  [hl]                                     ; $7E4B: $86
     ld   [hl], a                                  ; $7E4C: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7E4D: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7E4F: $21 $00 $C2
 
-jr_017_7E52:
+.updatePosition
     add  hl, bc                                   ; $7E52: $09
     pop  af                                       ; $7E53: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7E54: $1E $00
     bit  7, a                                     ; $7E56: $CB $7F
-    jr   z, jr_017_7E5C                           ; $7E58: $28 $02
+    jr   z, .positive                             ; $7E58: $28 $02
 
     ld   e, $F0                                   ; $7E5A: $1E $F0
 
-jr_017_7E5C:
+.positive
     swap a                                        ; $7E5C: $CB $37
     and  $0F                                      ; $7E5E: $E6 $0F
     or   e                                        ; $7E60: $B3
+    ; Get carry back from d
     rr   d                                        ; $7E61: $CB $1A
     adc  [hl]                                     ; $7E63: $8E
     ld   [hl], a                                  ; $7E64: $77
 
-jr_017_7E65:
+.return
     ret                                           ; $7E65: $C9
 
+AddEntityZSpeedToPos_17::
     ld   hl, wEntitiesSpeedZTable                 ; $7E66: $21 $20 $C3
     add  hl, bc                                   ; $7E69: $09
     ld   a, [hl]                                  ; $7E6A: $7E
     and  a                                        ; $7E6B: $A7
-    jr   z, jr_017_7E65                           ; $7E6C: $28 $F7
+    jr   z, AddEntitySpeedToPos_17.return         ; $7E6C: $28 $F7
 
     push af                                       ; $7E6E: $F5
     swap a                                        ; $7E6F: $CB $37
     and  $F0                                      ; $7E71: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7E73: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7E73: $21 $30 $C3
     add  hl, bc                                   ; $7E76: $09
     add  [hl]                                     ; $7E77: $86
     ld   [hl], a                                  ; $7E78: $77
     rl   d                                        ; $7E79: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7E7B: $21 $10 $C3
-    jr   jr_017_7E52                              ; $7E7E: $18 $D2
+    jr   AddEntitySpeedToPos_17.updatePosition    ; $7E7E: $18 $D2
 
 func_017_7E80::
     and  $01                                      ; $7E80: $E6 $01

--- a/src/code/entities/angler_fish.asm
+++ b/src/code/entities/angler_fish.asm
@@ -276,7 +276,7 @@ jr_005_572A:
     ld   hl, wEntitiesSpeedYTable                 ; $572F: $21 $50 $C2
     add  hl, bc                                   ; $5732: $09
     ld   [hl], a                                  ; $5733: $77
-    jp   func_005_7AB4                            ; $5734: $C3 $B4 $7A
+    jp   UpdateEntityYPosWithSpeed_05             ; $5734: $C3 $B4 $7A
 
 func_005_5737::
     ld   hl, wEntitiesUnknowTableY                ; $5737: $21 $D0 $C3
@@ -297,7 +297,7 @@ jr_005_574A:
     ld   hl, wEntitiesSpeedXTable                 ; $574B: $21 $40 $C2
     add  hl, bc                                   ; $574E: $09
     ld   [hl], $D0                                ; $574F: $36 $D0
-    call func_005_7ABE                            ; $5751: $CD $BE $7A
+    call AddEntitySpeedToPos_05                   ; $5751: $CD $BE $7A
     ldh  a, [hActiveEntityPosX]                   ; $5754: $F0 $EE
     cp   $18                                      ; $5756: $FE $18
     ret  nc                                       ; $5758: $D0
@@ -324,7 +324,7 @@ func_005_576E::
     ld   hl, wEntitiesSpeedXTable                 ; $577A: $21 $40 $C2
     add  hl, bc                                   ; $577D: $09
     ld   [hl], $20                                ; $577E: $36 $20
-    call func_005_7ABE                            ; $5780: $CD $BE $7A
+    call AddEntitySpeedToPos_05                   ; $5780: $CD $BE $7A
     ld   hl, wEntitiesPrivateState1Table          ; $5783: $21 $B0 $C2
     add  hl, bc                                   ; $5786: $09
     ldh  a, [hActiveEntityPosX]                   ; $5787: $F0 $EE
@@ -431,7 +431,7 @@ jr_005_5913:
     ld   hl, wEntitiesSpeedYTable                 ; $5921: $21 $50 $C2
     add  hl, bc                                   ; $5924: $09
     ld   [hl], $F8                                ; $5925: $36 $F8
-    call func_005_7AB4                            ; $5927: $CD $B4 $7A
+    call UpdateEntityYPosWithSpeed_05             ; $5927: $CD $B4 $7A
 
 jr_005_592A:
     ldh  a, [hActiveEntityVisualPosY]             ; $592A: $F0 $EC
@@ -474,7 +474,7 @@ jr_005_5962:
     ld   hl, wEntitiesSpeedYTable                 ; $5967: $21 $50 $C2
     add  hl, bc                                   ; $596A: $09
     ld   [hl], $0C                                ; $596B: $36 $0C
-    call func_005_7AB1                            ; $596D: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $596D: $CD $B1 $7A
     ldh  a, [hActiveEntityVisualPosY]             ; $5970: $F0 $EC
     cp   $8B                                      ; $5972: $FE $8B
     jp   nc, func_005_7B4B                        ; $5974: $D2 $4B $7B
@@ -536,7 +536,7 @@ func_005_5984::
     call IncrementEntityState                     ; $59CB: $CD $12 $3B
 
 jr_005_59CE:
-    call func_005_7AB1                            ; $59CE: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $59CE: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $59D1: $CD $05 $0C
     jr   nz, jr_005_59DD                          ; $59D4: $20 $07
 

--- a/src/code/entities/anti_fairy.asm
+++ b/src/code/entities/anti_fairy.asm
@@ -17,7 +17,7 @@ AntiFairyEntityHandler::
 jr_006_787F:
     call func_006_64F7                            ; $787F: $CD $F7 $64
     call label_3B39                               ; $7882: $CD $39 $3B
-    call func_006_6541                            ; $7885: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $7885: $CD $41 $65
     call label_3B23                               ; $7888: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $788B: $21 $A0 $C2
     add  hl, bc                                   ; $788E: $09

--- a/src/code/entities/anti_kirby.asm
+++ b/src/code/entities/anti_kirby.asm
@@ -2,7 +2,7 @@ AntiKirbyEntityHandler::
     call func_006_44B6                            ; $423A: $CD $B6 $44
     call func_006_64C6                            ; $423D: $CD $C6 $64
     call func_006_64F7                            ; $4240: $CD $F7 $64
-    call func_006_657A                            ; $4243: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $4243: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $4246: $21 $20 $C3
     add  hl, bc                                   ; $4249: $09
     dec  [hl]                                     ; $424A: $35
@@ -71,7 +71,7 @@ label_006_42A2:
     ld   [hl], $10                                ; $42AB: $36 $10
 
 jr_006_42AD:
-    call func_006_6541                            ; $42AD: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $42AD: $CD $41 $65
     call label_3B23                               ; $42B0: $CD $23 $3B
     ld   hl, wEntitiesDirectionTable              ; $42B3: $21 $80 $C3
     add  hl, bc                                   ; $42B6: $09

--- a/src/code/entities/armos_knight.asm
+++ b/src/code/entities/armos_knight.asm
@@ -96,7 +96,7 @@ jr_006_5361:
     call BossIntro                                ; $5364: $CD $E8 $3E
     call label_3B70                               ; $5367: $CD $70 $3B
     call func_006_641A                            ; $536A: $CD $1A $64
-    call func_006_657A                            ; $536D: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $536D: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $5370: $21 $20 $C3
     add  hl, bc                                   ; $5373: $09
     dec  [hl]                                     ; $5374: $35
@@ -275,7 +275,7 @@ jr_006_547E:
     ld   hl, wEntitiesSpeedXTable                 ; $547E: $21 $40 $C2
     add  hl, bc                                   ; $5481: $09
     ld   [hl], e                                  ; $5482: $73
-    jp   func_006_654E                            ; $5483: $C3 $4E $65
+    jp   AddEntitySpeedToPos_06                   ; $5483: $C3 $4E $65
 
 ArmosKnightState3Handler::
     call func_006_64F7                            ; $5486: $CD $F7 $64
@@ -313,7 +313,7 @@ jr_006_54B4:
     ldh  [hJingle], a                             ; $54B9: $E0 $F2
 
 jr_006_54BB:
-    jp   func_006_6541                            ; $54BB: $C3 $41 $65
+    jp   UpdateEntityPosWithSpeed_06              ; $54BB: $C3 $41 $65
 
 ArmosKnightState4Handler::
     call func_006_64F7                            ; $54BE: $CD $F7 $64
@@ -329,7 +329,7 @@ ArmosKnightState4Handler::
     call IncrementEntityState                     ; $54D2: $CD $12 $3B
 
 jr_006_54D5:
-    jp   func_006_6541                            ; $54D5: $C3 $41 $65
+    jp   UpdateEntityPosWithSpeed_06              ; $54D5: $C3 $41 $65
 
 ArmosKnightState5Handler::
     call func_006_64F7                            ; $54D8: $CD $F7 $64

--- a/src/code/entities/armos_statue.asm
+++ b/src/code/entities/armos_statue.asm
@@ -21,7 +21,7 @@ ArmosStatueEntityHandler::
     call CopyLinkFinalPositionToPosition          ; $746F: $CD $BE $0C
 
 jr_006_7472:
-    call func_006_6541                            ; $7472: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $7472: $CD $41 $65
     call label_3B23                               ; $7475: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $7478: $F0 $F0
     JP_TABLE                                      ; $747A

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -7,13 +7,13 @@
 ;   bc   entity slot index
 ResetEntity::
     call ClearEntitySpeed                         ; $4000: $CD $7F $3D
-    ld   hl, wEntitiesUnknowTableK                ; $4003: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $4003: $21 $30 $C3
     add  hl, bc                                   ; $4006: $09
     ld   [hl], b                                  ; $4007: $70
-    ld   hl, wEntitiesUnknowTableN                ; $4008: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $4008: $21 $60 $C2
     add  hl, bc                                   ; $400B: $09
     ld   [hl], b                                  ; $400C: $70
-    ld   hl, wEntitiesUnknowTableO                ; $400D: $21 $70 $C2
+    ld   hl, wEntitiesSpeedYCountTable            ; $400D: $21 $70 $C2
     add  hl, bc                                   ; $4010: $09
     ld   [hl], b                                  ; $4011: $70
     ld   hl, wEntitiesSpeedZTable                 ; $4012: $21 $20 $C3
@@ -7635,7 +7635,7 @@ func_015_7B95::
     push af                                       ; $7B9D: $F5
     swap a                                        ; $7B9E: $CB $37
     and  $F0                                      ; $7BA0: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7BA2: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7BA2: $21 $60 $C2
     add  hl, bc                                   ; $7BA5: $09
     add  [hl]                                     ; $7BA6: $86
     ld   [hl], a                                  ; $7BA7: $77
@@ -7672,7 +7672,7 @@ func_015_7BC1::
     push af                                       ; $7BC9: $F5
     swap a                                        ; $7BCA: $CB $37
     and  $F0                                      ; $7BCC: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7BCE: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7BCE: $21 $30 $C3
     add  hl, bc                                   ; $7BD1: $09
     add  [hl]                                     ; $7BD2: $86
     ld   [hl], a                                  ; $7BD3: $77

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -7,13 +7,13 @@
 ;   bc   entity slot index
 ResetEntity::
     call ClearEntitySpeed                         ; $4000: $CD $7F $3D
-    ld   hl, wEntitiesSpeedZCountTable            ; $4003: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $4003: $21 $30 $C3
     add  hl, bc                                   ; $4006: $09
     ld   [hl], b                                  ; $4007: $70
-    ld   hl, wEntitiesSpeedXCountTable            ; $4008: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $4008: $21 $60 $C2
     add  hl, bc                                   ; $400B: $09
     ld   [hl], b                                  ; $400C: $70
-    ld   hl, wEntitiesSpeedYCountTable            ; $400D: $21 $70 $C2
+    ld   hl, wEntitiesSpeedYAccTable              ; $400D: $21 $70 $C2
     add  hl, bc                                   ; $4010: $09
     ld   [hl], b                                  ; $4011: $70
     ld   hl, wEntitiesSpeedZTable                 ; $4012: $21 $20 $C3
@@ -217,8 +217,8 @@ jr_015_43DC:
     rra                                           ; $43DD: $1F
     and  $03                                      ; $43DE: $E6 $03
     call SetEntitySpriteVariant                   ; $43E0: $CD $0C $3B
-    call func_015_7B88                            ; $43E3: $CD $88 $7B
-    call func_015_7BC1                            ; $43E6: $CD $C1 $7B
+    call UpdateEntityPosWithSpeed_15              ; $43E3: $CD $88 $7B
+    call AddEntityZSpeedToPos_15                  ; $43E6: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $43E9: $21 $20 $C3
     add  hl, bc                                   ; $43EC: $09
     dec  [hl]                                     ; $43ED: $35
@@ -375,7 +375,7 @@ jr_015_44D1:
 jr_015_44D7:
     call func_015_7B0D                            ; $44D7: $CD $0D $7B
     call func_015_7B3E                            ; $44DA: $CD $3E $7B
-    call func_015_7B88                            ; $44DD: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $44DD: $CD $88 $7B
     call label_3B23                               ; $44E0: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $44E3: $F0 $F0
     JP_TABLE                                      ; $44E5
@@ -453,7 +453,7 @@ jr_015_454E:
 
 func_015_4553::
     call label_3B39                               ; $4553: $CD $39 $3B
-    call func_015_7BC1                            ; $4556: $CD $C1 $7B
+    call AddEntityZSpeedToPos_15                  ; $4556: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $4559: $21 $20 $C3
     add  hl, bc                                   ; $455C: $09
     dec  [hl]                                     ; $455D: $35
@@ -696,9 +696,9 @@ jr_015_46E1:
     ld   hl, wEntitiesPhysicsFlagsTable           ; $46F3: $21 $40 $C3
     add  hl, bc                                   ; $46F6: $09
     res  7, [hl]                                  ; $46F7: $CB $BE
-    call func_015_7B88                            ; $46F9: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $46F9: $CD $88 $7B
     call label_3B23                               ; $46FC: $CD $23 $3B
-    call func_015_7BC1                            ; $46FF: $CD $C1 $7B
+    call AddEntityZSpeedToPos_15                  ; $46FF: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $4702: $21 $20 $C3
     add  hl, bc                                   ; $4705: $09
     dec  [hl]                                     ; $4706: $35
@@ -1379,7 +1379,7 @@ jr_015_4C49:
     ld   [hl], a                                  ; $4C7E: $77
 
 jr_015_4C7F:
-    call func_015_7B88                            ; $4C7F: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $4C7F: $CD $88 $7B
     jp   label_3B23                               ; $4C82: $C3 $23 $3B
 
 func_015_4C85::
@@ -1451,7 +1451,7 @@ label_015_4CD9:
     call label_3B39                               ; $4CEA: $CD $39 $3B
 
 jr_015_4CED:
-    call func_015_7B88                            ; $4CED: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $4CED: $CD $88 $7B
     call label_3B23                               ; $4CF0: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $4CF3: $21 $A0 $C2
     add  hl, bc                                   ; $4CF6: $09
@@ -1611,7 +1611,7 @@ label_015_4DB5:
     ldh  [hLinkPositionYIncrement], a             ; $4DF0: $E0 $9B
 
 jr_015_4DF2:
-    call func_015_7B8B                            ; $4DF2: $CD $8B $7B
+    call UpdateEntityYPosWithSpeed_15             ; $4DF2: $CD $8B $7B
     ldh  a, [hActiveEntityState]                  ; $4DF5: $F0 $F0
     and  a                                        ; $4DF7: $A7
     jr   z, jr_015_4E49                           ; $4DF8: $28 $4F
@@ -1697,7 +1697,7 @@ label_015_4E62:
     ld   de, Data_015_4DA9                        ; $4E6A: $11 $A9 $4D
     call RenderActiveEntitySpritesPair            ; $4E6D: $CD $C0 $3B
     call func_015_7B0D                            ; $4E70: $CD $0D $7B
-    call func_015_7B88                            ; $4E73: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $4E73: $CD $88 $7B
     call GetEntityTransitionCountdown             ; $4E76: $CD $05 $0C
     jp   z, ClearEntityStatus_15            ; $4E79: $CA $31 $7C
 
@@ -1728,7 +1728,7 @@ StalfosEvasiveEntityHandler::
     rra                                           ; $4EAB: $1F
     and  $01                                      ; $4EAC: $E6 $01
     call SetEntitySpriteVariant                   ; $4EAE: $CD $0C $3B
-    call func_015_7B88                            ; $4EB1: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $4EB1: $CD $88 $7B
     call label_3B23                               ; $4EB4: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $4EB7: $21 $A0 $C2
     add  hl, bc                                   ; $4EBA: $09
@@ -1832,7 +1832,7 @@ jr_015_4F50:
 ._01 dw func_015_501A                             ; $4F58
 
 func_015_4F5A::
-    call func_015_7B88                            ; $4F5A: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $4F5A: $CD $88 $7B
     call label_3B23                               ; $4F5D: $CD $23 $3B
     ldh  a, [hJoypadState]                        ; $4F60: $F0 $CC
     and  $30                                      ; $4F62: $E6 $30
@@ -1958,7 +1958,7 @@ jr_015_500A:
     jp   SetEntitySpriteVariant                   ; $5017: $C3 $0C $3B
 
 func_015_501A::
-    call func_015_7B88                            ; $501A: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $501A: $CD $88 $7B
     ld   hl, wEntitiesIgnoreHitsCountdownTable    ; $501D: $21 $10 $C4
     add  hl, bc                                   ; $5020: $09
     ld   a, [hl]                                  ; $5021: $7E
@@ -1967,7 +1967,7 @@ func_015_501A::
     call label_3B23                               ; $5025: $CD $23 $3B
     pop  hl                                       ; $5028: $E1
     ld   [hl], b                                  ; $5029: $70
-    call func_015_7BC1                            ; $502A: $CD $C1 $7B
+    call AddEntityZSpeedToPos_15                  ; $502A: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $502D: $21 $20 $C3
     add  hl, bc                                   ; $5030: $09
     dec  [hl]                                     ; $5031: $35
@@ -2156,12 +2156,12 @@ func_015_5138::
     call IncrementEntityState                     ; $514D: $CD $12 $3B
 
 jr_015_5150:
-    jp   func_015_7B8B                            ; $5150: $C3 $8B $7B
+    jp   UpdateEntityYPosWithSpeed_15             ; $5150: $C3 $8B $7B
 
 func_015_5153::
     call func_015_5631                            ; $5153: $CD $31 $56
     call func_015_7B0D                            ; $5156: $CD $0D $7B
-    call func_015_7B8B                            ; $5159: $CD $8B $7B
+    call UpdateEntityYPosWithSpeed_15             ; $5159: $CD $8B $7B
     call GetEntityTransitionCountdown             ; $515C: $CD $05 $0C
     ret  nz                                       ; $515F: $C0
 
@@ -2302,9 +2302,9 @@ func_015_520C::
 func_015_522C::
     call func_015_5435                            ; $522C: $CD $35 $54
     call label_3B39                               ; $522F: $CD $39 $3B
-    call func_015_7B88                            ; $5232: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $5232: $CD $88 $7B
     call label_3B23                               ; $5235: $CD $23 $3B
-    call func_015_7BC1                            ; $5238: $CD $C1 $7B
+    call AddEntityZSpeedToPos_15                  ; $5238: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $523B: $21 $20 $C3
     add  hl, bc                                   ; $523E: $09
     dec  [hl]                                     ; $523F: $35
@@ -2578,7 +2578,7 @@ Data_015_53DD::
     db   $05, $03, $04, $03
 
 func_015_53E1::
-    call func_015_7BC1                            ; $53E1: $CD $C1 $7B
+    call AddEntityZSpeedToPos_15                  ; $53E1: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $53E4: $21 $20 $C3
     add  hl, bc                                   ; $53E7: $09
     dec  [hl]                                     ; $53E8: $35
@@ -2761,7 +2761,7 @@ label_015_54D6:
     and  [hl]                                     ; $54FC: $A6
     ret  nz                                       ; $54FD: $C0
 
-    jp   func_015_7B88                            ; $54FE: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15              ; $54FE: $C3 $88 $7B
 
 Data_015_5501::
     db   $00, $00, $4C, $00, $00, $08, $4C, $20, $00, $08, $FF, $20, $00, $10, $FF, $20
@@ -2984,7 +2984,7 @@ jr_015_57B7:
     ldh  [hLinkPositionY], a                      ; $57B8: $E0 $99
     pop  af                                       ; $57BA: $F1
     ldh  [hLinkPositionX], a                      ; $57BB: $E0 $98
-    jp   func_015_7B88                            ; $57BD: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15              ; $57BD: $C3 $88 $7B
 
 Data_015_57C0::
     db   $04, $03, $02, $01, $00, $00, $00, $00, $00, $00, $00, $00, $00, $00, $00
@@ -3280,7 +3280,7 @@ jr_015_59AC:
     ldh  [hLinkPositionX], a                      ; $59AD: $E0 $98
     pop  af                                       ; $59AF: $F1
     ldh  [hLinkPositionY], a                      ; $59B0: $E0 $99
-    jp   func_015_7B88                            ; $59B2: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15              ; $59B2: $C3 $88 $7B
 
 Data_015_59B5::
     db   $00, $0A, $0F, $05
@@ -3391,7 +3391,7 @@ jr_015_5A5E:
     ldh  [hLinkPositionY], a                      ; $5A5F: $E0 $99
     pop  af                                       ; $5A61: $F1
     ldh  [hLinkPositionX], a                      ; $5A62: $E0 $98
-    jp   func_015_7B88                            ; $5A64: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15              ; $5A64: $C3 $88 $7B
 
 func_015_5A67::
     call func_015_5D8D                            ; $5A67: $CD $8D $5D
@@ -3657,7 +3657,7 @@ jr_015_5E20:
     jp   SetEntitySpriteVariant                   ; $5E21: $C3 $0C $3B
 
 jr_015_5E24:
-    call func_015_7B88                            ; $5E24: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $5E24: $CD $88 $7B
     call label_3B23                               ; $5E27: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $5E2A: $F0 $F0
     JP_TABLE                                      ; $5E2C
@@ -4278,7 +4278,7 @@ func_015_6331::
     and  a                                        ; $633C: $A7
     jr   nz, jr_015_6342                          ; $633D: $20 $03
 
-    call func_015_7B88                            ; $633F: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $633F: $CD $88 $7B
 
 jr_015_6342:
     call label_3B23                               ; $6342: $CD $23 $3B
@@ -4497,7 +4497,7 @@ jr_015_64F8:
     ldh  [hLinkPositionY], a                      ; $64F9: $E0 $99
     pop  af                                       ; $64FB: $F1
     ldh  [hLinkPositionX], a                      ; $64FC: $E0 $98
-    jp   func_015_7B88                            ; $64FE: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15              ; $64FE: $C3 $88 $7B
 
 Data_015_6501::
     db   $04, $03, $02, $01, $00, $00, $00, $00, $00, $00, $00, $00, $00
@@ -4925,7 +4925,7 @@ jr_015_67D9:
     ldh  [hLinkPositionY], a                      ; $67DA: $E0 $99
     pop  af                                       ; $67DC: $F1
     ldh  [hLinkPositionX], a                      ; $67DD: $E0 $98
-    jp   func_015_7B88                            ; $67DF: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15              ; $67DF: $C3 $88 $7B
 
 func_015_67E2::
     ret                                           ; $67E2: $C9
@@ -4960,7 +4960,7 @@ func_015_67FA::
 
 func_015_6811::
     call label_3B39                               ; $6811: $CD $39 $3B
-    call func_015_7B88                            ; $6814: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $6814: $CD $88 $7B
     call label_3B23                               ; $6817: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $681A: $F0 $E7
     and  $01                                      ; $681C: $E6 $01
@@ -5089,7 +5089,7 @@ jr_015_68D6:
     ldh  [hLinkPositionY], a                      ; $68D7: $E0 $99
     pop  af                                       ; $68D9: $F1
     ldh  [hLinkPositionX], a                      ; $68DA: $E0 $98
-    jp   func_015_7B88                            ; $68DC: $C3 $88 $7B
+    jp   UpdateEntityPosWithSpeed_15                            ; $68DC: $C3 $88 $7B
 
 Data_015_68DF::
     db   $00, $00, $00, $01, $01, $01, $02, $02
@@ -5349,7 +5349,7 @@ jr_015_6CAB:
     ld   hl, wEntitiesUnknowTableY                ; $6CAB: $21 $D0 $C3
     add  hl, bc                                   ; $6CAE: $09
     inc  [hl]                                     ; $6CAF: $34
-    call func_015_7B88                            ; $6CB0: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $6CB0: $CD $88 $7B
     call label_3B44                               ; $6CB3: $CD $44 $3B
     call GetEntityTransitionCountdown             ; $6CB6: $CD $05 $0C
     jr   z, jr_015_6CBC                           ; $6CB9: $28 $01
@@ -5522,7 +5522,7 @@ jr_015_6DBB:
     rra                                           ; $6DBB: $1F
     jr   nc, jr_015_6DC4                          ; $6DBC: $30 $06
 
-    call func_015_7B88                            ; $6DBE: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $6DBE: $CD $88 $7B
 
 jr_015_6DC1:
     call label_3B44                               ; $6DC1: $CD $44 $3B
@@ -5782,7 +5782,7 @@ jr_015_6F6C:
     ldh  [hLinkPositionY], a                      ; $6F6E: $E0 $99
 
 jr_015_6F70:
-    call func_015_7B88                            ; $6F70: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $6F70: $CD $88 $7B
     call label_3B23                               ; $6F73: $CD $23 $3B
     ld   hl, wEntitiesPrivateState1Table          ; $6F76: $21 $B0 $C2
     add  hl, bc                                   ; $6F79: $09
@@ -6243,7 +6243,7 @@ SandCrabEntityHandler::
     call RenderActiveEntitySpritesPair            ; $7333: $CD $C0 $3B
     call func_015_7B0D                            ; $7336: $CD $0D $7B
     call func_015_7B3E                            ; $7339: $CD $3E $7B
-    call func_015_7B88                            ; $733C: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $733C: $CD $88 $7B
     call label_3B23                               ; $733F: $CD $23 $3B
     call label_3B39                               ; $7342: $CD $39 $3B
     ldh  a, [hFrameCounter]                       ; $7345: $F0 $E7
@@ -6367,7 +6367,7 @@ jr_015_7408:
     ld   [hl], a                                  ; $7412: $77
     ld   a, JINGLE_URCHIN_PUSH                    ; $7413: $3E $3E
     ldh  [hJingle], a                             ; $7415: $E0 $F2
-    call func_015_7B88                            ; $7417: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $7417: $CD $88 $7B
     ld   hl, wEntitiesIgnoreHitsCountdownTable    ; $741A: $21 $10 $C4
     add  hl, bc                                   ; $741D: $09
     ld   [hl], $03                                ; $741E: $36 $03
@@ -6403,7 +6403,7 @@ Entity68Handler::
     ld   hl, wEntitiesSpeedYTable                 ; $7446: $21 $50 $C2
     add  hl, bc                                   ; $7449: $09
     ld   [hl], a                                  ; $744A: $77
-    call func_015_7B8B                            ; $744B: $CD $8B $7B
+    call UpdateEntityYPosWithSpeed_15             ; $744B: $CD $8B $7B
     call label_3B23                               ; $744E: $CD $23 $3B
     ldh  a, [hObjectUnderEntity]                  ; $7451: $F0 $AF
     cp   $9D                                      ; $7453: $FE $9D
@@ -6619,7 +6619,7 @@ label_015_757F:
     rra                                           ; $758F: $1F
     and  $01                                      ; $7590: $E6 $01
     call SetEntitySpriteVariant                   ; $7592: $CD $0C $3B
-    call func_015_7B88                            ; $7595: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $7595: $CD $88 $7B
     call GetEntityPrivateCountdown1               ; $7598: $CD $00 $0C
     jr   nz, jr_015_75A0                          ; $759B: $20 $03
 
@@ -6671,7 +6671,7 @@ LaserBeamEntityHandler::
     call CheckLinkCollisionWithProjectile_trampoline; $75DE: $CD $4F $3B
 
 jr_015_75E1:
-    call func_015_7B88                            ; $75E1: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $75E1: $CD $88 $7B
     call label_3B2E                               ; $75E4: $CD $2E $3B
     ld   hl, wEntitiesCollisionsTable             ; $75E7: $21 $A0 $C2
     add  hl, bc                                   ; $75EA: $09
@@ -6925,8 +6925,8 @@ jr_015_7792:
 func_015_7793::
     ld   a, $03                                   ; $7793: $3E $03
     call SetEntitySpriteVariant                   ; $7795: $CD $0C $3B
-    call func_015_7B88                            ; $7798: $CD $88 $7B
-    call func_015_7BC1                            ; $779B: $CD $C1 $7B
+    call UpdateEntityPosWithSpeed_15              ; $7798: $CD $88 $7B
+    call AddEntityZSpeedToPos_15                  ; $779B: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $779E: $21 $20 $C3
     add  hl, bc                                   ; $77A1: $09
     dec  [hl]                                     ; $77A2: $35
@@ -6954,8 +6954,8 @@ jr_015_77BE:
 func_015_77BF::
     ld   a, $00                                   ; $77BF: $3E $00
     call SetEntitySpriteVariant                   ; $77C1: $CD $0C $3B
-    call func_015_7B88                            ; $77C4: $CD $88 $7B
-    call func_015_7BC1                            ; $77C7: $CD $C1 $7B
+    call UpdateEntityPosWithSpeed_15              ; $77C4: $CD $88 $7B
+    call AddEntityZSpeedToPos_15                  ; $77C7: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $77CA: $21 $20 $C3
     add  hl, bc                                   ; $77CD: $09
     dec  [hl]                                     ; $77CE: $35
@@ -7025,8 +7025,8 @@ label_015_7825:
     and  $01                                      ; $7837: $E6 $01
     call SetEntitySpriteVariant                   ; $7839: $CD $0C $3B
     call label_3B39                               ; $783C: $CD $39 $3B
-    call func_015_7B88                            ; $783F: $CD $88 $7B
-    call func_015_7BC1                            ; $7842: $CD $C1 $7B
+    call UpdateEntityPosWithSpeed_15              ; $783F: $CD $88 $7B
+    call AddEntityZSpeedToPos_15                  ; $7842: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $7845: $21 $20 $C3
     add  hl, bc                                   ; $7848: $09
     dec  [hl]                                     ; $7849: $35
@@ -7092,7 +7092,7 @@ jr_015_78AB:
     ld   de, Data_015_788D                        ; $78AB: $11 $8D $78
     call RenderActiveEntitySpritesPair            ; $78AE: $CD $C0 $3B
     call func_015_7B0D                            ; $78B1: $CD $0D $7B
-    call func_015_7BC1                            ; $78B4: $CD $C1 $7B
+    call AddEntityZSpeedToPos_15                  ; $78B4: $CD $C1 $7B
     ld   hl, wEntitiesSpeedZTable                 ; $78B7: $21 $20 $C3
     add  hl, bc                                   ; $78BA: $09
     dec  [hl]                                     ; $78BB: $35
@@ -7171,7 +7171,7 @@ jr_015_792D:
     ret                                           ; $792D: $C9
 
 func_015_792E::
-    call func_015_7B88                            ; $792E: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $792E: $CD $88 $7B
     call label_3B23                               ; $7931: $CD $23 $3B
     ldh  a, [hFFE8]                               ; $7934: $F0 $E8
     and  a                                        ; $7936: $A7
@@ -7590,7 +7590,7 @@ func_015_7B3E::
     ld   hl, wEntitiesSpeedYTable                 ; $7B66: $21 $50 $C2
     add  hl, bc                                   ; $7B69: $09
     ld   [hl], a                                  ; $7B6A: $77
-    call func_015_7B88                            ; $7B6B: $CD $88 $7B
+    call UpdateEntityPosWithSpeed_15              ; $7B6B: $CD $88 $7B
     ld   hl, wEntitiesUnknowTableH                ; $7B6E: $21 $30 $C4
     add  hl, bc                                   ; $7B71: $09
     ld   a, [hl]                                  ; $7B72: $7E
@@ -7613,72 +7613,88 @@ jr_015_7B7A:
 jr_015_7B87:
     ret                                           ; $7B87: $C9
 
-func_015_7B88::
-    call func_015_7B95                            ; $7B88: $CD $95 $7B
+UpdateEntityPosWithSpeed_15::
+    call AddEntitySpeedToPos_15                   ; $7B88: $CD $95 $7B
 
-func_015_7B8B::
+UpdateEntityYPosWithSpeed_15::
     push bc                                       ; $7B8B: $C5
     ld   a, c                                     ; $7B8C: $79
     add  $10                                      ; $7B8D: $C6 $10
     ld   c, a                                     ; $7B8F: $4F
-    call func_015_7B95                            ; $7B90: $CD $95 $7B
+    call AddEntitySpeedToPos_15                   ; $7B90: $CD $95 $7B
     pop  bc                                       ; $7B93: $C1
     ret                                           ; $7B94: $C9
 
-func_015_7B95::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_15::
     ld   hl, wEntitiesSpeedXTable                 ; $7B95: $21 $40 $C2
     add  hl, bc                                   ; $7B98: $09
     ld   a, [hl]                                  ; $7B99: $7E
     and  a                                        ; $7B9A: $A7
-    jr   z, jr_015_7BC0                           ; $7B9B: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7B9B: $28 $23
 
     push af                                       ; $7B9D: $F5
+    ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $7B9E: $CB $37
     and  $F0                                      ; $7BA0: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7BA2: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7BA2: $21 $60 $C2
     add  hl, bc                                   ; $7BA5: $09
     add  [hl]                                     ; $7BA6: $86
     ld   [hl], a                                  ; $7BA7: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7BA8: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7BAA: $21 $00 $C2
 
-jr_015_7BAD:
+.updatePosition
     add  hl, bc                                   ; $7BAD: $09
     pop  af                                       ; $7BAE: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7BAF: $1E $00
     bit  7, a                                     ; $7BB1: $CB $7F
-    jr   z, jr_015_7BB7                           ; $7BB3: $28 $02
+    jr   z, .positive                             ; $7BB3: $28 $02
 
     ld   e, $F0                                   ; $7BB5: $1E $F0
 
-jr_015_7BB7:
+.positive
     swap a                                        ; $7BB7: $CB $37
     and  $0F                                      ; $7BB9: $E6 $0F
     or   e                                        ; $7BBB: $B3
+    ; Get carry back from d
     rr   d                                        ; $7BBC: $CB $1A
     adc  [hl]                                     ; $7BBE: $8E
     ld   [hl], a                                  ; $7BBF: $77
 
-jr_015_7BC0:
+.return
     ret                                           ; $7BC0: $C9
 
-func_015_7BC1::
+AddEntityZSpeedToPos_15::
     ld   hl, wEntitiesSpeedZTable                 ; $7BC1: $21 $20 $C3
     add  hl, bc                                   ; $7BC4: $09
     ld   a, [hl]                                  ; $7BC5: $7E
     and  a                                        ; $7BC6: $A7
-    jr   z, jr_015_7BC0                           ; $7BC7: $28 $F7
+    jr   z, AddEntitySpeedToPos_15.return         ; $7BC7: $28 $F7
 
     push af                                       ; $7BC9: $F5
     swap a                                        ; $7BCA: $CB $37
     and  $F0                                      ; $7BCC: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7BCE: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7BCE: $21 $30 $C3
     add  hl, bc                                   ; $7BD1: $09
     add  [hl]                                     ; $7BD2: $86
     ld   [hl], a                                  ; $7BD3: $77
     rl   d                                        ; $7BD4: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7BD6: $21 $10 $C3
-    jr   jr_015_7BAD                              ; $7BD9: $18 $D2
+    jr   AddEntitySpeedToPos_15.updatePosition    ; $7BD9: $18 $D2
 
 func_015_7BDB::
     ld   e, $00                                   ; $7BDB: $1E $00

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -1958,7 +1958,7 @@ MadBatterState2Handler::
     ld   hl, wEntitiesSpeedYTable                 ; $4F53: $21 $50 $C2
     add  hl, bc                                   ; $4F56: $09
     ld   [hl], $FC                                ; $4F57: $36 $FC
-    jp   func_018_7E5F                            ; $4F59: $C3 $5F $7E
+    jp   UpdateEntityPosWithSpeed_18              ; $4F59: $C3 $5F $7E
 
 MadBatterState3Handler::
     call MadBatterRenderSmallSprite                            ; $4F5C: $CD $C3 $50
@@ -2135,7 +2135,7 @@ MadBatterState8Handler::
     ldh  [hJingle], a                             ; $5065: $E0 $F2
 
 jr_018_5067:
-    call func_018_7E62                            ; $5067: $CD $62 $7E
+    call UpdateEntityYPosWithSpeed_18             ; $5067: $CD $62 $7E
     ld   hl, wEntitiesSpeedYTable                 ; $506A: $21 $50 $C2
     add  hl, bc                                   ; $506D: $09
     dec  [hl]                                     ; $506E: $35
@@ -2706,7 +2706,7 @@ ENDC
     ld   hl, wEntitiesSpeedYTable                 ; $5451: $21 $50 $C2
     add  hl, bc                                   ; $5454: $09
     ld   [hl], $04                                ; $5455: $36 $04
-    call func_018_7E62                            ; $5457: $CD $62 $7E
+    call UpdateEntityYPosWithSpeed_18             ; $5457: $CD $62 $7E
     ld   a, $01                                   ; $545A: $3E $01
     ldh  [$FFBA], a                               ; $545C: $E0 $BA
 
@@ -2727,7 +2727,7 @@ jr_018_5466:
     ld   hl, wEntitiesSpeedYTable                 ; $546C: $21 $50 $C2
     add  hl, bc                                   ; $546F: $09
     ld   [hl], $FD                                ; $5470: $36 $FD
-    call func_018_7E62                            ; $5472: $CD $62 $7E
+    call UpdateEntityYPosWithSpeed_18             ; $5472: $CD $62 $7E
 
 IF !__PATCH_0__
     ld   a, $00                                   ; $5475: $3E $00
@@ -2828,7 +2828,7 @@ jr_018_54EE:
     and  $03                                      ; $54FB: $E6 $03
     ret  nz                                       ; $54FD: $C0
 
-    jp   func_018_7E5F                            ; $54FE: $C3 $5F $7E
+    jp   UpdateEntityPosWithSpeed_18              ; $54FE: $C3 $5F $7E
 
 WalrusEntityHandler::
     ld   hl, wEntitiesPrivateState1Table          ; $5501: $21 $B0 $C2
@@ -4493,7 +4493,7 @@ jr_018_6064:
     ld   hl, wEntitiesDirectionTable              ; $606A: $21 $80 $C3
     add  hl, bc                                   ; $606D: $09
     ld   [hl], $03                                ; $606E: $36 $03
-    jp   func_018_7E62                            ; $6070: $C3 $62 $7E
+    jp   UpdateEntityYPosWithSpeed_18             ; $6070: $C3 $62 $7E
 
 MarinAtTalTalHeightsStateBHandler::
     ld   a, $02                                   ; $6073: $3E $02
@@ -4579,7 +4579,7 @@ func_018_6109::
     ld   hl, wEntitiesSpeedYTable                 ; $610F: $21 $50 $C2
     add  hl, bc                                   ; $6112: $09
     ld   [hl], $F4                                ; $6113: $36 $F4
-    call func_018_7E62                            ; $6115: $CD $62 $7E
+    call UpdateEntityYPosWithSpeed_18             ; $6115: $CD $62 $7E
     ldh  a, [hActiveEntityVisualPosY]             ; $6118: $F0 $EC
     cp   $70                                      ; $611A: $FE $70
     ret  nc                                       ; $611C: $D0
@@ -5064,7 +5064,7 @@ jr_018_644C:
     jp   SetEntitySpriteVariant                   ; $644D: $C3 $0C $3B
 
 ZombieState2Handler::
-    call func_018_7E5F                            ; $6450: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $6450: $CD $5F $7E
     call label_3B23                               ; $6453: $CD $23 $3B
     call label_3B39                               ; $6456: $CD $39 $3B
     ld   hl, wEntitiesCollisionsTable             ; $6459: $21 $A0 $C2
@@ -5195,7 +5195,7 @@ jr_018_650A:
     call label_3B39                               ; $6516: $CD $39 $3B
 
 jr_018_6519:
-    call func_018_7E5F                            ; $6519: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $6519: $CD $5F $7E
     call label_3B23                               ; $651C: $CD $23 $3B
     call AddEntityZSpeedToPos_18                  ; $651F: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $6522: $21 $20 $C3
@@ -5839,7 +5839,7 @@ jr_018_6A71:
 jr_018_6A8B:
     call func_018_7DE8                            ; $6A8B: $CD $E8 $7D
     call func_018_7E15                            ; $6A8E: $CD $15 $7E
-    call func_018_7E5F                            ; $6A91: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $6A91: $CD $5F $7E
     call AddEntityZSpeedToPos_18                  ; $6A94: $CD $98 $7E
     ldh  a, [hActiveEntityState]                  ; $6A97: $F0 $F0
     JP_TABLE                                      ; $6A99
@@ -6635,7 +6635,7 @@ jr_018_6F51:
     jp   ClearEntityStatusBank18                  ; $6F51: $C3 $08 $7F
 
 jr_018_6F54:
-    call func_018_7E5F                            ; $6F54: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $6F54: $CD $5F $7E
     call GetEntityTransitionCountdown             ; $6F57: $CD $05 $0C
     ret  nz                                       ; $6F5A: $C0
 
@@ -6661,7 +6661,7 @@ label_018_6F70:
     call RenderActiveEntitySpritesPair            ; $6F73: $CD $C0 $3B
     call func_018_7DE8                            ; $6F76: $CD $E8 $7D
     call func_018_7E15                            ; $6F79: $CD $15 $7E
-    call func_018_7E5F                            ; $6F7C: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $6F7C: $CD $5F $7E
     ldh  a, [hFrameCounter]                       ; $6F7F: $F0 $E7
     and  $03                                      ; $6F81: $E6 $03
     jr   nz, jr_018_6F95                          ; $6F83: $20 $10
@@ -7108,7 +7108,7 @@ jr_018_726D:
     ldh  [hLinkPositionX], a                      ; $7271: $E0 $98
 
 func_018_7273::
-    call func_018_7E5F                            ; $7273: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $7273: $CD $5F $7E
 
 label_018_7276:
     ldh  a, [hFrameCounter]                       ; $7276: $F0 $E7
@@ -7213,7 +7213,7 @@ TurtleRockHeadEntityHandler::
     ld   de, Data_018_72F5                        ; $7310: $11 $F5 $72
     call RenderActiveEntitySprite                 ; $7313: $CD $77 $3C
     call func_018_7DE8                            ; $7316: $CD $E8 $7D
-    call func_018_7E5F                            ; $7319: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $7319: $CD $5F $7E
     call AddEntityZSpeedToPos_18                  ; $731C: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $731F: $21 $20 $C3
     add  hl, bc                                   ; $7322: $09
@@ -7493,7 +7493,7 @@ jr_018_74BC:
     ld   hl, wEntitiesSpeedYTable                 ; $74BC: $21 $50 $C2
     add  hl, bc                                   ; $74BF: $09
     ld   [hl], $04                                ; $74C0: $36 $04
-    jp   func_018_7E62                            ; $74C2: $C3 $62 $7E
+    jp   UpdateEntityYPosWithSpeed_18             ; $74C2: $C3 $62 $7E
 
 TurtleRockHeadState6Handler::
     call GetEntityTransitionCountdown             ; $74C5: $CD $05 $0C
@@ -7591,7 +7591,7 @@ jr_018_7546:
     call IncrementEntityState                     ; $7546: $CD $12 $3B
 
 jr_018_7549:
-    jp   func_018_7E5F                            ; $7549: $C3 $5F $7E
+    jp   UpdateEntityPosWithSpeed_18              ; $7549: $C3 $5F $7E
 
 TurtleRockHeadStateBHandler::
     ldh  a, [hLinkPositionX]                      ; $754C: $F0 $98
@@ -7628,7 +7628,7 @@ jr_018_7585:
     ldh  [hLinkPositionY], a                      ; $7586: $E0 $99
     pop  af                                       ; $7588: $F1
     ldh  [hLinkPositionX], a                      ; $7589: $E0 $98
-    jp   func_018_7E5F                            ; $758B: $C3 $5F $7E
+    jp   UpdateEntityPosWithSpeed_18              ; $758B: $C3 $5F $7E
 
 Data_018_758E::
     db   $F0, $F8, $7A, $16, $F0, $00, $7C, $16, $F0, $08, $7C, $36, $F0, $10, $7A, $36
@@ -7833,7 +7833,7 @@ BuzzBlobState0Handler::
     ld   [hl], a                                  ; $77A8: $77
 
 jr_018_77A9:
-    call func_018_7E5F                            ; $77A9: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $77A9: $CD $5F $7E
     call label_3B23                               ; $77AC: $CD $23 $3B
     ld   hl, wEntitiesPrivateState1Table          ; $77AF: $21 $B0 $C2
     add  hl, bc                                   ; $77B2: $09
@@ -7923,7 +7923,7 @@ BomberEntityHandler::
     add  hl, bc                                   ; $7851: $09
     ld   [hl], a                                  ; $7852: $77
     call func_018_7E15                            ; $7853: $CD $15 $7E
-    call func_018_7E5F                            ; $7856: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $7856: $CD $5F $7E
     call label_3B23                               ; $7859: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $785C: $F0 $F0
     JP_TABLE                                      ; $785E
@@ -8725,7 +8725,7 @@ func_018_7E15::
     ld   hl, wEntitiesSpeedYTable                 ; $7E3D: $21 $50 $C2
     add  hl, bc                                   ; $7E40: $09
     ld   [hl], a                                  ; $7E41: $77
-    call func_018_7E5F                            ; $7E42: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $7E42: $CD $5F $7E
     ld   hl, wEntitiesUnknowTableH                ; $7E45: $21 $30 $C4
     add  hl, bc                                   ; $7E48: $09
     ld   a, [hl]                                  ; $7E49: $7E

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -1145,7 +1145,7 @@ jr_018_49B6:
     ld   hl, wEntitiesSpeedXTable                 ; $49B7: $21 $40 $C2
     add  hl, bc                                   ; $49BA: $09
     ld   [hl], $FC                                ; $49BB: $36 $FC
-    jp   func_018_7E6C                            ; $49BD: $C3 $6C $7E
+    jp   AddEntitySpeedToPos_18                   ; $49BD: $C3 $6C $7E
 
 Data_018_49C0::
     db   $FF, $FF, $FF, $FF, $54, $02, $54, $62, $54, $42, $54, $22, $56, $02, $56, $22
@@ -2319,7 +2319,7 @@ BunnyD3EntityHandler::
 jr_018_51F3:
     call func_018_7D60                            ; $51F3: $CD $60 $7D
     call func_018_7DE8                            ; $51F6: $CD $E8 $7D
-    call func_018_7E98                            ; $51F9: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $51F9: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $51FC: $21 $20 $C3
     add  hl, bc                                   ; $51FF: $09
     dec  [hl]                                     ; $5200: $35
@@ -2435,7 +2435,7 @@ BunnyCallingMarinEntityHandler::
     ld   a, $02                                   ; $52B6: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $52B8: $E0 $A1
     ld   [wC167], a                               ; $52BA: $EA $67 $C1
-    call func_018_7E98                            ; $52BD: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $52BD: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $52C0: $21 $20 $C3
     add  hl, bc                                   ; $52C3: $09
     dec  [hl]                                     ; $52C4: $35
@@ -2467,7 +2467,7 @@ BunnyCallingMarinState0Handler::
     ld   hl, wEntitiesSpeedXTable                 ; $52E6: $21 $40 $C2
     add  hl, bc                                   ; $52E9: $09
     ld   [hl], $0C                                ; $52EA: $36 $0C
-    call func_018_7E6C                            ; $52EC: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $52EC: $CD $6C $7E
     ldh  a, [hActiveEntityPosX]                   ; $52EF: $F0 $EE
     cp   $20                                      ; $52F1: $FE $20
     jr   nz, jr_018_5304                          ; $52F3: $20 $0F
@@ -2579,7 +2579,7 @@ jr_018_5375:
     ld   hl, wEntitiesSpeedXTable                 ; $538E: $21 $40 $C2
     add  hl, bc                                   ; $5391: $09
     ld   [hl], $EC                                ; $5392: $36 $EC
-    call func_018_7E6C                            ; $5394: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $5394: $CD $6C $7E
 
 jr_018_5397:
     ld   a, [$C50F]                               ; $5397: $FA $0F $C5
@@ -2601,7 +2601,7 @@ jr_018_5397:
     push bc                                       ; $53B1: $C5
     ld   c, e                                     ; $53B2: $4B
     ld   b, d                                     ; $53B3: $42
-    call func_018_7E6C                            ; $53B4: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $53B4: $CD $6C $7E
     pop  bc                                       ; $53B7: $C1
     pop  de                                       ; $53B8: $D1
     ld   hl, wEntitiesPosXTable                   ; $53B9: $21 $00 $C2
@@ -2843,7 +2843,7 @@ WalrusEntityHandler::
 
     call func_018_586B                            ; $5512: $CD $6B $58
     call func_018_7DE8                            ; $5515: $CD $E8 $7D
-    call func_018_7E98                            ; $5518: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $5518: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $551B: $21 $20 $C3
     add  hl, bc                                   ; $551E: $09
     dec  [hl]                                     ; $551F: $35
@@ -3765,7 +3765,7 @@ func_018_5BD0::
     ld   hl, wEntitiesSpeedXTable                 ; $5BD5: $21 $40 $C2
     add  hl, bc                                   ; $5BD8: $09
     ld   [hl], $F4                                ; $5BD9: $36 $F4
-    call func_018_7E6C                            ; $5BDB: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $5BDB: $CD $6C $7E
     ldh  a, [hFrameCounter]                       ; $5BDE: $F0 $E7
     and  $08                                      ; $5BE0: $E6 $08
     ld   e, $04                                   ; $5BE2: $1E $04
@@ -4275,7 +4275,7 @@ MarinAtTalTalHeightsEntityHandler::
     ld   de, Data_018_5EB7                        ; $5EFA: $11 $B7 $5E
     call RenderActiveEntitySpritesPair            ; $5EFD: $CD $C0 $3B
     call func_018_7D60                            ; $5F00: $CD $60 $7D
-    call func_018_7E98                            ; $5F03: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $5F03: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $5F06: $21 $20 $C3
     add  hl, bc                                   ; $5F09: $09
     dec  [hl]                                     ; $5F0A: $35
@@ -4504,7 +4504,7 @@ MarinAtTalTalHeightsStateBHandler::
     ld   hl, wEntitiesDirectionTable              ; $607D: $21 $80 $C3
     add  hl, bc                                   ; $6080: $09
     ld   [hl], $01                                ; $6081: $36 $01
-    call func_018_7E6C                            ; $6083: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $6083: $CD $6C $7E
     ldh  a, [hActiveEntityPosX]                   ; $6086: $F0 $EE
     cp   $18                                      ; $6088: $FE $18
     ret  nc                                       ; $608A: $D0
@@ -4531,7 +4531,7 @@ jr_018_60A3:
     ld   hl, wEntitiesDirectionTable              ; $60A9: $21 $80 $C3
     add  hl, bc                                   ; $60AC: $09
     ld   [hl], $01                                ; $60AD: $36 $01
-    call func_018_7E6C                            ; $60AF: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $60AF: $CD $6C $7E
     ldh  a, [hActiveEntityPosX]                   ; $60B2: $F0 $EE
     cp   $F0                                      ; $60B4: $FE $F0
     jr   nz, jr_018_60C7                          ; $60B6: $20 $0F
@@ -4639,7 +4639,7 @@ func_018_6173::
     ld   hl, wEntitiesSpeedXTable                 ; $6179: $21 $40 $C2
     add  hl, bc                                   ; $617C: $09
     ld   [hl], $F8                                ; $617D: $36 $F8
-    call func_018_7E6C                            ; $617F: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $617F: $CD $6C $7E
     ldh  a, [hActiveEntityPosX]                   ; $6182: $F0 $EE
     cp   $E0                                      ; $6184: $FE $E0
     ret  nz                                       ; $6186: $C0
@@ -5197,7 +5197,7 @@ jr_018_650A:
 jr_018_6519:
     call func_018_7E5F                            ; $6519: $CD $5F $7E
     call label_3B23                               ; $651C: $CD $23 $3B
-    call func_018_7E98                            ; $651F: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $651F: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $6522: $21 $20 $C3
     add  hl, bc                                   ; $6525: $09
     dec  [hl]                                     ; $6526: $35
@@ -5840,7 +5840,7 @@ jr_018_6A8B:
     call func_018_7DE8                            ; $6A8B: $CD $E8 $7D
     call func_018_7E15                            ; $6A8E: $CD $15 $7E
     call func_018_7E5F                            ; $6A91: $CD $5F $7E
-    call func_018_7E98                            ; $6A94: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $6A94: $CD $98 $7E
     ldh  a, [hActiveEntityState]                  ; $6A97: $F0 $F0
     JP_TABLE                                      ; $6A99
 ._00 dw VireState0Handler
@@ -6767,7 +6767,7 @@ jr_018_7011:
     ld   hl, wEntitiesSpeedZTable                 ; $7011: $21 $20 $C3
     add  hl, bc                                   ; $7014: $09
     ld   [hl], $20                                ; $7015: $36 $20
-    call func_018_7E98                            ; $7017: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $7017: $CD $98 $7E
     ld   hl, wEntitiesPosZTable                   ; $701A: $21 $10 $C3
     add  hl, bc                                   ; $701D: $09
     ld   a, [hl]                                  ; $701E: $7E
@@ -7166,7 +7166,7 @@ jr_018_72C5:
 func_018_72C8::
     call label_3B39                               ; $72C8: $CD $39 $3B
     call func_018_7273                            ; $72CB: $CD $73 $72
-    call func_018_7E98                            ; $72CE: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $72CE: $CD $98 $7E
     ldh  a, [hFrameCounter]                       ; $72D1: $F0 $E7
     and  $03                                      ; $72D3: $E6 $03
     jr   nz, jr_018_72E1                          ; $72D5: $20 $0A
@@ -7214,7 +7214,7 @@ TurtleRockHeadEntityHandler::
     call RenderActiveEntitySprite                 ; $7313: $CD $77 $3C
     call func_018_7DE8                            ; $7316: $CD $E8 $7D
     call func_018_7E5F                            ; $7319: $CD $5F $7E
-    call func_018_7E98                            ; $731C: $CD $98 $7E
+    call AddEntityZSpeedToPos_18                  ; $731C: $CD $98 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $731F: $21 $20 $C3
     add  hl, bc                                   ; $7322: $09
     dec  [hl]                                     ; $7323: $35
@@ -7351,7 +7351,7 @@ jr_018_73E6:
     ld   hl, wEntitiesSpeedXTable                 ; $73E6: $21 $40 $C2
     add  hl, bc                                   ; $73E9: $09
     ld   [hl], e                                  ; $73EA: $73
-    jp   func_018_7E6C                            ; $73EB: $C3 $6C $7E
+    jp   AddEntitySpeedToPos_18                   ; $73EB: $C3 $6C $7E
 
 Data_018_73EE::
     db   $F8, $08, $10, $00, $00, $08
@@ -7517,7 +7517,7 @@ TurtleRockHeadState7Handler::
     call IncrementEntityState                     ; $74E4: $CD $12 $3B
 
 jr_018_74E7:
-    jp   func_018_7E6C                            ; $74E7: $C3 $6C $7E
+    jp   AddEntitySpeedToPos_18                   ; $74E7: $C3 $6C $7E
 
 TurtleRockHeadState8Handler::
     call GetEntityTransitionCountdown             ; $74EA: $CD $05 $0C
@@ -8748,72 +8748,88 @@ jr_018_7E51:
 jr_018_7E5E:
     ret                                           ; $7E5E: $C9
 
-func_018_7E5F::
-    call func_018_7E6C                            ; $7E5F: $CD $6C $7E
+UpdateEntityPosWithSpeed_18::
+    call AddEntitySpeedToPos_18                   ; $7E5F: $CD $6C $7E
 
-func_018_7E62::
+UpdateEntityYPosWithSpeed_18::
     push bc                                       ; $7E62: $C5
     ld   a, c                                     ; $7E63: $79
     add  $10                                      ; $7E64: $C6 $10
     ld   c, a                                     ; $7E66: $4F
-    call func_018_7E6C                            ; $7E67: $CD $6C $7E
+    call AddEntitySpeedToPos_18                   ; $7E67: $CD $6C $7E
     pop  bc                                       ; $7E6A: $C1
     ret                                           ; $7E6B: $C9
 
-func_018_7E6C::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_18::
     ld   hl, wEntitiesSpeedXTable                 ; $7E6C: $21 $40 $C2
     add  hl, bc                                   ; $7E6F: $09
     ld   a, [hl]                                  ; $7E70: $7E
     and  a                                        ; $7E71: $A7
-    jr   z, jr_018_7E97                           ; $7E72: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7E72: $28 $23
 
     push af                                       ; $7E74: $F5
+    ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $7E75: $CB $37
     and  $F0                                      ; $7E77: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7E79: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7E79: $21 $60 $C2
     add  hl, bc                                   ; $7E7C: $09
     add  [hl]                                     ; $7E7D: $86
     ld   [hl], a                                  ; $7E7E: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7E7F: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7E81: $21 $00 $C2
 
-jr_018_7E84:
+.updatePosition
     add  hl, bc                                   ; $7E84: $09
     pop  af                                       ; $7E85: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7E86: $1E $00
     bit  7, a                                     ; $7E88: $CB $7F
-    jr   z, jr_018_7E8E                           ; $7E8A: $28 $02
+    jr   z, .positive                             ; $7E8A: $28 $02
 
     ld   e, $F0                                   ; $7E8C: $1E $F0
 
-jr_018_7E8E:
+.positive
     swap a                                        ; $7E8E: $CB $37
     and  $0F                                      ; $7E90: $E6 $0F
     or   e                                        ; $7E92: $B3
+    ; Get carry back from d
     rr   d                                        ; $7E93: $CB $1A
     adc  [hl]                                     ; $7E95: $8E
     ld   [hl], a                                  ; $7E96: $77
 
-jr_018_7E97:
+.return
     ret                                           ; $7E97: $C9
 
-func_018_7E98::
+AddEntityZSpeedToPos_18::
     ld   hl, wEntitiesSpeedZTable                 ; $7E98: $21 $20 $C3
     add  hl, bc                                   ; $7E9B: $09
     ld   a, [hl]                                  ; $7E9C: $7E
     and  a                                        ; $7E9D: $A7
-    jr   z, jr_018_7E97                           ; $7E9E: $28 $F7
+    jr   z, AddEntitySpeedToPos_18.return         ; $7E9E: $28 $F7
 
     push af                                       ; $7EA0: $F5
     swap a                                        ; $7EA1: $CB $37
     and  $F0                                      ; $7EA3: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7EA5: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7EA5: $21 $30 $C3
     add  hl, bc                                   ; $7EA8: $09
     add  [hl]                                     ; $7EA9: $86
     ld   [hl], a                                  ; $7EAA: $77
     rl   d                                        ; $7EAB: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7EAD: $21 $10 $C3
-    jr   jr_018_7E84                              ; $7EB0: $18 $D2
+    jr   AddEntitySpeedToPos_18.updatePosition    ; $7EB0: $18 $D2
 
 func_018_7EB2::
     ld   e, $00                                   ; $7EB2: $1E $00

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -8770,7 +8770,7 @@ func_018_7E6C::
     push af                                       ; $7E74: $F5
     swap a                                        ; $7E75: $CB $37
     and  $F0                                      ; $7E77: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7E79: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7E79: $21 $60 $C2
     add  hl, bc                                   ; $7E7C: $09
     add  [hl]                                     ; $7E7D: $86
     ld   [hl], a                                  ; $7E7E: $77
@@ -8807,7 +8807,7 @@ func_018_7E98::
     push af                                       ; $7EA0: $F5
     swap a                                        ; $7EA1: $CB $37
     and  $F0                                      ; $7EA3: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7EA5: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7EA5: $21 $30 $C3
     add  hl, bc                                   ; $7EA8: $09
     add  [hl]                                     ; $7EA9: $86
     ld   [hl], a                                  ; $7EAA: $77

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -8178,7 +8178,7 @@ func_019_7DC5::
     push af                                       ; $7DCD: $F5
     swap a                                        ; $7DCE: $CB $37
     and  $F0                                      ; $7DD0: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7DD2: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7DD2: $21 $60 $C2
     add  hl, bc                                   ; $7DD5: $09
     add  [hl]                                     ; $7DD6: $86
     ld   [hl], a                                  ; $7DD7: $77
@@ -8215,7 +8215,7 @@ func_019_7DF1::
     push af                                       ; $7DF9: $F5
     swap a                                        ; $7DFA: $CB $37
     and  $F0                                      ; $7DFC: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7DFE: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7DFE: $21 $30 $C3
     add  hl, bc                                   ; $7E01: $09
     add  [hl]                                     ; $7E02: $86
     ld   [hl], a                                  ; $7E03: $77

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -2446,7 +2446,7 @@ jr_019_5158:
     add  hl, de                                   ; $5166: $19
     ldh  a, [hFrameCounter]                       ; $5167: $F0 $E7
     and  [hl]                                     ; $5169: $A6
-    call z, func_019_7DB8                         ; $516A: $CC $B8 $7D
+    call z, UpdateEntityPosWithSpeed_19           ; $516A: $CC $B8 $7D
     call label_3B23                               ; $516D: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $5170: $21 $A0 $C2
     add  hl, bc                                   ; $5173: $09

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -21,8 +21,8 @@ LiftableStatueEntityHandler::
     ld   de, Data_019_4020                        ; $402A: $11 $20 $40
     call RenderActiveEntitySprite                 ; $402D: $CD $77 $3C
     call func_019_7D3D                            ; $4030: $CD $3D $7D
-    call func_019_7DB8                            ; $4033: $CD $B8 $7D
-    call func_019_7DF1                            ; $4036: $CD $F1 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4033: $CD $B8 $7D
+    call AddEntityZSpeedToPos_19                  ; $4036: $CD $F1 $7D
     ld   hl, wEntitiesSpeedZTable                 ; $4039: $21 $20 $C3
     add  hl, bc                                   ; $403C: $09
     dec  [hl]                                     ; $403D: $35
@@ -167,8 +167,8 @@ jr_019_4122:
     ret                                           ; $4122: $C9
 
 LiftableStatueState1And2Handler::
-    call func_019_7DB8                            ; $4123: $CD $B8 $7D
-    call func_019_7DF1                            ; $4126: $CD $F1 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4123: $CD $B8 $7D
+    call AddEntityZSpeedToPos_19                  ; $4126: $CD $F1 $7D
     call label_3B23                               ; $4129: $CD $23 $3B
     ld   hl, wEntitiesSpeedZTable                 ; $412C: $21 $20 $C3
     add  hl, bc                                   ; $412F: $09
@@ -714,7 +714,7 @@ jr_019_4562:
     ld   a, $01                                   ; $4568: $3E $01
     ld   [$C19E], a                               ; $456A: $EA $9E $C1
     call label_3B7B                               ; $456D: $CD $7B $3B
-    call func_019_7DB8                            ; $4570: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4570: $CD $B8 $7D
     call label_3B2E                               ; $4573: $CD $2E $3B
     ld   hl, wEntitiesCollisionsTable             ; $4576: $21 $A0 $C2
     add  hl, bc                                   ; $4579: $09
@@ -1083,7 +1083,7 @@ jr_019_47E8:
     ld   hl, wEntitiesSpeedYTable                 ; $4810: $21 $50 $C2
     add  hl, bc                                   ; $4813: $09
     ld   [hl], a                                  ; $4814: $77
-    call func_019_7DB8                            ; $4815: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4815: $CD $B8 $7D
     call label_3B23                               ; $4818: $CD $23 $3B
     ldh  a, [hLinkDirection]                      ; $481B: $F0 $9E
     xor  $01                                      ; $481D: $EE $01
@@ -1221,7 +1221,7 @@ jr_019_48EE:
     call RenderActiveEntitySpritesPair            ; $48F1: $CD $C0 $3B
     call func_019_7D3D                            ; $48F4: $CD $3D $7D
     call DecrementEntityIgnoreHitsCountdown       ; $48F7: $CD $56 $0C
-    call func_019_7DF1                            ; $48FA: $CD $F1 $7D
+    call AddEntityZSpeedToPos_19                  ; $48FA: $CD $F1 $7D
     ld   hl, wEntitiesSpeedZTable                 ; $48FD: $21 $20 $C3
     add  hl, bc                                   ; $4900: $09
     dec  [hl]                                     ; $4901: $35
@@ -1369,7 +1369,7 @@ jr_019_49D8:
     jp   func_019_49FD                            ; $49D8: $C3 $FD $49
 
 DogState1Handler::
-    call func_019_7DB8                            ; $49DB: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $49DB: $CD $B8 $7D
     call label_3B23                               ; $49DE: $CD $23 $3B
     ldh  a, [hFFE8]                               ; $49E1: $F0 $E8
     and  a                                        ; $49E3: $A7
@@ -1423,7 +1423,7 @@ jr_019_4A23:
     jp   SetEntitySpriteVariant                   ; $4A29: $C3 $0C $3B
 
 DogState3Handler::
-    call func_019_7DB8                            ; $4A2C: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4A2C: $CD $B8 $7D
     call label_3B23                               ; $4A2F: $CD $23 $3B
     ld   hl, wEntitiesPhysicsFlagsTable           ; $4A32: $21 $40 $C3
     add  hl, bc                                   ; $4A35: $09
@@ -1837,7 +1837,7 @@ Data_019_4CF7::
 label_019_4CFF:
     ld   de, Data_019_4CF7                        ; $4CFF: $11 $F7 $4C
     call RenderActiveEntitySprite                 ; $4D02: $CD $77 $3C
-    call func_019_7DB8                            ; $4D05: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4D05: $CD $B8 $7D
     ld   hl, wEntitiesSpeedYTable                 ; $4D08: $21 $50 $C2
     add  hl, bc                                   ; $4D0B: $09
     inc  [hl]                                     ; $4D0C: $34
@@ -2178,7 +2178,7 @@ jr_019_4F8F:
     ld   hl, wEntitiesSpeedYTable                 ; $4FA9: $21 $50 $C2
     add  hl, bc                                   ; $4FAC: $09
     ld   [hl], a                                  ; $4FAD: $77
-    call func_019_7DB8                            ; $4FAE: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4FAE: $CD $B8 $7D
     ld   hl, wEntitiesUnknowTableY                ; $4FB1: $21 $D0 $C3
     add  hl, bc                                   ; $4FB4: $09
     ld   a, [hl]                                  ; $4FB5: $7E
@@ -2747,7 +2747,7 @@ label_019_5363:
     ld   hl, wEntitiesSpeedYTable                 ; $5363: $21 $50 $C2
     add  hl, bc                                   ; $5366: $09
     ld   [hl], $FC                                ; $5367: $36 $FC
-    jp   func_019_7DBB                            ; $5369: $C3 $BB $7D
+    jp   UpdateEntityYPosWithSpeed_19             ; $5369: $C3 $BB $7D
 
 Data_019_536C::
     db   $F8, $F8, $60, $00, $F8, $00, $62, $00, $F8, $08, $62, $20, $F8, $10, $60, $20
@@ -2779,7 +2779,7 @@ GiantBubbleEntityHandler::
     call RenderActiveEntitySpritesRect            ; $53AE: $CD $E6 $3C
     call func_019_7D3D                            ; $53B1: $CD $3D $7D
     call label_3B44                               ; $53B4: $CD $44 $3B
-    call func_019_7DB8                            ; $53B7: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $53B7: $CD $B8 $7D
     call label_3B23                               ; $53BA: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $53BD: $21 $A0 $C2
     add  hl, bc                                   ; $53C0: $09
@@ -2913,7 +2913,7 @@ PodobooState2Handler::
     call RenderActiveEntitySpritesPair            ; $5476: $CD $C0 $3B
     call func_019_7D3D                            ; $5479: $CD $3D $7D
     call label_3B44                               ; $547C: $CD $44 $3B
-    call func_019_7DBB                            ; $547F: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $547F: $CD $BB $7D
     ld   hl, wEntitiesSpeedYTable                 ; $5482: $21 $50 $C2
     add  hl, bc                                   ; $5485: $09
     inc  [hl]                                     ; $5486: $34
@@ -3025,7 +3025,7 @@ jr_019_552D:
     rra                                           ; $5536: $1F
     and  $01                                      ; $5537: $E6 $01
     call SetEntitySpriteVariant                   ; $5539: $CD $0C $3B
-    call func_019_7DB8                            ; $553C: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $553C: $CD $B8 $7D
     ld   hl, wEntitiesSpeedYTable                 ; $553F: $21 $50 $C2
     add  hl, bc                                   ; $5542: $09
     inc  [hl]                                     ; $5543: $34
@@ -3112,7 +3112,7 @@ jr_019_55EC:
     and  a                                        ; $55EC: $A7
     ret  nz                                       ; $55ED: $C0
 
-    call func_019_7DBB                            ; $55EE: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $55EE: $CD $BB $7D
     ld   hl, wEntitiesSpeedYTable                 ; $55F1: $21 $50 $C2
     add  hl, bc                                   ; $55F4: $09
     ld   a, [hl]                                  ; $55F5: $7E
@@ -3286,7 +3286,7 @@ jr_019_5721:
     and  a                                        ; $5721: $A7
     ret  nz                                       ; $5722: $C0
 
-    call func_019_7DBB                            ; $5723: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $5723: $CD $BB $7D
     ld   hl, wEntitiesSpeedYTable                 ; $5726: $21 $50 $C2
     add  hl, bc                                   ; $5729: $09
     ld   a, [hl]                                  ; $572A: $7E
@@ -3330,7 +3330,7 @@ jr_019_575F:
     ld   hl, wEntitiesSpeedYTable                 ; $575F: $21 $50 $C2
     add  hl, bc                                   ; $5762: $09
     ld   [hl], $F8                                ; $5763: $36 $F8
-    jp   func_019_7DBB                            ; $5765: $C3 $BB $7D
+    jp   UpdateEntityYPosWithSpeed_19             ; $5765: $C3 $BB $7D
 
 Data_019_5768::
     db   $00, $00, $70, $07, $00, $08, $72, $07, $00, $10, $72, $27, $00, $18, $70, $27
@@ -3419,7 +3419,7 @@ jr_019_581D:
     jp   SetEntitySpriteVariant                   ; $5834: $C3 $0C $3B
 
 ThwompState2Handler::
-    call func_019_7DBB                            ; $5837: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $5837: $CD $BB $7D
     ld   hl, wEntitiesSpeedYTable                 ; $583A: $21 $50 $C2
     add  hl, bc                                   ; $583D: $09
     ld   a, [hl]                                  ; $583E: $7E
@@ -3482,7 +3482,7 @@ jr_019_5899:
     ld   hl, wEntitiesSpeedYTable                 ; $5899: $21 $50 $C2
     add  hl, bc                                   ; $589C: $09
     ld   [hl], $F8                                ; $589D: $36 $F8
-    jp   func_019_7DBB                            ; $589F: $C3 $BB $7D
+    jp   UpdateEntityYPosWithSpeed_19             ; $589F: $C3 $BB $7D
 
 func_019_58A2::
     call CheckLinkCollisionWithEnemy_trampoline   ; $58A2: $CD $5A $3B
@@ -3623,7 +3623,7 @@ jr_019_5950:
     ret                                           ; $5978: $C9
 
 SideViewPotState1And2Handler::
-    call func_019_7DB8                            ; $5979: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $5979: $CD $B8 $7D
     ld   hl, wEntitiesSpeedYTable                 ; $597C: $21 $50 $C2
     add  hl, bc                                   ; $597F: $09
     ld   a, [hl]                                  ; $5980: $7E
@@ -3706,7 +3706,7 @@ RoosterEntityHandler::
     jr   jr_019_5A31                              ; $5A0B: $18 $24
 
 jr_019_5A0D:
-    call func_019_7DF1                            ; $5A0D: $CD $F1 $7D
+    call AddEntityZSpeedToPos_19                  ; $5A0D: $CD $F1 $7D
     ld   hl, wEntitiesSpeedZTable                 ; $5A10: $21 $20 $C3
     add  hl, bc                                   ; $5A13: $09
     dec  [hl]                                     ; $5A14: $35
@@ -3784,7 +3784,7 @@ jr_019_5A6F:
     ld   [hl], a                                  ; $5A7E: $77
 
 jr_019_5A7F:
-    call func_019_7DB8                            ; $5A7F: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $5A7F: $CD $B8 $7D
     jp   label_3B23                               ; $5A82: $C3 $23 $3B
 
 jr_019_5A85:
@@ -3999,8 +3999,8 @@ RichardFrogEntityHandler::
     ld   de, Data_019_5BA0
     call RenderActiveEntitySpritesPair            ; $5BC3: $CD $C0 $3B
     call func_019_7D3D                            ; $5BC6: $CD $3D $7D
-    call func_019_7DB8                            ; $5BC9: $CD $B8 $7D
-    call func_019_7DF1                            ; $5BCC: $CD $F1 $7D
+    call UpdateEntityPosWithSpeed_19              ; $5BC9: $CD $B8 $7D
+    call AddEntityZSpeedToPos_19                  ; $5BCC: $CD $F1 $7D
     call label_3B23                               ; $5BCF: $CD $23 $3B
 
 jr_019_5BD2:
@@ -4336,7 +4336,7 @@ jr_019_5EA9:
     call ApplyVectorTowardsLink_trampoline        ; $5EA9: $CD $AA $3B
 
 jr_019_5EAC:
-    call func_019_7DB8                            ; $5EAC: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $5EAC: $CD $B8 $7D
 
 jr_019_5EAF:
     ld   a, [wIsIndoor]                           ; $5EAF: $FA $A5 $DB
@@ -4421,7 +4421,7 @@ jr_019_5F30:
     ldh  [hLinkPositionX], a                      ; $5F31: $E0 $98
     pop  af                                       ; $5F33: $F1
     ldh  [hLinkPositionY], a                      ; $5F34: $E0 $99
-    call func_019_7DB8                            ; $5F36: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $5F36: $CD $B8 $7D
     jp   label_019_6053                           ; $5F39: $C3 $53 $60
 
 GhostState2Handler::
@@ -4613,7 +4613,7 @@ func_019_6037::
     ld   [hl], b                                  ; $604F: $70
 
 jr_019_6050:
-    call func_019_7DB8                            ; $6050: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $6050: $CD $B8 $7D
 
 label_019_6053:
     ld   hl, wEntitiesDirectionTable              ; $6053: $21 $80 $C3
@@ -4662,7 +4662,7 @@ jr_019_608D:
     ld   hl, wEntitiesDirectionTable              ; $6099: $21 $80 $C3
     add  hl, bc                                   ; $609C: $09
     ld   [hl], $02                                ; $609D: $36 $02
-    call func_019_7DB8                            ; $609F: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $609F: $CD $B8 $7D
     jp   label_019_6053                           ; $60A2: $C3 $53 $60
 
 func_019_60A5::
@@ -5680,7 +5680,7 @@ jr_019_6AD4:
     call func_019_7D3D                            ; $6AD4: $CD $3D $7D
     call func_019_7D6E                            ; $6AD7: $CD $6E $7D
     call label_3B39                               ; $6ADA: $CD $39 $3B
-    call func_019_7DB8                            ; $6ADD: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $6ADD: $CD $B8 $7D
     call label_3B23                               ; $6AE0: $CD $23 $3B
     ld   a, [wCollisionType]                      ; $6AE3: $FA $33 $C1
     and  a                                        ; $6AE6: $A7
@@ -5815,7 +5815,7 @@ CheepCheepState1Handler::
     call IncrementEntityState                     ; $6BA8: $CD $12 $3B
 
 jr_019_6BAB:
-    jp   func_019_7DB8                            ; $6BAB: $C3 $B8 $7D
+    jp   UpdateEntityPosWithSpeed_19              ; $6BAB: $C3 $B8 $7D
 
 CheepCheepState2Handler::
     call GetEntityTransitionCountdown             ; $6BAE: $CD $05 $0C
@@ -5941,14 +5941,14 @@ jr_019_6C53:
     ld   [hl], a                                  ; $6C67: $77
 
 jr_019_6C68:
-    call func_019_7DC5                            ; $6C68: $CD $C5 $7D
+    call AddEntitySpeedToPos_19                   ; $6C68: $CD $C5 $7D
     jp   label_3B23                               ; $6C6B: $C3 $23 $3B
 
 CheepCheepJumpingState3Handler::
     call GetEntityTransitionCountdown             ; $6C6E: $CD $05 $0C
     ret  nz                                       ; $6C71: $C0
 
-    call func_019_7DBB                            ; $6C72: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $6C72: $CD $BB $7D
     call func_019_6C99                            ; $6C75: $CD $99 $6C
     ld   hl, wEntitiesSpeedYTable                 ; $6C78: $21 $50 $C2
     add  hl, bc                                   ; $6C7B: $09
@@ -5973,7 +5973,7 @@ CheepCheepJumpingState4Handler::
     ret                                           ; $6C95: $C9
 
 jr_019_6C96:
-    call func_019_7DBB                            ; $6C96: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $6C96: $CD $BB $7D
 
 func_019_6C99::
     ld   hl, wEntitiesUnknowTableH                ; $6C99: $21 $30 $C4
@@ -6004,7 +6004,7 @@ CheepCheepJumpingState5Handler::
     ld   [hl], $06                                ; $6CC0: $36 $06
 
 jr_019_6CC2:
-    call func_019_7DBB                            ; $6CC2: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $6CC2: $CD $BB $7D
     ldh  a, [hActiveEntityVisualPosY]             ; $6CC5: $F0 $EC
     cp   $70                                      ; $6CC7: $FE $70
     jr   c, func_019_6C99                         ; $6CC9: $38 $CE
@@ -6032,7 +6032,7 @@ Data_019_6CE3::
 label_019_6CE7:
     ld   de, Data_019_6CE3                        ; $6CE7: $11 $E3 $6C
     call RenderActiveEntitySpritesPair            ; $6CEA: $CD $C0 $3B
-    call func_019_7DF1                            ; $6CED: $CD $F1 $7D
+    call AddEntityZSpeedToPos_19                  ; $6CED: $CD $F1 $7D
     ld   hl, wEntitiesSpeedZTable                 ; $6CF0: $21 $20 $C3
     add  hl, bc                                   ; $6CF3: $09
     dec  [hl]                                     ; $6CF4: $35
@@ -7189,7 +7189,7 @@ func_019_767B::
     ldh  [hLinkInteractiveMotionBlocked], a       ; $767D: $E0 $A1
     ld   [wC167], a                               ; $767F: $EA $67 $C1
     call func_019_78F1                            ; $7682: $CD $F1 $78
-    call func_019_7DBB                            ; $7685: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $7685: $CD $BB $7D
     ld   hl, wEntitiesSpeedYTable                 ; $7688: $21 $50 $C2
     add  hl, bc                                   ; $768B: $09
     inc  [hl]                                     ; $768C: $34
@@ -7392,7 +7392,7 @@ func_019_787D::
 
     ld   de, Data_019_7879                        ; $7881: $11 $79 $78
     call RenderActiveEntitySpritesPair            ; $7884: $CD $C0 $3B
-    call func_019_7DBB                            ; $7887: $CD $BB $7D
+    call UpdateEntityYPosWithSpeed_19             ; $7887: $CD $BB $7D
     ld   hl, wEntitiesSpeedYTable                       ; $788A: $21 $50 $C2
     add  hl, bc                                   ; $788D: $09
     inc  [hl]                                     ; $788E: $34
@@ -8133,7 +8133,7 @@ func_019_7D6E::
     ld   hl, wEntitiesSpeedYTable                 ; $7D96: $21 $50 $C2
     add  hl, bc                                   ; $7D99: $09
     ld   [hl], a                                  ; $7D9A: $77
-    call func_019_7DB8                            ; $7D9B: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $7D9B: $CD $B8 $7D
     ld   hl, wEntitiesUnknowTableH                ; $7D9E: $21 $30 $C4
     add  hl, bc                                   ; $7DA1: $09
     ld   a, [hl]                                  ; $7DA2: $7E
@@ -8156,72 +8156,88 @@ jr_019_7DAA:
 jr_019_7DB7:
     ret                                           ; $7DB7: $C9
 
-func_019_7DB8::
-    call func_019_7DC5                            ; $7DB8: $CD $C5 $7D
+UpdateEntityPosWithSpeed_19::
+    call AddEntitySpeedToPos_19                   ; $7DB8: $CD $C5 $7D
 
-func_019_7DBB::
+UpdateEntityYPosWithSpeed_19::
     push bc                                       ; $7DBB: $C5
     ld   a, c                                     ; $7DBC: $79
     add  $10                                      ; $7DBD: $C6 $10
     ld   c, a                                     ; $7DBF: $4F
-    call func_019_7DC5                            ; $7DC0: $CD $C5 $7D
+    call AddEntitySpeedToPos_19                   ; $7DC0: $CD $C5 $7D
     pop  bc                                       ; $7DC3: $C1
     ret                                           ; $7DC4: $C9
 
-func_019_7DC5::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_19::
     ld   hl, wEntitiesSpeedXTable                 ; $7DC5: $21 $40 $C2
     add  hl, bc                                   ; $7DC8: $09
     ld   a, [hl]                                  ; $7DC9: $7E
     and  a                                        ; $7DCA: $A7
-    jr   z, jr_019_7DF0                           ; $7DCB: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7DCB: $28 $23
 
     push af                                       ; $7DCD: $F5
+    ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $7DCE: $CB $37
     and  $F0                                      ; $7DD0: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7DD2: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7DD2: $21 $60 $C2
     add  hl, bc                                   ; $7DD5: $09
     add  [hl]                                     ; $7DD6: $86
     ld   [hl], a                                  ; $7DD7: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7DD8: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7DDA: $21 $00 $C2
 
-jr_019_7DDD:
+.updatePosition
     add  hl, bc                                   ; $7DDD: $09
     pop  af                                       ; $7DDE: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7DDF: $1E $00
     bit  7, a                                     ; $7DE1: $CB $7F
-    jr   z, jr_019_7DE7                           ; $7DE3: $28 $02
+    jr   z, .positive                             ; $7DE3: $28 $02
 
     ld   e, $F0                                   ; $7DE5: $1E $F0
 
-jr_019_7DE7:
+.positive
     swap a                                        ; $7DE7: $CB $37
     and  $0F                                      ; $7DE9: $E6 $0F
     or   e                                        ; $7DEB: $B3
+    ; Get carry back from d
     rr   d                                        ; $7DEC: $CB $1A
     adc  [hl]                                     ; $7DEE: $8E
     ld   [hl], a                                  ; $7DEF: $77
 
-jr_019_7DF0:
+.return
     ret                                           ; $7DF0: $C9
 
-func_019_7DF1::
+AddEntityZSpeedToPos_19::
     ld   hl, wEntitiesSpeedZTable                 ; $7DF1: $21 $20 $C3
     add  hl, bc                                   ; $7DF4: $09
     ld   a, [hl]                                  ; $7DF5: $7E
     and  a                                        ; $7DF6: $A7
-    jr   z, jr_019_7DF0                           ; $7DF7: $28 $F7
+    jr   z, AddEntitySpeedToPos_19.return         ; $7DF7: $28 $F7
 
     push af                                       ; $7DF9: $F5
     swap a                                        ; $7DFA: $CB $37
     and  $F0                                      ; $7DFC: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7DFE: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7DFE: $21 $30 $C3
     add  hl, bc                                   ; $7E01: $09
     add  [hl]                                     ; $7E02: $86
     ld   [hl], a                                  ; $7E03: $77
     rl   d                                        ; $7E04: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7E06: $21 $10 $C3
-    jr   jr_019_7DDD                              ; $7E09: $18 $D2
+    jr   AddEntitySpeedToPos_19.updatePosition    ; $7E09: $18 $D2
 
 func_019_7E0B::
     ld   e, $00                                   ; $7E0B: $1E $00

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -9471,9 +9471,12 @@ UpdateEntityPosWithSpeed::
 
 ; Update the entity's position using its speed.
 ;
-; The value in the entity speed tables is the number of pixels to move
-; within 16 frames. For example, if it's 8, the entity will move 1
-; pixel every other frame (8/16).
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedCountTables.
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1156,7 +1156,7 @@ jr_003_4D66:
     ldh  [hLinkPositionY], a                      ; $4D8C: $E0 $99
     pop  af                                       ; $4D8E: $F1
     ldh  [hLinkPositionX], a                      ; $4D8F: $E0 $98
-    jp   UpdateEntityPosWithSpeed                 ; $4D91: $C3 $25 $7F
+    jp   UpdateEntityPosWithSpeed_03              ; $4D91: $C3 $25 $7F
 
 EntityThrownHandler::
     call ExecuteActiveEntityHandler_trampoline    ; $4D94: $CD $81 $3A
@@ -1326,7 +1326,7 @@ jr_003_4E85:
     ld   hl, wEntitiesSpeedXTable                 ; $4E95: $21 $40 $C2
     add  hl, bc                                   ; $4E98: $09
     ld   [hl], a                                  ; $4E99: $77
-    call AddEntitySpeedToPos                      ; $4E9A: $CD $32 $7F
+    call AddEntitySpeedToPos_03                   ; $4E9A: $CD $32 $7F
     jp   ClearEntitySpeed                         ; $4E9D: $C3 $7F $3D
 
 EntityRandomSpeedX::
@@ -1592,7 +1592,7 @@ IronMaskEntityHandler::
     call func_003_7F78                            ; $5009: $CD $78 $7F
     call func_003_7FA9                            ; $500C: $CD $A9 $7F
     call func_003_6E28                            ; $500F: $CD $28 $6E
-    call UpdateEntityPosWithSpeed                 ; $5012: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $5012: $CD $25 $7F
     call func_003_7893                            ; $5015: $CD $93 $78
     call GetEntityTransitionCountdown             ; $5018: $CD $05 $0C
     jr   nz, .jp_003_503D                         ; $501B: $20 $20
@@ -2885,7 +2885,7 @@ jr_003_58E5:
     call ClearEntitySpeed                         ; $58F3: $CD $7F $3D
 
 jr_003_58F6:
-    call UpdateEntityPosWithSpeed                 ; $58F6: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $58F6: $CD $25 $7F
     call func_003_7893                            ; $58F9: $CD $93 $78
 
 func_003_58FC::
@@ -3812,7 +3812,7 @@ Data_003_5E8B::
 SirensInstrumentState1Handler::
     ld   de, Data_003_5E8B                        ; $5E93: $11 $8B $5E
     call RenderActiveEntitySpritesPair            ; $5E96: $CD $C0 $3B
-    call UpdateEntityPosWithSpeed                 ; $5E99: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $5E99: $CD $25 $7F
     call GetEntityTransitionCountdown             ; $5E9C: $CD $05 $0C
     jp   z, UnloadEntityAndReturn                 ; $5E9F: $CA $8D $3F
 
@@ -4197,7 +4197,7 @@ label_003_60AA:
     call func_003_62EB                            ; $60B0: $CD $EB $62
 
 func_003_60B3::
-    call UpdateEntityPosWithSpeed                 ; $60B3: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $60B3: $CD $25 $7F
     call func_003_6B7B                            ; $60B6: $CD $7B $6B
     call func_003_7893                            ; $60B9: $CD $93 $78
     ldh  a, [hIsSideScrolling]                    ; $60BC: $F0 $F9
@@ -5709,7 +5709,7 @@ jr_003_6ADA:
     call GetEntityTransitionCountdown             ; $6ADD: $CD $05 $0C
     jr   nz, @+$6C                                ; $6AE0: $20 $6A
 
-    call UpdateEntityPosWithSpeed                 ; $6AE2: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $6AE2: $CD $25 $7F
     call ApplySwordIntersectionWithObjects        ; $6AE5: $CD $AB $7C
     ld   hl, wEntitiesCollisionsTable             ; $6AE8: $21 $A0 $C2
     add  hl, bc                                   ; $6AEB: $09
@@ -5818,7 +5818,7 @@ jr_003_6B53:
     call SetEntitySpriteVariant                   ; $6B6B: $CD $0C $3B
 .octorockRockEnd
 
-    call UpdateEntityPosWithSpeed                 ; $6B6E: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $6B6E: $CD $25 $7F
     jr   func_003_6B7B                            ; $6B71: $18 $08
 
 Data_003_6B73::
@@ -5832,7 +5832,7 @@ func_003_6B7B::
     and  a                                        ; $6B7D: $A7
     jr   nz, jr_003_6B8C                          ; $6B7E: $20 $0C
 
-    call AddEntityZSpeedToPos                     ; $6B80: $CD $5E $7F
+    call AddEntityZSpeedToPos_03                  ; $6B80: $CD $5E $7F
     ld   hl, wEntitiesSpeedZTable                 ; $6B83: $21 $20 $C3
     add  hl, bc                                   ; $6B86: $09
     ld   a, [hl]                                  ; $6B87: $7E
@@ -9459,13 +9459,13 @@ jr_003_7F23:
     ld   e, a                                     ; $7F23: $5F
     ret                                           ; $7F24: $C9
 
-UpdateEntityPosWithSpeed::
-    call AddEntitySpeedToPos                      ; $7F25: $CD $32 $7F
+UpdateEntityPosWithSpeed_03::
+    call AddEntitySpeedToPos_03                   ; $7F25: $CD $32 $7F
     push bc                                       ; $7F28: $C5
     ld   a, c                                     ; $7F29: $79
     add  $10                                      ; $7F2A: $C6 $10
     ld   c, a                                     ; $7F2C: $4F
-    call AddEntitySpeedToPos                      ; $7F2D: $CD $32 $7F
+    call AddEntitySpeedToPos_03                   ; $7F2D: $CD $32 $7F
     pop  bc                                       ; $7F30: $C1
     ret                                           ; $7F31: $C9
 
@@ -9476,11 +9476,11 @@ UpdateEntityPosWithSpeed::
 ; 8, the entity will move 1 pixel every other frame (8/16).
 ;
 ; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedCountTables.
+; move, in addition to the carry from the SpeedAccTables.
 ;
 ; Inputs:
 ;   bc  entity index
-AddEntitySpeedToPos::
+AddEntitySpeedToPos_03::
     ld   hl, wEntitiesSpeedXTable                 ; $7F32: $21 $40 $C2
     add  hl, bc                                   ; $7F35: $09
     ld   a, [hl]                                  ; $7F36: $7E
@@ -9492,17 +9492,18 @@ AddEntitySpeedToPos::
     ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $7F3B: $CB $37
     and  $F0                                      ; $7F3D: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7F3F: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7F3F: $21 $60 $C2
     add  hl, bc                                   ; $7F42: $09
     add  [hl]                                     ; $7F43: $86
     ld   [hl], a                                  ; $7F44: $77
-    ; Save carry in bit 7 of d
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7F45: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7F47: $21 $00 $C2
 
 .updatePosition
     add  hl, bc                                   ; $7F4A: $09
     pop  af                                       ; $7F4B: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7F4C: $1E $00
     bit  7, a                                     ; $7F4E: $CB $7F
     jr   z, .positive                             ; $7F50: $28 $02
@@ -9513,9 +9514,6 @@ AddEntitySpeedToPos::
     swap a                                        ; $7F54: $CB $37
     and  $0F                                      ; $7F56: $E6 $0F
     or   e                                        ; $7F58: $B3
-    ; Unless speed < -15 or speed > 15:
-    ; a = speed < 0 ? $FF : $00
-    
     ; Get carry back from d
     rr   d                                        ; $7F59: $CB $1A
     adc  [hl]                                     ; $7F5B: $8E
@@ -9524,23 +9522,23 @@ AddEntitySpeedToPos::
 .return
     ret                                           ; $7F5D: $C9
 
-AddEntityZSpeedToPos::
+AddEntityZSpeedToPos_03::
     ld   hl, wEntitiesSpeedZTable                 ; $7F5E: $21 $20 $C3
     add  hl, bc                                   ; $7F61: $09
     ld   a, [hl]                                  ; $7F62: $7E
     and  a                                        ; $7F63: $A7
-    jr   z, AddEntitySpeedToPos.return            ; $7F64: $28 $F7
+    jr   z, AddEntitySpeedToPos_03.return         ; $7F64: $28 $F7
 
     push af                                       ; $7F66: $F5
     swap a                                        ; $7F67: $CB $37
     and  $F0                                      ; $7F69: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7F6B: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7F6B: $21 $30 $C3
     add  hl, bc                                   ; $7F6E: $09
     add  [hl]                                     ; $7F6F: $86
     ld   [hl], a                                  ; $7F70: $77
     rl   d                                        ; $7F71: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7F73: $21 $10 $C3
-    jr   AddEntitySpeedToPos.updatePosition       ; $7F76: $18 $D2
+    jr   AddEntitySpeedToPos_03.updatePosition    ; $7F76: $18 $D2
 
 func_003_7F78::
     ldh  a, [hActiveEntityStatus]                 ; $7F78: $F0 $EA
@@ -9616,7 +9614,7 @@ func_003_7FA9::
     ld   hl, wEntitiesSpeedYTable                 ; $7FD0: $21 $50 $C2
     add  hl, bc                                   ; $7FD3: $09
     ld   [hl], a                                  ; $7FD4: $77
-    call UpdateEntityPosWithSpeed                 ; $7FD5: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $7FD5: $CD $25 $7F
     ld   hl, wEntitiesUnknowTableH                ; $7FD8: $21 $30 $C4
     add  hl, bc                                   ; $7FDB: $09
     ld   a, [hl]                                  ; $7FDC: $7E

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1156,7 +1156,7 @@ jr_003_4D66:
     ldh  [hLinkPositionY], a                      ; $4D8C: $E0 $99
     pop  af                                       ; $4D8E: $F1
     ldh  [hLinkPositionX], a                      ; $4D8F: $E0 $98
-    jp   func_003_7F25                            ; $4D91: $C3 $25 $7F
+    jp   UpdateEntityPosWithSpeed                 ; $4D91: $C3 $25 $7F
 
 EntityThrownHandler::
     call ExecuteActiveEntityHandler_trampoline    ; $4D94: $CD $81 $3A
@@ -1326,7 +1326,7 @@ jr_003_4E85:
     ld   hl, wEntitiesSpeedXTable                 ; $4E95: $21 $40 $C2
     add  hl, bc                                   ; $4E98: $09
     ld   [hl], a                                  ; $4E99: $77
-    call func_003_7F32                            ; $4E9A: $CD $32 $7F
+    call AddEntitySpeedToPos                      ; $4E9A: $CD $32 $7F
     jp   ClearEntitySpeed                         ; $4E9D: $C3 $7F $3D
 
 EntityRandomSpeedX::
@@ -1592,7 +1592,7 @@ IronMaskEntityHandler::
     call func_003_7F78                            ; $5009: $CD $78 $7F
     call func_003_7FA9                            ; $500C: $CD $A9 $7F
     call func_003_6E28                            ; $500F: $CD $28 $6E
-    call func_003_7F25                            ; $5012: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $5012: $CD $25 $7F
     call func_003_7893                            ; $5015: $CD $93 $78
     call GetEntityTransitionCountdown             ; $5018: $CD $05 $0C
     jr   nz, .jp_003_503D                         ; $501B: $20 $20
@@ -2885,7 +2885,7 @@ jr_003_58E5:
     call ClearEntitySpeed                         ; $58F3: $CD $7F $3D
 
 jr_003_58F6:
-    call func_003_7F25                            ; $58F6: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $58F6: $CD $25 $7F
     call func_003_7893                            ; $58F9: $CD $93 $78
 
 func_003_58FC::
@@ -3812,7 +3812,7 @@ Data_003_5E8B::
 SirensInstrumentState1Handler::
     ld   de, Data_003_5E8B                        ; $5E93: $11 $8B $5E
     call RenderActiveEntitySpritesPair            ; $5E96: $CD $C0 $3B
-    call func_003_7F25                            ; $5E99: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $5E99: $CD $25 $7F
     call GetEntityTransitionCountdown             ; $5E9C: $CD $05 $0C
     jp   z, UnloadEntityAndReturn                 ; $5E9F: $CA $8D $3F
 
@@ -4197,7 +4197,7 @@ label_003_60AA:
     call func_003_62EB                            ; $60B0: $CD $EB $62
 
 func_003_60B3::
-    call func_003_7F25                            ; $60B3: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $60B3: $CD $25 $7F
     call func_003_6B7B                            ; $60B6: $CD $7B $6B
     call func_003_7893                            ; $60B9: $CD $93 $78
     ldh  a, [hIsSideScrolling]                    ; $60BC: $F0 $F9
@@ -5709,7 +5709,7 @@ jr_003_6ADA:
     call GetEntityTransitionCountdown             ; $6ADD: $CD $05 $0C
     jr   nz, @+$6C                                ; $6AE0: $20 $6A
 
-    call func_003_7F25                            ; $6AE2: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $6AE2: $CD $25 $7F
     call ApplySwordIntersectionWithObjects        ; $6AE5: $CD $AB $7C
     ld   hl, wEntitiesCollisionsTable             ; $6AE8: $21 $A0 $C2
     add  hl, bc                                   ; $6AEB: $09
@@ -5818,7 +5818,7 @@ jr_003_6B53:
     call SetEntitySpriteVariant                   ; $6B6B: $CD $0C $3B
 .octorockRockEnd
 
-    call func_003_7F25                            ; $6B6E: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $6B6E: $CD $25 $7F
     jr   func_003_6B7B                            ; $6B71: $18 $08
 
 Data_003_6B73::
@@ -5832,7 +5832,7 @@ func_003_6B7B::
     and  a                                        ; $6B7D: $A7
     jr   nz, jr_003_6B8C                          ; $6B7E: $20 $0C
 
-    call func_003_7F5E                            ; $6B80: $CD $5E $7F
+    call AddEntityZSpeedToPos                     ; $6B80: $CD $5E $7F
     ld   hl, wEntitiesSpeedZTable                 ; $6B83: $21 $20 $C3
     add  hl, bc                                   ; $6B86: $09
     ld   a, [hl]                                  ; $6B87: $7E
@@ -6132,7 +6132,7 @@ ApplyLinkCollisionWithEnemy::
     cp   ENTITY_CHEEP_CHEEP_JUMPING               ; $6CD7: $FE $AC
     jr   nz, .cheepCheepEnd                       ; $6CD9: $20 $1E
 
-    call func_003_7EE9                            ; $6CDB: $CD $E9 $7E
+    call GetEntityYDistanceAwayFromLink           ; $6CDB: $CD $E9 $7E
     ld   a, e                                     ; $6CDE: $7B
     cp   $02                                      ; $6CDF: $FE $02
     jr   nz, .goombaEnd                          ; $6CE1: $20 $5A
@@ -6359,7 +6359,7 @@ jr_003_6E0E:
     cp   $02                                      ; $6E10: $FE $02
     jr   z, setCarryAndReturn                           ; $6E12: $28 $F6
 
-    call func_003_7ED9                            ; $6E14: $CD $D9 $7E
+    call GetEntityXDistanceAwayFromLink           ; $6E14: $CD $D9 $7E
     ld   d, b                                     ; $6E17: $50
     ld   hl, Data_003_6E0C                        ; $6E18: $21 $0C $6E
     add  hl, de                                   ; $6E1B: $19
@@ -6644,7 +6644,7 @@ func_003_6F93::
 
 label_003_6FA7:
     push de                                       ; $6FA7: $D5
-    call func_003_7ED9                            ; $6FA8: $CD $D9 $7E
+    call GetEntityXDistanceAwayFromLink           ; $6FA8: $CD $D9 $7E
     ld   a, e                                     ; $6FAB: $7B
     and  a                                        ; $6FAC: $A7
     pop  de                                       ; $6FAD: $D1
@@ -9250,8 +9250,7 @@ func_003_7E0E::
 ;
 ; Inputs:
 ;   a    vector length
-;   ???  vector origin X
-;   ???  vector origin Y
+;   bc   entity index
 ;
 ; Outputs:
 ;   hScratch0   resulting vector Y
@@ -9259,40 +9258,44 @@ func_003_7E0E::
 GetVectorTowardsLink::
     ldh  [hScratch1], a                           ; $7E45: $E0 $D8
     and  a                                        ; $7E47: $A7
-    jp   z, label_003_7EC3                        ; $7E48: $CA $C3 $7E
+    jp   z, .cancelAndReturn                      ; $7E48: $CA $C3 $7E
 
-    call func_003_7EE9                            ; $7E4B: $CD $E9 $7E
+    call GetEntityYDistanceAwayFromLink           ; $7E4B: $CD $E9 $7E
     dec  e                                        ; $7E4E: $1D
     dec  e                                        ; $7E4F: $1D
     ld   a, e                                     ; $7E50: $7B
+    ; hScratch2 = dy < 0 ? 0 : 1
     ldh  [hScratch2], a                           ; $7E51: $E0 $D9
     ld   a, d                                     ; $7E53: $7A
     bit  7, a                                     ; $7E54: $CB $7F
-    jr   z, jr_003_7E5A                           ; $7E56: $28 $02
+    jr   z, .absoluteY                            ; $7E56: $28 $02
 
     cpl                                           ; $7E58: $2F
     inc  a                                        ; $7E59: $3C
 
-jr_003_7E5A:
+.absoluteY
     ldh  [hScratchC], a                           ; $7E5A: $E0 $E3
-    call func_003_7ED9                            ; $7E5C: $CD $D9 $7E
+    call GetEntityXDistanceAwayFromLink           ; $7E5C: $CD $D9 $7E
     ld   a, e                                     ; $7E5F: $7B
+    ; hScratch3 = dx < 0 ? 1 : 0
     ldh  [hScratch3], a                           ; $7E60: $E0 $DA
     ld   a, d                                     ; $7E62: $7A
     bit  7, a                                     ; $7E63: $CB $7F
-    jr   z, jr_003_7E69                           ; $7E65: $28 $02
+    jr   z, .absoluteX                            ; $7E65: $28 $02
 
     cpl                                           ; $7E67: $2F
     inc  a                                        ; $7E68: $3C
 
-jr_003_7E69:
+.absoluteX
     ldh  [hScratchD], a                           ; $7E69: $E0 $E4
     ld   e, $00                                   ; $7E6B: $1E $00
     ld   hl, hScratchC                            ; $7E6D: $21 $E3 $FF
     ldh  a, [hScratchD]                           ; $7E70: $F0 $E4
+    ; Always divide the larger distance by the smaller distance...
     cp   [hl]                                     ; $7E72: $BE
-    jr   nc, jr_003_7E7E                          ; $7E73: $30 $09
+    jr   nc, .noSwap1                             ; $7E73: $30 $09
 
+    ; ...so swap them if necessary
     inc  e                                        ; $7E75: $1C
     push af                                       ; $7E76: $F5
     ldh  a, [hScratchC]                           ; $7E77: $F0 $E3
@@ -9300,37 +9303,42 @@ jr_003_7E69:
     pop  af                                       ; $7E7B: $F1
     ldh  [hScratchC], a                           ; $7E7C: $E0 $E3
 
-jr_003_7E7E:
+.noSwap1
+    ; e = dx > dy ? 0 : 1
+    
     xor  a                                        ; $7E7E: $AF
     ldh  [hScratchB], a                           ; $7E7F: $E0 $E2
     ldh  [hScratch0], a                           ; $7E81: $E0 $D7
+    
     ldh  a, [hScratch1]                           ; $7E83: $F0 $D8
     ld   d, a                                     ; $7E85: $57
 
-jr_003_7E86:
+.divideLoop
     ldh  a, [hScratchB]                           ; $7E86: $F0 $E2
     ld   hl, hScratchC                            ; $7E88: $21 $E3 $FF
     add  [hl]                                     ; $7E8B: $86
-    jr   c, jr_003_7E94                           ; $7E8C: $38 $06
+    jr   c, .incResult                            ; $7E8C: $38 $06
 
     ld   hl, hScratchD                            ; $7E8E: $21 $E4 $FF
     cp   [hl]                                     ; $7E91: $BE
-    jr   c, jr_003_7E99                           ; $7E92: $38 $05
+    jr   c, .decCounter                           ; $7E92: $38 $05
 
-jr_003_7E94:
+.incResult
     sub  [hl]                                     ; $7E94: $96
     ld   hl, hScratch0                            ; $7E95: $21 $D7 $FF
     inc  [hl]                                     ; $7E98: $34
 
-jr_003_7E99:
+.decCounter
     ldh  [hScratchB], a                           ; $7E99: $E0 $E2
     dec  d                                        ; $7E9B: $15
-    jr   nz, jr_003_7E86                          ; $7E9C: $20 $E8
+    jr   nz, .divideLoop                          ; $7E9C: $20 $E8
 
     ld   a, e                                     ; $7E9E: $7B
+    ; If the X and Y were swapped before...
     and  a                                        ; $7E9F: $A7
-    jr   z, jr_003_7EAC                           ; $7EA0: $28 $0A
+    jr   z, .noSwap2                              ; $7EA0: $28 $0A
 
+    ; ...swap them back
     ldh  a, [hScratch0]                           ; $7EA2: $F0 $D7
     push af                                       ; $7EA4: $F5
     ldh  a, [hScratch1]                           ; $7EA5: $F0 $D8
@@ -9338,30 +9346,31 @@ jr_003_7E99:
     pop  af                                       ; $7EA9: $F1
     ldh  [hScratch1], a                           ; $7EAA: $E0 $D8
 
-jr_003_7EAC:
+.noSwap2
     ldh  a, [hScratch2]                           ; $7EAC: $F0 $D9
+    ; If the distance was negative...
     and  a                                        ; $7EAE: $A7
     ldh  a, [hScratch0]                           ; $7EAF: $F0 $D7
-    jr   nz, jr_003_7EB7                          ; $7EB1: $20 $04
+    jr   nz, .positiveResultY                     ; $7EB1: $20 $04
 
+    ; ...make the result negative
     cpl                                           ; $7EB3: $2F
     inc  a                                        ; $7EB4: $3C
     ldh  [hScratch0], a                           ; $7EB5: $E0 $D7
 
-jr_003_7EB7:
+.positiveResultY
     ldh  a, [hScratch3]                           ; $7EB7: $F0 $DA
     and  a                                        ; $7EB9: $A7
     ldh  a, [hScratch1]                           ; $7EBA: $F0 $D8
-    jr   z, jr_003_7EC2                           ; $7EBC: $28 $04
+    jr   z, .positiveResultX                      ; $7EBC: $28 $04
 
     cpl                                           ; $7EBE: $2F
     inc  a                                        ; $7EBF: $3C
     ldh  [hScratch1], a                           ; $7EC0: $E0 $D8
-
-jr_003_7EC2:
+.positiveResultX
     ret                                           ; $7EC2: $C9
 
-label_003_7EC3:
+.cancelAndReturn
     xor  a                                        ; $7EC3: $AF
     ldh  [hScratch0], a                           ; $7EC4: $E0 $D7
     ret                                           ; $7EC6: $C9
@@ -9379,22 +9388,22 @@ ApplyVectorTowardsLinkAndReturn::
     ld   [hl], a                                  ; $7ED7: $77
     ret                                           ; $7ED8: $C9
 
-func_003_7ED9::
+GetEntityXDistanceAwayFromLink::
     ld   e, $00                                   ; $7ED9: $1E $00
     ldh  a, [hLinkPositionX]                      ; $7EDB: $F0 $98
     ld   hl, wEntitiesPosXTable                   ; $7EDD: $21 $00 $C2
     add  hl, bc                                   ; $7EE0: $09
     sub  [hl]                                     ; $7EE1: $96
     bit  7, a                                     ; $7EE2: $CB $7F
-    jr   z, jr_003_7EE7                           ; $7EE4: $28 $01
+    jr   z, .positive                             ; $7EE4: $28 $01
 
     inc  e                                        ; $7EE6: $1C
 
-jr_003_7EE7:
+.positive
     ld   d, a                                     ; $7EE7: $57
     ret                                           ; $7EE8: $C9
 
-func_003_7EE9::
+GetEntityYDistanceAwayFromLink::
     ld   e, $02                                   ; $7EE9: $1E $02
     ldh  a, [hLinkPositionY]                      ; $7EEB: $F0 $99
     ld   hl, wEntitiesPosYTable                   ; $7EED: $21 $10 $C2
@@ -9404,16 +9413,16 @@ func_003_7EE9::
     add  hl, bc                                   ; $7EF5: $09
     add  [hl]                                     ; $7EF6: $86
     bit  7, a                                     ; $7EF7: $CB $7F
-    jr   nz, jr_003_7EFC                          ; $7EF9: $20 $01
+    jr   nz, .negative                            ; $7EF9: $20 $01
 
     inc  e                                        ; $7EFB: $1C
 
-jr_003_7EFC:
+.negative
     ld   d, a                                     ; $7EFC: $57
     ret                                           ; $7EFD: $C9
 
 func_003_7EFE::
-    call func_003_7ED9                            ; $7EFE: $CD $D9 $7E
+    call GetEntityXDistanceAwayFromLink           ; $7EFE: $CD $D9 $7E
     ld   a, e                                     ; $7F01: $7B
     ldh  [hScratch0], a                           ; $7F02: $E0 $D7
     ld   a, d                                     ; $7F04: $7A
@@ -9425,7 +9434,7 @@ func_003_7EFE::
 
 jr_003_7F0B:
     push af                                       ; $7F0B: $F5
-    call func_003_7EE9                            ; $7F0C: $CD $E9 $7E
+    call GetEntityYDistanceAwayFromLink           ; $7F0C: $CD $E9 $7E
     ld   a, e                                     ; $7F0F: $7B
     ldh  [hScratch1], a                           ; $7F10: $E0 $D8
     ld   a, d                                     ; $7F12: $7A
@@ -9450,70 +9459,85 @@ jr_003_7F23:
     ld   e, a                                     ; $7F23: $5F
     ret                                           ; $7F24: $C9
 
-func_003_7F25::
-    call func_003_7F32                            ; $7F25: $CD $32 $7F
+UpdateEntityPosWithSpeed::
+    call AddEntitySpeedToPos                      ; $7F25: $CD $32 $7F
     push bc                                       ; $7F28: $C5
     ld   a, c                                     ; $7F29: $79
     add  $10                                      ; $7F2A: $C6 $10
     ld   c, a                                     ; $7F2C: $4F
-    call func_003_7F32                            ; $7F2D: $CD $32 $7F
+    call AddEntitySpeedToPos                      ; $7F2D: $CD $32 $7F
     pop  bc                                       ; $7F30: $C1
     ret                                           ; $7F31: $C9
 
-func_003_7F32::
+; Update the entity's position using its speed.
+;
+; The value in the entity speed tables is the number of pixels to move
+; within 16 frames. For example, if it's 8, the entity will move 1
+; pixel every other frame (8/16).
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos::
     ld   hl, wEntitiesSpeedXTable                 ; $7F32: $21 $40 $C2
     add  hl, bc                                   ; $7F35: $09
     ld   a, [hl]                                  ; $7F36: $7E
     and  a                                        ; $7F37: $A7
-    jr   z, jr_003_7F5D                           ; $7F38: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7F38: $28 $23
 
     push af                                       ; $7F3A: $F5
+    ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $7F3B: $CB $37
     and  $F0                                      ; $7F3D: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7F3F: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7F3F: $21 $60 $C2
     add  hl, bc                                   ; $7F42: $09
     add  [hl]                                     ; $7F43: $86
     ld   [hl], a                                  ; $7F44: $77
+    ; Save carry in bit 7 of d
     rl   d                                        ; $7F45: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7F47: $21 $00 $C2
 
-jr_003_7F4A:
+.updatePosition
     add  hl, bc                                   ; $7F4A: $09
     pop  af                                       ; $7F4B: $F1
     ld   e, $00                                   ; $7F4C: $1E $00
     bit  7, a                                     ; $7F4E: $CB $7F
-    jr   z, jr_003_7F54                           ; $7F50: $28 $02
+    jr   z, .positive                             ; $7F50: $28 $02
 
     ld   e, $F0                                   ; $7F52: $1E $F0
 
-jr_003_7F54:
+.positive
     swap a                                        ; $7F54: $CB $37
     and  $0F                                      ; $7F56: $E6 $0F
     or   e                                        ; $7F58: $B3
+    ; Unless speed < -15 or speed > 15:
+    ; a = speed < 0 ? $FF : $00
+    
+    ; Get carry back from d
     rr   d                                        ; $7F59: $CB $1A
     adc  [hl]                                     ; $7F5B: $8E
     ld   [hl], a                                  ; $7F5C: $77
 
-jr_003_7F5D:
+.return
     ret                                           ; $7F5D: $C9
 
-func_003_7F5E::
+AddEntityZSpeedToPos::
     ld   hl, wEntitiesSpeedZTable                 ; $7F5E: $21 $20 $C3
     add  hl, bc                                   ; $7F61: $09
     ld   a, [hl]                                  ; $7F62: $7E
     and  a                                        ; $7F63: $A7
-    jr   z, jr_003_7F5D                           ; $7F64: $28 $F7
+    jr   z, AddEntitySpeedToPos.return            ; $7F64: $28 $F7
 
     push af                                       ; $7F66: $F5
     swap a                                        ; $7F67: $CB $37
     and  $F0                                      ; $7F69: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7F6B: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7F6B: $21 $30 $C3
     add  hl, bc                                   ; $7F6E: $09
     add  [hl]                                     ; $7F6F: $86
     ld   [hl], a                                  ; $7F70: $77
     rl   d                                        ; $7F71: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7F73: $21 $10 $C3
-    jr   jr_003_7F4A                              ; $7F76: $18 $D2
+    jr   AddEntitySpeedToPos.updatePosition       ; $7F76: $18 $D2
 
 func_003_7F78::
     ldh  a, [hActiveEntityStatus]                 ; $7F78: $F0 $EA
@@ -9589,7 +9613,7 @@ func_003_7FA9::
     ld   hl, wEntitiesSpeedYTable                 ; $7FD0: $21 $50 $C2
     add  hl, bc                                   ; $7FD3: $09
     ld   [hl], a                                  ; $7FD4: $77
-    call func_003_7F25                            ; $7FD5: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $7FD5: $CD $25 $7F
     ld   hl, wEntitiesUnknowTableH                ; $7FD8: $21 $30 $C4
     add  hl, bc                                   ; $7FDB: $09
     ld   a, [hl]                                  ; $7FDC: $7E

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -1588,7 +1588,7 @@ jr_036_49AD:
     push af                                       ; $49AD: $F5
     swap a                                        ; $49AE: $CB $37
     and  $F0                                      ; $49B0: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $49B2: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $49B2: $21 $60 $C2
     add  [hl]                                     ; $49B5: $86
     ld   [hl], a                                  ; $49B6: $77
     rl   d                                        ; $49B7: $CB $12
@@ -7016,7 +7016,7 @@ func_036_6A6F::
     push af                                       ; $6A75: $F5
     swap a                                        ; $6A76: $CB $37
     and  $F0                                      ; $6A78: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $6A7A: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $6A7A: $21 $60 $C2
     add  hl, bc                                   ; $6A7D: $09
     add  [hl]                                     ; $6A7E: $86
     ld   [hl], a                                  ; $6A7F: $77
@@ -7103,7 +7103,7 @@ func_036_6AEC::
     push af                                       ; $6AF2: $F5
     swap a                                        ; $6AF3: $CB $37
     and  $F0                                      ; $6AF5: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $6AF7: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $6AF7: $21 $30 $C3
     add  hl, bc                                   ; $6AFA: $09
     add  [hl]                                     ; $6AFB: $86
     ld   [hl], a                                  ; $6AFC: $77

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -52,9 +52,9 @@ func_036_403A::
     ld   hl, wIsRoosterFollowingLink              ; $4049: $21 $7B $DB
     or   [hl]                                     ; $404C: $B6
     call nz, UnloadEntity                         ; $404D: $C4 $8D $3F
-    call func_036_6C23                            ; $4050: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4050: $CD $23 $6C
     ld   [hl], $E8                                ; $4053: $36 $E8
-    call func_036_6C28                            ; $4055: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4055: $CD $28 $6C
     ld   [hl], $4D                                ; $4058: $36 $4D
     jp   IncrementEntityState                     ; $405A: $C3 $12 $3B
 
@@ -138,7 +138,7 @@ jr_036_40B0:
 
 func_036_40C5::
     call func_036_4365                            ; $40C5: $CD $65 $43
-    call func_036_6C23                            ; $40C8: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $40C8: $CD $23 $6C
     ld   a, [hl]                                  ; $40CB: $7E
     cp   $37                                      ; $40CC: $FE $37
     jr   z, jr_036_40DF                           ; $40CE: $28 $0F
@@ -148,7 +148,7 @@ func_036_40C5::
     and  $07                                      ; $40D3: $E6 $07
     jr   nz, jr_036_40DE                          ; $40D5: $20 $07
 
-    call func_036_6C02                            ; $40D7: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $40D7: $CD $02 $6C
     ld   a, [hl]                                  ; $40DA: $7E
     xor  $01                                      ; $40DB: $EE $01
     ld   [hl], a                                  ; $40DD: $77
@@ -181,13 +181,13 @@ func_036_40FD::
     and  $01                                      ; $4102: $E6 $01
     jr   nz, jr_036_4117                          ; $4104: $20 $11
 
-    call func_036_6C23                            ; $4106: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4106: $CD $23 $6C
     dec  [hl]                                     ; $4109: $35
     ldh  a, [hFrameCounter]                       ; $410A: $F0 $E7
     and  $07                                      ; $410C: $E6 $07
     jr   nz, jr_036_4117                          ; $410E: $20 $07
 
-    call func_036_6C02                            ; $4110: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4110: $CD $02 $6C
     ld   a, [hl]                                  ; $4113: $7E
     xor  $01                                      ; $4114: $EE $01
     ld   [hl], a                                  ; $4116: $77
@@ -211,15 +211,15 @@ func_036_4126::
     and  $01                                      ; $412B: $E6 $01
     jr   nz, jr_036_4144                          ; $412D: $20 $15
 
-    call func_036_6C23                            ; $412F: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $412F: $CD $23 $6C
     dec  [hl]                                     ; $4132: $35
-    call func_036_6C28                            ; $4133: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4133: $CD $28 $6C
     inc  [hl]                                     ; $4136: $34
     ldh  a, [hFrameCounter]                       ; $4137: $F0 $E7
     and  $07                                      ; $4139: $E6 $07
     jr   nz, jr_036_4144                          ; $413B: $20 $07
 
-    call func_036_6C02                            ; $413D: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $413D: $CD $02 $6C
     ld   a, [hl]                                  ; $4140: $7E
     xor  $01                                      ; $4141: $EE $01
     ld   [hl], a                                  ; $4143: $77
@@ -239,7 +239,7 @@ jr_036_4144:
 
 func_036_4153::
     call func_036_4365                            ; $4153: $CD $65 $43
-    call func_036_6C28                            ; $4156: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4156: $CD $28 $6C
     inc  [hl]                                     ; $4159: $34
     ld   a, [hl]                                  ; $415A: $7E
     cp   $70                                      ; $415B: $FE $70
@@ -408,7 +408,7 @@ func_036_4254::
     jp   IncrementEntityState                     ; $4261: $C3 $12 $3B
 
 func_036_4264::
-    call func_036_6C28                            ; $4264: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4264: $CD $28 $6C
     ld   a, [hl]                                  ; $4267: $7E
     cp   $3B                                      ; $4268: $FE $3B
     jr   c, jr_036_427A                           ; $426A: $38 $0E
@@ -418,7 +418,7 @@ func_036_4264::
     and  $07                                      ; $426F: $E6 $07
     ret  nz                                       ; $4271: $C0
 
-    call func_036_6C02                            ; $4272: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4272: $CD $02 $6C
     ld   a, [hl]                                  ; $4275: $7E
     xor  $01                                      ; $4276: $EE $01
     ld   [hl], a                                  ; $4278: $77
@@ -435,13 +435,13 @@ Data_036_4282::
     db   $10, $08, $5C, $07, $10, $10, $5E, $07
 
 label_036_429A:
-    call func_036_6C23                            ; $429A: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $429A: $CD $23 $6C
     ld   a, [hl]                                  ; $429D: $7E
     cp   $20                                      ; $429E: $FE $20
     jr   nc, jr_036_42D4                          ; $42A0: $30 $32
 
     ld   [hl], $14                                ; $42A2: $36 $14
-    call func_036_6C28                            ; $42A4: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $42A4: $CD $28 $6C
     ld   [hl], $64                                ; $42A7: $36 $64
     push bc                                       ; $42A9: $C5
     sla  c                                        ; $42AA: $CB $21
@@ -467,7 +467,7 @@ label_036_429A:
     ret                                           ; $42D3: $C9
 
 jr_036_42D4:
-    call func_036_6C02                            ; $42D4: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $42D4: $CD $02 $6C
     ld   a, [hl+]                                 ; $42D7: $2A
     sla  a                                        ; $42D8: $CB $27
     ld   e, a                                     ; $42DA: $5F
@@ -646,7 +646,7 @@ func_036_43F3::
 jr_036_4405:
     call func_036_4365                            ; $4405: $CD $65 $43
     call_open_dialog $294                         ; $4408
-    call func_036_6C23                            ; $440D: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $440D: $CD $23 $6C
     ld   a, [hl]                                  ; $4410: $7E
     ld   hl, wEntitiesPrivateState2Table          ; $4411: $21 $C0 $C2
     add  hl, bc                                   ; $4414: $09
@@ -727,13 +727,13 @@ func_036_4471::
     and  $07                                      ; $4476: $E6 $07
     jr   nz, jr_036_4481                          ; $4478: $20 $07
 
-    call func_036_6C02                            ; $447A: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $447A: $CD $02 $6C
     ld   a, [hl]                                  ; $447D: $7E
     xor  $01                                      ; $447E: $EE $01
     ld   [hl], a                                  ; $4480: $77
 
 jr_036_4481:
-    call func_036_6C23                            ; $4481: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4481: $CD $23 $6C
     ld   a, [hl]                                  ; $4484: $7E
     cp   $50                                      ; $4485: $FE $50
     jr   c, jr_036_448B                           ; $4487: $38 $02
@@ -742,11 +742,11 @@ jr_036_4481:
     ret                                           ; $448A: $C9
 
 jr_036_448B:
-    call func_036_6C02                            ; $448B: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $448B: $CD $02 $6C
     ld   a, [hl]                                  ; $448E: $7E
     or   $02                                      ; $448F: $F6 $02
     ld   [hl], a                                  ; $4491: $77
-    call func_036_6C28                            ; $4492: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4492: $CD $28 $6C
     ld   a, [hl]                                  ; $4495: $7E
     cp   $38                                      ; $4496: $FE $38
     jr   c, jr_036_449C                           ; $4498: $38 $02
@@ -818,7 +818,7 @@ func_036_44FC::
     ld   hl, wEntitiesPrivateState2Table          ; $44FF: $21 $C0 $C2
     add  hl, bc                                   ; $4502: $09
     ld   a, [hl]                                  ; $4503: $7E
-    call func_036_6C23                            ; $4504: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4504: $CD $23 $6C
     cp   [hl]                                     ; $4507: $BE
     jr   z, jr_036_452D                           ; $4508: $28 $23
 
@@ -826,7 +826,7 @@ func_036_44FC::
     and  $07                                      ; $450C: $E6 $07
     jr   nz, jr_036_4517                          ; $450E: $20 $07
 
-    call func_036_6C02                            ; $4510: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4510: $CD $02 $6C
     ld   a, [hl]                                  ; $4513: $7E
     xor  $01                                      ; $4514: $EE $01
     ld   [hl], a                                  ; $4516: $77
@@ -834,7 +834,7 @@ func_036_44FC::
 jr_036_4517:
     ld   a, $08                                   ; $4517: $3E $08
     call ApplyVectorTowardsLink_trampoline        ; $4519: $CD $AA $3B
-    call func_036_6A62                            ; $451C: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $451C: $CD $62 $6A
     call func_036_6B8A                            ; $451F: $CD $8A $6B
     cp   $0C                                      ; $4522: $FE $0C
     jr   nc, jr_036_452D                          ; $4524: $30 $07
@@ -864,7 +864,7 @@ jr_036_4542:
     ld   hl, wEntitiesPrivateState2Table          ; $4542: $21 $C0 $C2
     add  hl, bc                                   ; $4545: $09
     ld   a, [hl]                                  ; $4546: $7E
-    call func_036_6C23                            ; $4547: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4547: $CD $23 $6C
     cp   [hl]                                     ; $454A: $BE
     ret  nz                                       ; $454B: $C0
 
@@ -879,7 +879,7 @@ func_036_4557::
     and  $07                                      ; $455C: $E6 $07
     jr   nz, jr_036_4567                          ; $455E: $20 $07
 
-    call func_036_6C02                            ; $4560: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4560: $CD $02 $6C
     ld   a, [hl]                                  ; $4563: $7E
     xor  $01                                      ; $4564: $EE $01
     ld   [hl], a                                  ; $4566: $77
@@ -889,18 +889,18 @@ jr_036_4567:
     and  $01                                      ; $4569: $E6 $01
     ret  nz                                       ; $456B: $C0
 
-    call func_036_6C23                            ; $456C: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $456C: $CD $23 $6C
     ld   a, [hl]                                  ; $456F: $7E
     cp   $50                                      ; $4570: $FE $50
     jr   nc, jr_036_457C                          ; $4572: $30 $08
 
-    call func_036_6C02                            ; $4574: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4574: $CD $02 $6C
     ld   [hl], $02                                ; $4577: $36 $02
     jp   IncrementEntityState                     ; $4579: $C3 $12 $3B
 
 jr_036_457C:
     dec  [hl]                                     ; $457C: $35
-    call func_036_6C28                            ; $457D: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $457D: $CD $28 $6C
     inc  [hl]                                     ; $4580: $34
     ldh  a, [hLinkPositionY]                      ; $4581: $F0 $99
     ld   hl, wEntitiesPrivateState2Table          ; $4583: $21 $C0 $C2
@@ -913,7 +913,7 @@ func_036_4589::
     ld   hl, wEntitiesPrivateState2Table          ; $458C: $21 $C0 $C2
     add  hl, bc                                   ; $458F: $09
     ld   a, [hl]                                  ; $4590: $7E
-    call func_036_6C28                            ; $4591: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4591: $CD $28 $6C
     cp   [hl]                                     ; $4594: $BE
     jr   z, jr_036_45E6                           ; $4595: $28 $4F
 
@@ -921,7 +921,7 @@ func_036_4589::
     and  $07                                      ; $4599: $E6 $07
     jr   nz, jr_036_45A4                          ; $459B: $20 $07
 
-    call func_036_6C02                            ; $459D: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $459D: $CD $02 $6C
     ld   a, [hl]                                  ; $45A0: $7E
     xor  $01                                      ; $45A1: $EE $01
     ld   [hl], a                                  ; $45A3: $77
@@ -935,7 +935,7 @@ jr_036_45A4:
 
     ld   a, $0C                                   ; $45AD: $3E $0C
     call ApplyVectorTowardsLink_trampoline        ; $45AF: $CD $AA $3B
-    call func_036_6A62                            ; $45B2: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $45B2: $CD $62 $6A
     call func_036_6B9A                            ; $45B5: $CD $9A $6B
     cp   $0C                                      ; $45B8: $FE $0C
     jr   nc, jr_036_45E6                          ; $45BA: $30 $2A
@@ -949,8 +949,8 @@ jr_036_45A4:
 jr_036_45C5:
     ld   a, $08                                   ; $45C5: $3E $08
     call ApplyVectorTowardsLink_trampoline        ; $45C7: $CD $AA $3B
-    call func_036_6A62                            ; $45CA: $CD $62 $6A
-    call func_036_6C28                            ; $45CD: $CD $28 $6C
+    call UpdateEntityPosWithSpeed_36              ; $45CA: $CD $62 $6A
+    call PointHLToEntityPosY                      ; $45CD: $CD $28 $6C
     ld   a, [hl]                                  ; $45D0: $7E
     cp   $2E                                      ; $45D1: $FE $2E
     jr   nc, jr_036_45D8                          ; $45D3: $30 $03
@@ -988,7 +988,7 @@ jr_036_45FB:
     ld   hl, wEntitiesPrivateState2Table          ; $45FB: $21 $C0 $C2
     add  hl, bc                                   ; $45FE: $09
     ld   a, [hl]                                  ; $45FF: $7E
-    call func_036_6C28                            ; $4600: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4600: $CD $28 $6C
     cp   [hl]                                     ; $4603: $BE
     ret  nz                                       ; $4604: $C0
 
@@ -1141,7 +1141,7 @@ func_036_46CA::
     call GetEntityTransitionCountdown             ; $46CD: $CD $05 $0C
     ret  nz                                       ; $46D0: $C0
 
-    call func_036_6C02                            ; $46D1: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $46D1: $CD $02 $6C
     ld   [hl], $00                                ; $46D4: $36 $00
     jp   IncrementEntityState                     ; $46D6: $C3 $12 $3B
 
@@ -1151,19 +1151,19 @@ func_036_46D9::
     and  $07                                      ; $46DE: $E6 $07
     jr   nz, jr_036_46E9                          ; $46E0: $20 $07
 
-    call func_036_6C02                            ; $46E2: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $46E2: $CD $02 $6C
     ld   a, [hl]                                  ; $46E5: $7E
     xor  $01                                      ; $46E6: $EE $01
     ld   [hl], a                                  ; $46E8: $77
 
 jr_036_46E9:
-    call func_036_6C23                            ; $46E9: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $46E9: $CD $23 $6C
     dec  [hl]                                     ; $46EC: $35
     ld   a, [hl]                                  ; $46ED: $7E
     cp   $35                                      ; $46EE: $FE $35
     ret  nc                                       ; $46F0: $D0
 
-    call func_036_6C02                            ; $46F1: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $46F1: $CD $02 $6C
     ld   [hl], $02                                ; $46F4: $36 $02
     jp   IncrementEntityState                     ; $46F6: $C3 $12 $3B
 
@@ -1173,20 +1173,20 @@ func_036_46F9::
     and  $07                                      ; $46FE: $E6 $07
     jr   nz, jr_036_4709                          ; $4700: $20 $07
 
-    call func_036_6C02                            ; $4702: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4702: $CD $02 $6C
     ld   a, [hl]                                  ; $4705: $7E
     xor  $01                                      ; $4706: $EE $01
     ld   [hl], a                                  ; $4708: $77
 
 jr_036_4709:
-    call func_036_6C28                            ; $4709: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4709: $CD $28 $6C
     dec  [hl]                                     ; $470C: $35
     ld   a, [hl]                                  ; $470D: $7E
     cp   $2E                                      ; $470E: $FE $2E
     ret  nc                                       ; $4710: $D0
 
     call_open_dialog $298                         ; $4711
-    call func_036_6C02                            ; $4716: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4716: $CD $02 $6C
     ld   [hl], $00                                ; $4719: $36 $00
     jp   IncrementEntityState                     ; $471B: $C3 $12 $3B
 
@@ -1223,7 +1223,7 @@ func_036_4742::
     ld   a, [wPhotos1]                            ; $4754: $FA $0C $DC
     or   $01                                      ; $4757: $F6 $01
     ld   [wPhotos1], a                            ; $4759: $EA $0C $DC
-    call func_036_6C02                            ; $475C: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $475C: $CD $02 $6C
     ld   [hl], $04                                ; $475F: $36 $04
     jp   IncrementEntityState                     ; $4761: $C3 $12 $3B
 
@@ -1329,9 +1329,9 @@ func_036_47DE::
     ldh  [hAnimatedTilesFrameCount], a            ; $47DF: $E0 $A6
     ld   a, $11                                   ; $47E1: $3E $11
     ldh  [hAnimatedTilesGroup], a                 ; $47E3: $E0 $A4
-    call func_036_6C23                            ; $47E5: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $47E5: $CD $23 $6C
     ld   [hl], $B0                                ; $47E8: $36 $B0
-    call func_036_6C28                            ; $47EA: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $47EA: $CD $28 $6C
     ld   [hl], $6A                                ; $47ED: $36 $6A
     jp   IncrementEntityState                     ; $47EF: $C3 $12 $3B
 
@@ -1353,13 +1353,13 @@ func_036_4803::
     and  $07                                      ; $4805: $E6 $07
     jr   nz, jr_036_4810                          ; $4807: $20 $07
 
-    call func_036_6C02                            ; $4809: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4809: $CD $02 $6C
     ld   a, [hl]                                  ; $480C: $7E
     xor  $01                                      ; $480D: $EE $01
     ld   [hl], a                                  ; $480F: $77
 
 jr_036_4810:
-    call func_036_6C23                            ; $4810: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4810: $CD $23 $6C
     dec  [hl]                                     ; $4813: $35
     ld   a, [hl]                                  ; $4814: $7E
     cp   $6A                                      ; $4815: $FE $6A
@@ -1397,13 +1397,13 @@ jr_036_4842:
     and  $07                                      ; $4844: $E6 $07
     jr   nz, jr_036_484F                          ; $4846: $20 $07
 
-    call func_036_6C02                            ; $4848: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4848: $CD $02 $6C
     ld   a, [hl]                                  ; $484B: $7E
     xor  $01                                      ; $484C: $EE $01
     ld   [hl], a                                  ; $484E: $77
 
 jr_036_484F:
-    call func_036_6C23                            ; $484F: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $484F: $CD $23 $6C
     ld   a, [hl]                                  ; $4852: $7E
     cp   $60                                      ; $4853: $FE $60
     jr   z, jr_036_4859                           ; $4855: $28 $02
@@ -1412,7 +1412,7 @@ jr_036_484F:
     ret                                           ; $4858: $C9
 
 jr_036_4859:
-    call func_036_6C02                            ; $4859: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4859: $CD $02 $6C
     ld   [hl], $02                                ; $485C: $36 $02
     call_open_dialog $109                         ; $485E
     jp   IncrementEntityState                     ; $4863: $C3 $12 $3B
@@ -1539,7 +1539,7 @@ func_036_496E::
     and  $0F                                      ; $4970: $E6 $0F
     ret  nz                                       ; $4972: $C0
 
-    call func_036_6C02                            ; $4973: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4973: $CD $02 $6C
     ld   a, [hl]                                  ; $4976: $7E
     xor  $01                                      ; $4977: $EE $01
     ld   [hl], a                                  ; $4979: $77
@@ -1551,7 +1551,7 @@ func_036_497B::
     add  hl, bc                                   ; $4981: $09
     ld   a, [hl]                                  ; $4982: $7E
     and  a                                        ; $4983: $A7
-    call func_036_6BEE                            ; $4984: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $4984: $CD $EE $6B
     ld   e, $E8                                   ; $4987: $1E $E8
     and  a                                        ; $4989: $A7
     jr   z, jr_036_498E                           ; $498A: $28 $02
@@ -1564,7 +1564,7 @@ jr_036_498E:
 
 func_036_4992::
     call func_036_496E                            ; $4992: $CD $6E $49
-    call func_036_6BEE                            ; $4995: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $4995: $CD $EE $6B
     ld   a, [hl]                                  ; $4998: $7E
     bit  7, a                                     ; $4999: $CB $7F
     jr   z, jr_036_49A0                           ; $499B: $28 $03
@@ -1588,7 +1588,7 @@ jr_036_49AD:
     push af                                       ; $49AD: $F5
     swap a                                        ; $49AE: $CB $37
     and  $F0                                      ; $49B0: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $49B2: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $49B2: $21 $60 $C2
     add  [hl]                                     ; $49B5: $86
     ld   [hl], a                                  ; $49B6: $77
     rl   d                                        ; $49B7: $CB $12
@@ -1624,7 +1624,7 @@ func_036_49DA::
     and  a                                        ; $49DF: $A7
     xor  $01                                      ; $49E0: $EE $01
     ld   [hl], a                                  ; $49E2: $77
-    call func_036_6C02                            ; $49E3: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $49E3: $CD $02 $6C
     ld   a, [hl]                                  ; $49E6: $7E
     xor  $02                                      ; $49E7: $EE $02
     ld   [hl], a                                  ; $49E9: $77
@@ -1637,7 +1637,7 @@ func_036_49DA::
     ret                                           ; $49F5: $C9
 
 func_036_49F6::
-    call func_036_6C02                            ; $49F6: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $49F6: $CD $02 $6C
     ld   [hl], $04                                ; $49F9: $36 $04
     ret                                           ; $49FB: $C9
 
@@ -2042,14 +2042,14 @@ jr_036_4C31:
     cp   $18                                      ; $4C3B: $FE $18
     jr   nc, jr_036_4C4C                          ; $4C3D: $30 $0D
 
-    call func_036_6BF8                            ; $4C3F: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $4C3F: $CD $F8 $6B
     ld   [hl], $28                                ; $4C42: $36 $28
     ld   a, $10                                   ; $4C44: $3E $10
     call ApplyVectorTowardsLink_trampoline        ; $4C46: $CD $AA $3B
     call IncrementEntityState                     ; $4C49: $CD $12 $3B
 
 jr_036_4C4C:
-    call func_036_6A62                            ; $4C4C: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $4C4C: $CD $62 $6A
     call label_3B23                               ; $4C4F: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $4C52: $F0 $E7
     rra                                           ; $4C54: $1F
@@ -2059,10 +2059,10 @@ jr_036_4C4C:
     ret                                           ; $4C5B: $C9
 
 func_036_4C5C::
-    call func_036_6A62                            ; $4C5C: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $4C5C: $CD $62 $6A
     call label_3B23                               ; $4C5F: $CD $23 $3B
     call func_036_6AEC                            ; $4C62: $CD $EC $6A
-    call func_036_6BF8                            ; $4C65: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $4C65: $CD $F8 $6B
     dec  [hl]                                     ; $4C68: $35
     dec  [hl]                                     ; $4C69: $35
     ld   a, [hl]                                  ; $4C6A: $7E
@@ -2085,7 +2085,7 @@ func_036_4C82::
     ret  nz                                       ; $4C85: $C0
 
     call func_036_6AEC                            ; $4C86: $CD $EC $6A
-    call func_036_6C2D                            ; $4C89: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $4C89: $CD $2D $6C
     ld   a, [hl]                                  ; $4C8C: $7E
     bit  7, a                                     ; $4C8D: $CB $7F
     ret  z                                        ; $4C8F: $C8
@@ -2130,7 +2130,7 @@ HardhitBeetleEntityHandler::
     and  $1F                                      ; $4CC9: $E6 $1F
     jr   nz, jr_036_4CD5                          ; $4CCB: $20 $08
 
-    call func_036_6C02                            ; $4CCD: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4CCD: $CD $02 $6C
     ld   a, [hl]                                  ; $4CD0: $7E
     inc  a                                        ; $4CD1: $3C
     and  $01                                      ; $4CD2: $E6 $01
@@ -2139,7 +2139,7 @@ HardhitBeetleEntityHandler::
 jr_036_4CD5:
     call BossIntro                                ; $4CD5: $CD $E8 $3E
     call func_036_6A40                            ; $4CD8: $CD $40 $6A
-    call func_036_6A62                            ; $4CDB: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $4CDB: $CD $62 $6A
     ld   de, Data_036_4CB4                        ; $4CDE: $11 $B4 $4C
     call func_036_6C90                            ; $4CE1: $CD $90 $6C
     call label_3B39                               ; $4CE4: $CD $39 $3B
@@ -2319,12 +2319,12 @@ func_036_4DD8::
     ld   hl, wEntitiesStateTable                  ; $4DF0: $21 $90 $C2
     add  hl, de                                   ; $4DF3: $19
     ld   [hl], $04                                ; $4DF4: $36 $04
-    call func_036_6C23                            ; $4DF6: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $4DF6: $CD $23 $6C
     ld   a, [hl]                                  ; $4DF9: $7E
     ld   hl, wEntitiesPosXTable                   ; $4DFA: $21 $00 $C2
     add  hl, de                                   ; $4DFD: $19
     ld   [hl], a                                  ; $4DFE: $77
-    call func_036_6C28                            ; $4DFF: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $4DFF: $CD $28 $6C
     ld   a, [hl]                                  ; $4E02: $7E
     ld   hl, wEntitiesPosYTable                   ; $4E03: $21 $10 $C2
     add  hl, de                                   ; $4E06: $19
@@ -2383,9 +2383,9 @@ jr_036_4E42:
     call_open_dialog $26E                         ; $4E4B
 
 jr_036_4E50:
-    call func_036_6BEE                            ; $4E50: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $4E50: $CD $EE $6B
     ld   [hl], a                                  ; $4E53: $77
-    call func_036_6BF3                            ; $4E54: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $4E54: $CD $F3 $6B
     ld   [hl], a                                  ; $4E57: $77
     call IncrementEntityState                     ; $4E58: $CD $12 $3B
     ret                                           ; $4E5B: $C9
@@ -2404,12 +2404,12 @@ jr_036_4E5C:
     ld   hl, Data_036_4E1F                        ; $4E6C: $21 $1F $4E
     add  hl, de                                   ; $4E6F: $19
     ld   a, [hl]                                  ; $4E70: $7E
-    call func_036_6BEE                            ; $4E71: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $4E71: $CD $EE $6B
     ld   [hl], a                                  ; $4E74: $77
     ld   hl, Data_036_4E1D                        ; $4E75: $21 $1D $4E
     add  hl, de                                   ; $4E78: $19
     ld   a, [hl]                                  ; $4E79: $7E
-    call func_036_6BF3                            ; $4E7A: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $4E7A: $CD $F3 $6B
     ld   [hl], a                                  ; $4E7D: $77
     ret                                           ; $4E7E: $C9
 
@@ -2508,7 +2508,7 @@ Data_036_4F4A::
     dw   Data_036_4F1A
 
 func_036_4F4E::
-    call func_036_6C02                            ; $4F4E: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $4F4E: $CD $02 $6C
     ld   a, [hl]                                  ; $4F51: $7E
     sla  a                                        ; $4F52: $CB $27
     ld   e, a                                     ; $4F54: $5F
@@ -2595,13 +2595,13 @@ jr_036_4FB1:
     ld   a, $36                                   ; $4FD4: $3E $36
     ld   [wCurrentBank], a                        ; $4FD6: $EA $AF $DB
     call label_3CD9                               ; $4FD9: $CD $D9 $3C
-    call func_036_6BEE                            ; $4FDC: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $4FDC: $CD $EE $6B
     ld   a, [hl]                                  ; $4FDF: $7E
     rlca                                          ; $4FE0: $07
     rlca                                          ; $4FE1: $07
     and  $01                                      ; $4FE2: $E6 $01
     call SetEntitySpriteVariant                   ; $4FE4: $CD $0C $3B
-    call func_036_6A62                            ; $4FE7: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $4FE7: $CD $62 $6A
     call func_036_5000                            ; $4FEA: $CD $00 $50
     ld   a, [wIsLinkInTheAir]                     ; $4FED: $FA $46 $C1
     and  a                                        ; $4FF0: $A7
@@ -2624,15 +2624,15 @@ func_036_5000::
 ._01 dw func_036_501C                             ; $5005
 
 func_036_5007::
-    call func_036_6C28                            ; $5007: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $5007: $CD $28 $6C
     ld   a, [hl]                                  ; $500A: $7E
     cp   $50                                      ; $500B: $FE $50
     jr   c, jr_036_501B                           ; $500D: $38 $0C
 
     xor  a                                        ; $500F: $AF
-    call func_036_6BEE                            ; $5010: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5010: $CD $EE $6B
     ld   [hl], a                                  ; $5013: $77
-    call func_036_6BF3                            ; $5014: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5014: $CD $F3 $6B
     ld   [hl], a                                  ; $5017: $77
     call IncrementEntityState                     ; $5018: $CD $12 $3B
 
@@ -2648,12 +2648,12 @@ func_036_501C::
     call GetRandomByte                            ; $5025: $CD $0D $28
     and  $0F                                      ; $5028: $E6 $0F
     sub  $08                                      ; $502A: $D6 $08
-    call func_036_6BEE                            ; $502C: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $502C: $CD $EE $6B
     ld   [hl], a                                  ; $502F: $77
     call GetRandomByte                            ; $5030: $CD $0D $28
     and  $0F                                      ; $5033: $E6 $0F
     sub  $08                                      ; $5035: $D6 $08
-    call func_036_6BF3                            ; $5037: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5037: $CD $F3 $6B
     ld   [hl], a                                  ; $503A: $77
     ret                                           ; $503B: $C9
 
@@ -2732,7 +2732,7 @@ jr_036_506B:
     ld   e, $02                                   ; $50AF: $1E $02
 
 jr_036_50B1:
-    call func_036_6BF8                            ; $50B1: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $50B1: $CD $F8 $6B
     ld   [hl], e                                  ; $50B4: $73
     call func_036_6AEC                            ; $50B5: $CD $EC $6A
     ld   a, [wCurrentBank]                        ; $50B8: $FA $AF $DB
@@ -3428,7 +3428,7 @@ func_036_5537::
     and  $07                                      ; $554B: $E6 $07
     ret  nz                                       ; $554D: $C0
 
-    call func_036_6C02                            ; $554E: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $554E: $CD $02 $6C
     inc  [hl]                                     ; $5551: $34
     ld   a, [hl]                                  ; $5552: $7E
     cp   $04                                      ; $5553: $FE $04
@@ -3474,7 +3474,7 @@ func_036_558E::
     and  $03                                      ; $5594: $E6 $03
     ret  nz                                       ; $5596: $C0
 
-    call func_036_6C02                            ; $5597: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5597: $CD $02 $6C
     inc  [hl]                                     ; $559A: $34
     ld   a, [hl]                                  ; $559B: $7E
     cp   $0B                                      ; $559C: $FE $0B
@@ -3505,15 +3505,15 @@ func_036_55B1::
     and  a                                        ; $55BB: $A7
     jr   z, jr_036_55E0                           ; $55BC: $28 $22
 
-    call func_036_6C02                            ; $55BE: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $55BE: $CD $02 $6C
     ld   a, [hl]                                  ; $55C1: $7E
     and  $01                                      ; $55C2: $E6 $01
     jr   nz, jr_036_55E0                          ; $55C4: $20 $1A
 
     ld   [hl], a                                  ; $55C6: $77
-    call func_036_6BEE                            ; $55C7: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $55C7: $CD $EE $6B
     ld   [hl], a                                  ; $55CA: $77
-    call func_036_6BF3                            ; $55CB: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $55CB: $CD $F3 $6B
     ld   [hl], a                                  ; $55CE: $77
     ld   hl, wEntitiesUnknownTableD               ; $55CF: $21 $D0 $C2
     add  hl, bc                                   ; $55D2: $09
@@ -3538,16 +3538,16 @@ jr_036_55E0:
     ld   hl, Data_036_55A7                        ; $55F1: $21 $A7 $55
     add  hl, de                                   ; $55F4: $19
     ld   a, [hl]                                  ; $55F5: $7E
-    call func_036_6BEE                            ; $55F6: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $55F6: $CD $EE $6B
     ld   [hl], a                                  ; $55F9: $77
     ld   hl, Data_036_55A5                        ; $55FA: $21 $A5 $55
     add  hl, de                                   ; $55FD: $19
     ld   a, [hl]                                  ; $55FE: $7E
-    call func_036_6BF3                            ; $55FF: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $55FF: $CD $F3 $6B
     ld   [hl], a                                  ; $5602: $77
 
 jr_036_5603:
-    call func_036_6A62                            ; $5603: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5603: $CD $62 $6A
     ld   de, Data_036_55AF                        ; $5606: $11 $AF $55
     call func_036_6C90                            ; $5609: $CD $90 $6C
     ld   hl, wEntitiesStateTable                  ; $560C: $21 $90 $C2
@@ -3618,7 +3618,7 @@ jr_036_5673:
     and  $0F                                      ; $5675: $E6 $0F
     ret  nz                                       ; $5677: $C0
 
-    call func_036_6C02                            ; $5678: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5678: $CD $02 $6C
     inc  [hl]                                     ; $567B: $34
     ld   a, [hl]                                  ; $567C: $7E
     cp   $04                                      ; $567D: $FE $04
@@ -3668,7 +3668,7 @@ func_036_56CD::
     ld   hl, wEntitiesStateTable                  ; $56D6: $21 $90 $C2
     add  hl, de                                   ; $56D9: $19
     ld   [hl], $02                                ; $56DA: $36 $02
-    call func_036_6C23                            ; $56DC: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $56DC: $CD $23 $6C
     ld   a, [hl]                                  ; $56DF: $7E
     pop  hl                                       ; $56E0: $E1
     add  [hl]                                     ; $56E1: $86
@@ -3683,7 +3683,7 @@ func_036_56CD::
     ld   hl, wEntitiesSpeedXTable                 ; $56EC: $21 $40 $C2
     add  hl, de                                   ; $56EF: $19
     ld   [hl], a                                  ; $56F0: $77
-    call func_036_6C28                            ; $56F1: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $56F1: $CD $28 $6C
     ld   a, [hl]                                  ; $56F4: $7E
     pop  hl                                       ; $56F5: $E1
     add  [hl]                                     ; $56F6: $86
@@ -3721,7 +3721,7 @@ func_036_5721::
     and  $03                                      ; $5723: $E6 $03
     ret  nz                                       ; $5725: $C0
 
-    call func_036_6C02                            ; $5726: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5726: $CD $02 $6C
     inc  [hl]                                     ; $5729: $34
     ld   a, [hl]                                  ; $572A: $7E
     cp   $03                                      ; $572B: $FE $03
@@ -3745,7 +3745,7 @@ func_036_573E::
     and  $03                                      ; $5740: $E6 $03
     ret  nz                                       ; $5742: $C0
 
-    call func_036_6C02                            ; $5743: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5743: $CD $02 $6C
     inc  [hl]                                     ; $5746: $34
     ld   a, [hl]                                  ; $5747: $7E
     cp   $07                                      ; $5748: $FE $07
@@ -3774,7 +3774,7 @@ func_036_5756::
     and  a                                        ; $576B: $A7
     ret  nz                                       ; $576C: $C0
 
-    call func_036_6C02                            ; $576D: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $576D: $CD $02 $6C
     ld   a, [hl]                                  ; $5770: $7E
     and  a                                        ; $5771: $A7
     ret  nz                                       ; $5772: $C0
@@ -3803,7 +3803,7 @@ func_036_578F::
     and  $07                                      ; $5791: $E6 $07
     jr   nz, jr_036_57AB                          ; $5793: $20 $16
 
-    call func_036_6C02                            ; $5795: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5795: $CD $02 $6C
     inc  [hl]                                     ; $5798: $34
     ld   a, [hl]                                  ; $5799: $7E
     cp   $02                                      ; $579A: $FE $02
@@ -3811,7 +3811,7 @@ func_036_578F::
 
     ld   a, $08                                   ; $579E: $3E $08
     call ApplyVectorTowardsLink_trampoline        ; $57A0: $CD $AA $3B
-    call func_036_6BF8                            ; $57A3: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $57A3: $CD $F8 $6B
     ld   [hl], $20                                ; $57A6: $36 $20
     call IncrementEntityState                     ; $57A8: $CD $12 $3B
 
@@ -3820,16 +3820,16 @@ jr_036_57AB:
     ret                                           ; $57AE: $C9
 
 func_036_57AF::
-    call func_036_6A62                            ; $57AF: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $57AF: $CD $62 $6A
     call func_036_6AEC                            ; $57B2: $CD $EC $6A
-    call func_036_6BF8                            ; $57B5: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $57B5: $CD $F8 $6B
     dec  [hl]                                     ; $57B8: $35
-    call func_036_6C2D                            ; $57B9: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $57B9: $CD $2D $6C
     ld   a, [hl]                                  ; $57BC: $7E
     bit  7, a                                     ; $57BD: $CB $7F
     ret  z                                        ; $57BF: $C8
 
-    call func_036_6C02                            ; $57C0: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $57C0: $CD $02 $6C
     inc  [hl]                                     ; $57C3: $34
     call IncrementEntityState                     ; $57C4: $CD $12 $3B
     ret                                           ; $57C7: $C9
@@ -3839,7 +3839,7 @@ func_036_57C8::
     and  $07                                      ; $57CA: $E6 $07
     jr   nz, jr_036_57E6                          ; $57CC: $20 $18
 
-    call func_036_6C02                            ; $57CE: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $57CE: $CD $02 $6C
     inc  [hl]                                     ; $57D1: $34
     ld   a, [hl]                                  ; $57D2: $7E
     cp   $04                                      ; $57D3: $FE $04
@@ -3925,7 +3925,7 @@ func_036_5844::
     ld   hl, Data_036_582C                        ; $584B: $21 $2C $58
     call func_036_6C7E                            ; $584E: $CD $7E $6C
     push hl                                       ; $5851: $E5
-    call func_036_6C02                            ; $5852: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5852: $CD $02 $6C
 
 jr_036_5855:
     ld   e, [hl]                                  ; $5855: $5E
@@ -3993,9 +3993,9 @@ func_036_58A1::
     cp   $05                                      ; $58A7: $FE $05
     jr   nc, jr_036_58B8                          ; $58A9: $30 $0D
 
-    call func_036_6BF3                            ; $58AB: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $58AB: $CD $F3 $6B
     ld   [hl], $14                                ; $58AE: $36 $14
-    call func_036_6BF8                            ; $58B0: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $58B0: $CD $F8 $6B
     ld   [hl], $10                                ; $58B3: $36 $10
     call IncrementEntityState                     ; $58B5: $CD $12 $3B
 
@@ -4003,13 +4003,13 @@ jr_036_58B8:
     ret                                           ; $58B8: $C9
 
 func_036_58B9::
-    call func_036_6A62                            ; $58B9: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $58B9: $CD $62 $6A
     call func_036_6AEC                            ; $58BC: $CD $EC $6A
     ldh  a, [hFrameCounter]                       ; $58BF: $F0 $E7
     and  $01                                      ; $58C1: $E6 $01
     jr   z, jr_036_58CD                           ; $58C3: $28 $08
 
-    call func_036_6BF3                            ; $58C5: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $58C5: $CD $F3 $6B
     ld   a, [hl]                                  ; $58C8: $7E
     and  a                                        ; $58C9: $A7
     jr   z, jr_036_58CD                           ; $58CA: $28 $01
@@ -4017,16 +4017,16 @@ func_036_58B9::
     dec  [hl]                                     ; $58CC: $35
 
 jr_036_58CD:
-    call func_036_6BF8                            ; $58CD: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $58CD: $CD $F8 $6B
     dec  [hl]                                     ; $58D0: $35
-    call func_036_6C2D                            ; $58D1: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $58D1: $CD $2D $6C
     ld   a, [hl]                                  ; $58D4: $7E
     bit  7, a                                     ; $58D5: $CB $7F
     jr   z, jr_036_58E3                           ; $58D7: $28 $0A
 
     xor  a                                        ; $58D9: $AF
     ld   [hl], a                                  ; $58DA: $77
-    call func_036_6BF8                            ; $58DB: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $58DB: $CD $F8 $6B
     ld   [hl], $10                                ; $58DE: $36 $10
     call IncrementEntityState                     ; $58E0: $CD $12 $3B
 
@@ -4169,7 +4169,7 @@ jr_036_5993:
     ld   hl, wEntitiesTypeTable                   ; $59A3: $21 $A0 $C3
     add  hl, bc                                   ; $59A6: $09
     ld   a, [hl]                                  ; $59A7: $7E
-    call func_036_6BEE                            ; $59A8: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $59A8: $CD $EE $6B
     ld   [hl], $FA                                ; $59AB: $36 $FA
     and  $01                                      ; $59AD: $E6 $01
     jr   nz, jr_036_59B3                          ; $59AF: $20 $02
@@ -4246,7 +4246,7 @@ ENDC
     ret                                           ; $5A1D: $C9
 
 jr_036_5A1E:
-    call func_036_6BEE                            ; $5A1E: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5A1E: $CD $EE $6B
     ld   [hl], $FA                                ; $5A21: $36 $FA
     ld   a, e                                     ; $5A23: $7B
     and  a                                        ; $5A24: $A7
@@ -4278,7 +4278,7 @@ func_036_5A40::
     ld   a, $02                                   ; $5A40: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $5A42: $E0 $A1
     ld   [wC167], a                               ; $5A44: $EA $67 $C1
-    call func_036_6C23                            ; $5A47: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $5A47: $CD $23 $6C
     ld   e, $5F                                   ; $5A4A: $1E $5F
     ld   a, [hl]                                  ; $5A4C: $7E
     cp   $3C                                      ; $5A4D: $FE $3C
@@ -4301,8 +4301,8 @@ jr_036_5A57:
     ret                                           ; $5A69: $C9
 
 jr_036_5A6A:
-    call func_036_6A62                            ; $5A6A: $CD $62 $6A
-    call func_036_6C02                            ; $5A6D: $CD $02 $6C
+    call UpdateEntityPosWithSpeed_36              ; $5A6A: $CD $62 $6A
+    call PointHLToEntitySpriteVariant             ; $5A6D: $CD $02 $6C
     ldh  a, [hFrameCounter]                       ; $5A70: $F0 $E7
     srl  a                                        ; $5A72: $CB $3F
     srl  a                                        ; $5A74: $CB $3F
@@ -4320,7 +4320,7 @@ func_036_5A7D::
     ret                                           ; $5A86: $C9
 
 func_036_5A87::
-    call func_036_6C23                            ; $5A87: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $5A87: $CD $23 $6C
     ld   a, [hl]                                  ; $5A8A: $7E
     cp   $50                                      ; $5A8B: $FE $50
     jr   nz, jr_036_5A6A                          ; $5A8D: $20 $DB
@@ -4387,7 +4387,7 @@ label_036_5AE4:
     call func_036_6A40                            ; $5AEA: $CD $40 $6A
     call DecrementEntityIgnoreHitsCountdown       ; $5AED: $CD $56 $0C
     call label_3B39                               ; $5AF0: $CD $39 $3B
-    call func_036_6A62                            ; $5AF3: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5AF3: $CD $62 $6A
     call func_036_6C15                            ; $5AF6: $CD $15 $6C
     jp   label_036_5BE8                           ; $5AF9: $C3 $E8 $5B
 
@@ -4402,7 +4402,7 @@ jr_036_5B1C:
     call func_036_6A40                            ; $5B22: $CD $40 $6A
     call DecrementEntityIgnoreHitsCountdown       ; $5B25: $CD $56 $0C
     call label_3B39                               ; $5B28: $CD $39 $3B
-    call func_036_6A62                            ; $5B2B: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5B2B: $CD $62 $6A
     ld   hl, wEntitiesPrivateState1Table          ; $5B2E: $21 $B0 $C2
     add  hl, bc                                   ; $5B31: $09
     ldh  a, [hFrameCounter]                       ; $5B32: $F0 $E7
@@ -4410,7 +4410,7 @@ jr_036_5B1C:
     srl  a                                        ; $5B36: $CB $3F
     srl  a                                        ; $5B38: $CB $3F
     or   [hl]                                     ; $5B3A: $B6
-    call func_036_6C02                            ; $5B3B: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5B3B: $CD $02 $6C
     ld   [hl], a                                  ; $5B3E: $77
     jp   label_036_5BE8                           ; $5B3F: $C3 $E8 $5B
 
@@ -4458,17 +4458,17 @@ jr_036_5B73:
     rra                                           ; $5B91: $1F
     and  $03                                      ; $5B92: $E6 $03
     call SetEntitySpriteVariant                   ; $5B94: $CD $0C $3B
-    call func_036_6A62                            ; $5B97: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5B97: $CD $62 $6A
     ldh  a, [hActiveEntityState]                  ; $5B9A: $F0 $F0
     bit  3, a                                     ; $5B9C: $CB $5F
     jr   nz, label_036_5BE8                       ; $5B9E: $20 $48
 
     call func_036_6AEC                            ; $5BA0: $CD $EC $6A
     call label_3CD9                               ; $5BA3: $CD $D9 $3C
-    call func_036_6BF8                            ; $5BA6: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $5BA6: $CD $F8 $6B
     dec  [hl]                                     ; $5BA9: $35
     dec  [hl]                                     ; $5BAA: $35
-    call func_036_6C2D                            ; $5BAB: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $5BAB: $CD $2D $6C
     ld   a, [hl]                                  ; $5BAE: $7E
     and  $80                                      ; $5BAF: $E6 $80
     jr   z, label_036_5BE8                        ; $5BB1: $28 $35
@@ -4481,7 +4481,7 @@ jr_036_5B73:
     ld   hl, Data_036_5B52                        ; $5BBB: $21 $52 $5B
     add  hl, de                                   ; $5BBE: $19
     ld   a, [hl]                                  ; $5BBF: $7E
-    call func_036_6BEE                            ; $5BC0: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5BC0: $CD $EE $6B
     ld   [hl], a                                  ; $5BC3: $77
     call GetRandomByte                            ; $5BC4: $CD $0D $28
     and  $03                                      ; $5BC7: $E6 $03
@@ -4490,7 +4490,7 @@ jr_036_5B73:
     ld   hl, Data_036_5B56                        ; $5BCB: $21 $56 $5B
     add  hl, de                                   ; $5BCE: $19
     ld   a, [hl]                                  ; $5BCF: $7E
-    call func_036_6BF3                            ; $5BD0: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5BD0: $CD $F3 $6B
     ld   [hl], a                                  ; $5BD3: $77
     call GetRandomByte                            ; $5BD4: $CD $0D $28
     and  $03                                      ; $5BD7: $E6 $03
@@ -4499,7 +4499,7 @@ jr_036_5B73:
     ld   hl, Data_036_5B5A                        ; $5BDB: $21 $5A $5B
     add  hl, de                                   ; $5BDE: $19
     ld   a, [hl]                                  ; $5BDF: $7E
-    call func_036_6BF8                            ; $5BE0: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $5BE0: $CD $F8 $6B
     ld   [hl], a                                  ; $5BE3: $77
     ld   a, JINGLE_BIG_BUMP                       ; $5BE4: $3E $20
     ldh  [hJingle], a                             ; $5BE6: $E0 $F2
@@ -4712,9 +4712,9 @@ AvalaunchState3Handler::
     ret  nz                                       ; $5D12: $C0
 
     xor  a                                        ; $5D13: $AF
-    call func_036_6BEE                            ; $5D14: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5D14: $CD $EE $6B
     ld   [hl], a                                  ; $5D17: $77
-    call func_036_6BF3                            ; $5D18: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5D18: $CD $F3 $6B
     ld   [hl], a                                  ; $5D1B: $77
     ld   hl, wEntitiesUnknownTableD               ; $5D1C: $21 $D0 $C2
     add  hl, bc                                   ; $5D1F: $09
@@ -4723,7 +4723,7 @@ AvalaunchState3Handler::
     jr   nz, jr_036_5D39                          ; $5D24: $20 $13
 
     ld   [hl], $01                                ; $5D26: $36 $01
-    call func_036_6BF8                            ; $5D28: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $5D28: $CD $F8 $6B
     ld   [hl], $18                                ; $5D2B: $36 $18
     ld   hl, wEntitiesPrivateState2Table          ; $5D2D: $21 $C0 $C2
     add  hl, bc                                   ; $5D30: $09
@@ -4738,7 +4738,7 @@ jr_036_5D39:
     ld   hl, wEntitiesPrivateState1Table          ; $5D3E: $21 $B0 $C2
     add  hl, bc                                   ; $5D41: $09
     ld   [hl], $06                                ; $5D42: $36 $06
-    call func_036_6BFD                            ; $5D44: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $5D44: $CD $FD $6B
     ld   [hl], $03                                ; $5D47: $36 $03
     call IncrementEntityState                     ; $5D49: $CD $12 $3B
     call GetRandomByte                            ; $5D4C: $CD $0D $28
@@ -4746,7 +4746,7 @@ jr_036_5D39:
     jr   z, jr_036_5D62                           ; $5D51: $28 $0F
 
     ld   [hl], $06                                ; $5D53: $36 $06
-    call func_036_6BEE                            ; $5D55: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5D55: $CD $EE $6B
     call GetRandomByte                            ; $5D58: $CD $0D $28
     and  $01                                      ; $5D5B: $E6 $01
     jr   nz, jr_036_5D65                          ; $5D5D: $20 $06
@@ -4755,7 +4755,7 @@ jr_036_5D39:
     ret                                           ; $5D61: $C9
 
 jr_036_5D62:
-    call func_036_6BF3                            ; $5D62: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5D62: $CD $F3 $6B
 
 jr_036_5D65:
     ld   [hl], $40                                ; $5D65: $36 $40
@@ -4768,7 +4768,7 @@ AvalaunchState4Handler::
     call GetEntityTransitionCountdown             ; $5D6C: $CD $05 $0C
     jr   nz, jr_036_5D97                          ; $5D6F: $20 $26
 
-    call func_036_6A62                            ; $5D71: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5D71: $CD $62 $6A
     call label_3B23                               ; $5D74: $CD $23 $3B
     call func_036_6C0D                            ; $5D77: $CD $0D $6C
     ld   a, $20                                   ; $5D7A: $3E $20
@@ -4781,7 +4781,7 @@ AvalaunchState4Handler::
     jr   nz, jr_036_5D97                          ; $5D86: $20 $0F
 
     ld   [hl], $06                                ; $5D88: $36 $06
-    call func_036_6BF3                            ; $5D8A: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5D8A: $CD $F3 $6B
     ld   [hl], $C0                                ; $5D8D: $36 $C0
     ld   a, $30                                   ; $5D8F: $3E $30
     call func_036_6C83                            ; $5D91: $CD $83 $6C
@@ -4797,7 +4797,7 @@ AvalaunchState5Handler::
     call GetEntityTransitionCountdown             ; $5D9C: $CD $05 $0C
     jr   nz, jr_036_5DC2                          ; $5D9F: $20 $21
 
-    call func_036_6A62                            ; $5DA1: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5DA1: $CD $62 $6A
     call label_3B23                               ; $5DA4: $CD $23 $3B
     call func_036_6C0D                            ; $5DA7: $CD $0D $6C
     ld   a, $20                                   ; $5DAA: $3E $20
@@ -4824,7 +4824,7 @@ AvalaunchState6Handler::
     call GetEntityTransitionCountdown             ; $5DC7: $CD $05 $0C
     ret  nz                                       ; $5DCA: $C0
 
-    call func_036_6A62                            ; $5DCB: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5DCB: $CD $62 $6A
     call label_3B23                               ; $5DCE: $CD $23 $3B
     call func_036_6C0D                            ; $5DD1: $CD $0D $6C
     ld   a, $20                                   ; $5DD4: $3E $20
@@ -4837,7 +4837,7 @@ AvalaunchState6Handler::
     ret  nz                                       ; $5DE0: $C0
 
     ld   [hl], $06                                ; $5DE1: $36 $06
-    call func_036_6BEE                            ; $5DE3: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5DE3: $CD $EE $6B
     ld   a, [hl]                                  ; $5DE6: $7E
     cpl                                           ; $5DE7: $2F
     inc  a                                        ; $5DE8: $3C
@@ -4854,7 +4854,7 @@ AvalaunchState7Handler::
     call GetEntityTransitionCountdown             ; $5DF7: $CD $05 $0C
     ret  nz                                       ; $5DFA: $C0
 
-    call func_036_6A62                            ; $5DFB: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5DFB: $CD $62 $6A
     call label_3B23                               ; $5DFE: $CD $23 $3B
     call func_036_6C0D                            ; $5E01: $CD $0D $6C
     ld   a, $20                                   ; $5E04: $3E $20
@@ -4888,16 +4888,16 @@ AvalaunchState8Handler::
 
     ld   [hl], $01                                ; $5E30: $36 $01
     xor  a                                        ; $5E32: $AF
-    call func_036_6BEE                            ; $5E33: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5E33: $CD $EE $6B
     ld   [hl], a                                  ; $5E36: $77
-    call func_036_6BF3                            ; $5E37: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5E37: $CD $F3 $6B
     ld   [hl], a                                  ; $5E3A: $77
-    call func_036_6BF8                            ; $5E3B: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $5E3B: $CD $F8 $6B
     ld   [hl], $18                                ; $5E3E: $36 $18
     call IncrementEntityState                     ; $5E40: $CD $12 $3B
-    call func_036_6C23                            ; $5E43: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $5E43: $CD $23 $6C
     ld   a, [hl]                                  ; $5E46: $7E
-    call func_036_6BEE                            ; $5E47: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5E47: $CD $EE $6B
     cp   $50                                      ; $5E4A: $FE $50
     jr   z, jr_036_5E53                           ; $5E4C: $28 $05
 
@@ -4907,21 +4907,21 @@ AvalaunchState8Handler::
     ret                                           ; $5E52: $C9
 
 jr_036_5E53:
-    call func_036_6BF3                            ; $5E53: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $5E53: $CD $F3 $6B
 
 jr_036_5E56:
     ld   [hl], $F0                                ; $5E56: $36 $F0
     ret                                           ; $5E58: $C9
 
 AvalaunchState9Handler::
-    call func_036_6A62                            ; $5E59: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5E59: $CD $62 $6A
     call label_3B23                               ; $5E5C: $CD $23 $3B
-    call func_036_6BEE                            ; $5E5F: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5E5F: $CD $EE $6B
     ld   a, [hl]                                  ; $5E62: $7E
     and  a                                        ; $5E63: $A7
     jr   z, jr_036_5E81                           ; $5E64: $28 $1B
 
-    call func_036_6C23                            ; $5E66: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $5E66: $CD $23 $6C
     and  $80                                      ; $5E69: $E6 $80
     jr   nz, jr_036_5E74                          ; $5E6B: $20 $07
 
@@ -4939,12 +4939,12 @@ jr_036_5E74:
 jr_036_5E79:
     ld   a, $50                                   ; $5E79: $3E $50
     ld   [hl], a                                  ; $5E7B: $77
-    call func_036_6BEE                            ; $5E7C: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5E7C: $CD $EE $6B
     xor  a                                        ; $5E7F: $AF
     ld   [hl], a                                  ; $5E80: $77
 
 jr_036_5E81:
-    call func_036_6BF8                            ; $5E81: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $5E81: $CD $F8 $6B
     dec  [hl]                                     ; $5E84: $35
     call func_036_6AEC                            ; $5E85: $CD $EC $6A
     ld   a, [hl]                                  ; $5E88: $7E
@@ -4970,7 +4970,7 @@ jr_036_5E81:
     call func_036_5EC2                            ; $5EA9: $CD $C2 $5E
 
 jr_036_5EAC:
-    call func_036_6C02                            ; $5EAC: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5EAC: $CD $02 $6C
     ld   a, [hl]                                  ; $5EAF: $7E
     and  $01                                      ; $5EB0: $E6 $01
     jr   nz, jr_036_5EB6                          ; $5EB2: $20 $02
@@ -5066,7 +5066,7 @@ jr_036_5F26:
     ld   [wC167], a                               ; $5F2B: $EA $67 $C1
     ld   a, $04                                   ; $5F2E: $3E $04
     call func_036_6C83                            ; $5F30: $CD $83 $6C
-    call func_036_6C02                            ; $5F33: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5F33: $CD $02 $6C
     inc  [hl]                                     ; $5F36: $34
     ld   a, [hl]                                  ; $5F37: $7E
     and  $0F                                      ; $5F38: $E6 $0F
@@ -5116,7 +5116,7 @@ Data_036_5F69::
 
 func_036_5F75::
     ld   d, $00                                   ; $5F75: $16 $00
-    call func_036_6C02                            ; $5F77: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $5F77: $CD $02 $6C
     ld   e, [hl]                                  ; $5F7A: $5E
     ldh  a, [hActiveEntityState]                  ; $5F7B: $F0 $F0
     cp   $0A                                      ; $5F7D: $FE $0A
@@ -5147,7 +5147,7 @@ HopperEntityHandler::
     call func_036_6219                            ; $5FA2: $CD $19 $62
     call func_036_6A40                            ; $5FA5: $CD $40 $6A
     call label_3B70                               ; $5FA8: $CD $70 $3B
-    call func_036_6A62                            ; $5FAB: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $5FAB: $CD $62 $6A
     call label_3CD9                               ; $5FAE: $CD $D9 $3C
     ld   hl, wEntitiesFlashCountdownTable         ; $5FB1: $21 $20 $C4
     add  hl, bc                                   ; $5FB4: $09
@@ -5181,7 +5181,7 @@ jr_036_5FC8:
 ._04 dw HopperState4Handler
 
 HopperState4Handler::
-    call func_036_6BF8                            ; $5FDB: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $5FDB: $CD $F8 $6B
     dec  [hl]                                     ; $5FDE: $35
     ld   a, [hl]                                  ; $5FDF: $7E
     ldh  [hScratch0], a                           ; $5FE0: $E0 $D7
@@ -5202,9 +5202,9 @@ HopperState4Handler::
     ld   e, $FC                                   ; $5FF9: $1E $FC
 
 jr_036_5FFB:
-    call func_036_6BEE                            ; $5FFB: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $5FFB: $CD $EE $6B
     ld   [hl], e                                  ; $5FFE: $73
-    call func_036_6BFD                            ; $5FFF: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $5FFF: $CD $FD $6B
     ld   [hl], $00                                ; $6002: $36 $00
     bit  7, e                                     ; $6004: $CB $7B
     jr   nz, jr_036_6009                          ; $6006: $20 $01
@@ -5220,21 +5220,21 @@ jr_036_6009:
     ld   e, $FD                                   ; $6012: $1E $FD
 
 jr_036_6014:
-    call func_036_6BF3                            ; $6014: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6014: $CD $F3 $6B
     ld   [hl], e                                  ; $6017: $73
-    call func_036_6BF8                            ; $6018: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $6018: $CD $F8 $6B
     ld   [hl], $14                                ; $601B: $36 $14
     ld   a, JINGLE_FEATHER_JUMP                   ; $601D: $3E $0D
     ldh  [hJingle], a                             ; $601F: $E0 $F2
 
 func_036_6021::
     ld   d, $00                                   ; $6021: $16 $00
-    call func_036_6BFD                            ; $6023: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $6023: $CD $FD $6B
     ld   e, [hl]                                  ; $6026: $5E
-    call func_036_6C23                            ; $6027: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6027: $CD $23 $6C
     ld   a, [hl]                                  ; $602A: $7E
     ldh  [hScratch0], a                           ; $602B: $E0 $D7
-    call func_036_6C28                            ; $602D: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $602D: $CD $28 $6C
     ld   a, [hl]                                  ; $6030: $7E
     ldh  [hScratch1], a                           ; $6031: $E0 $D8
     ld   a, $36                                   ; $6033: $3E $36
@@ -5260,11 +5260,11 @@ jr_036_604E:
 
 HopperState3Handler::
     xor  a                                        ; $604F: $AF
-    call func_036_6BEE                            ; $6050: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6050: $CD $EE $6B
     ld   [hl], a                                  ; $6053: $77
-    call func_036_6BF3                            ; $6054: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6054: $CD $F3 $6B
     ld   [hl], a                                  ; $6057: $77
-    call func_036_6C02                            ; $6058: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6058: $CD $02 $6C
     ld   [hl], a                                  ; $605B: $77
     ld   hl, wEntitiesIgnoreHitsCountdownTable    ; $605C: $21 $10 $C4
     add  hl, bc                                   ; $605F: $09
@@ -5308,7 +5308,7 @@ func_036_6084::
     cp   $10                                      ; $6093: $FE $10
     jr   nc, jr_036_60B2                          ; $6095: $30 $1B
 
-    call func_036_6BF3                            ; $6097: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6097: $CD $F3 $6B
     ld   [hl], $10                                ; $609A: $36 $10
     bit  1, e                                     ; $609C: $CB $4B
     jr   z, jr_036_60A2                           ; $609E: $28 $02
@@ -5316,7 +5316,7 @@ func_036_6084::
     ld   [hl], $F0                                ; $60A0: $36 $F0
 
 jr_036_60A2:
-    call func_036_6BEE                            ; $60A2: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $60A2: $CD $EE $6B
     ld   [hl], $10                                ; $60A5: $36 $10
     bit  0, e                                     ; $60A7: $CB $43
     jr   z, jr_036_60AD                           ; $60A9: $28 $02
@@ -5345,7 +5345,7 @@ HopperState0Handler::
     ld   hl, wEntitiesPrivateState1Table          ; $60CB: $21 $B0 $C2
     add  hl, bc                                   ; $60CE: $09
     ld   [hl], a                                  ; $60CF: $77
-    call func_036_6C23                            ; $60D0: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $60D0: $CD $23 $6C
     ld   a, [hl]                                  ; $60D3: $7E
     sub  $40                                      ; $60D4: $D6 $40
     ld   hl, wEntitiesPrivateState1Table          ; $60D6: $21 $B0 $C2
@@ -5379,7 +5379,7 @@ jr_036_60EC:
 
 jr_036_60F8:
     ld   a, [hl]                                  ; $60F8: $7E
-    call func_036_6BFD                            ; $60F9: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $60F9: $CD $FD $6B
     ld   [hl], $00                                ; $60FC: $36 $00
     bit  7, a                                     ; $60FE: $CB $7F
     jr   nz, jr_036_6103                          ; $6100: $20 $01
@@ -5397,7 +5397,7 @@ jr_036_6103:
     ld   hl, wEntitiesPrivateState2Table          ; $6110: $21 $C0 $C2
     add  hl, bc                                   ; $6113: $09
     ld   [hl], a                                  ; $6114: $77
-    call func_036_6C28                            ; $6115: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6115: $CD $28 $6C
     ld   a, [hl]                                  ; $6118: $7E
     sub  $40                                      ; $6119: $D6 $40
     ld   hl, wEntitiesPrivateState2Table          ; $611B: $21 $C0 $C2
@@ -5444,7 +5444,7 @@ HopperState1Handler::
     add  hl, bc                                   ; $6150: $09
     ld   a, [hl]                                  ; $6151: $7E
     ld   e, a                                     ; $6152: $5F
-    call func_036_6BEE                            ; $6153: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6153: $CD $EE $6B
     cp   [hl]                                     ; $6156: $BE
     jr   z, jr_036_6160                           ; $6157: $28 $07
 
@@ -5460,7 +5460,7 @@ jr_036_6160:
     add  hl, bc                                   ; $6163: $09
     ld   a, [hl]                                  ; $6164: $7E
     ld   d, a                                     ; $6165: $57
-    call func_036_6BF3                            ; $6166: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6166: $CD $F3 $6B
     cp   [hl]                                     ; $6169: $BE
     jr   z, jr_036_6173                           ; $616A: $28 $07
 
@@ -5476,7 +5476,7 @@ jr_036_6173:
     cp   d                                        ; $6174: $BA
     jr   nz, jr_036_6181                          ; $6175: $20 $0A
 
-    call func_036_6BEE                            ; $6177: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6177: $CD $EE $6B
     ld   a, [hl]                                  ; $617A: $7E
     cp   e                                        ; $617B: $BB
     jr   nz, jr_036_6181                          ; $617C: $20 $03
@@ -5493,7 +5493,7 @@ HopperState2Handler::
     and  $01                                      ; $618A: $E6 $01
     jr   z, jr_036_6205                           ; $618C: $28 $77
 
-    call func_036_6BEE                            ; $618E: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $618E: $CD $EE $6B
     ld   a, [hl]                                  ; $6191: $7E
     and  a                                        ; $6192: $A7
     jr   z, jr_036_619C                           ; $6193: $28 $07
@@ -5506,7 +5506,7 @@ HopperState2Handler::
     dec  [hl]                                     ; $619B: $35
 
 jr_036_619C:
-    call func_036_6BF3                            ; $619C: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $619C: $CD $F3 $6B
     ld   a, [hl]                                  ; $619F: $7E
     and  a                                        ; $61A0: $A7
     jr   z, jr_036_61AA                           ; $61A1: $28 $07
@@ -5523,7 +5523,7 @@ jr_036_61AA:
     and  a                                        ; $61AB: $A7
     jr   nz, jr_036_6205                          ; $61AC: $20 $57
 
-    call func_036_6BEE                            ; $61AE: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $61AE: $CD $EE $6B
     ld   a, [hl]                                  ; $61B1: $7E
     and  a                                        ; $61B2: $A7
     jr   nz, jr_036_6205                          ; $61B3: $20 $50
@@ -5547,17 +5547,17 @@ jr_036_61AA:
     ld   hl, wEntitiesUnknowTableH                ; $61D2: $21 $30 $C4
     add  hl, de                                   ; $61D5: $19
     res  0, [hl]                                  ; $61D6: $CB $86
-    call func_036_6C23                            ; $61D8: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $61D8: $CD $23 $6C
     ld   a, [hl]                                  ; $61DB: $7E
     ld   hl, wEntitiesPosXTable                   ; $61DC: $21 $00 $C2
     add  hl, de                                   ; $61DF: $19
     ld   [hl], a                                  ; $61E0: $77
-    call func_036_6C28                            ; $61E1: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $61E1: $CD $28 $6C
     ld   a, [hl]                                  ; $61E4: $7E
     ld   hl, wEntitiesPosYTable                   ; $61E5: $21 $10 $C2
     add  hl, de                                   ; $61E8: $19
     ld   [hl], a                                  ; $61E9: $77
-    call func_036_6C2D                            ; $61EA: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $61EA: $CD $2D $6C
     ld   a, [hl]                                  ; $61ED: $7E
     ld   hl, wEntitiesPosZTable                   ; $61EE: $21 $10 $C3
     add  hl, de                                   ; $61F1: $19
@@ -5588,14 +5588,14 @@ Data_036_6209::
 
 func_036_6219::
     ld   d, $00                                   ; $6219: $16 $00
-    call func_036_6C02                            ; $621B: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $621B: $CD $02 $6C
     ld   a, [hl]                                  ; $621E: $7E
     sla  a                                        ; $621F: $CB $27
     ld   e, a                                     ; $6221: $5F
     ld   hl, Data_036_6209                        ; $6222: $21 $09 $62
     add  hl, de                                   ; $6225: $19
     push hl                                       ; $6226: $E5
-    call func_036_6BFD                            ; $6227: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $6227: $CD $FD $6B
     ld   a, [hl]                                  ; $622A: $7E
     sla  a                                        ; $622B: $CB $27
     sla  a                                        ; $622D: $CB $27
@@ -5647,7 +5647,7 @@ RotoswitchState0Handler::
 
 jr_036_6273:
     call label_3B23                               ; $6273: $CD $23 $3B
-    call func_036_6C02                            ; $6276: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6276: $CD $02 $6C
     ld   a, [hl]                                  ; $6279: $7E
     and  $03                                      ; $627A: $E6 $03
     jr   nz, jr_036_629E                          ; $627C: $20 $20
@@ -5660,7 +5660,7 @@ jr_036_6273:
 
     ld   a, $04                                   ; $6286: $3E $04
     call func_036_6C83                            ; $6288: $CD $83 $6C
-    call func_036_6C02                            ; $628B: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $628B: $CD $02 $6C
     inc  [hl]                                     ; $628E: $34
     xor  a                                        ; $628F: $AF
     ld   hl, wEntitiesFlashCountdownTable         ; $6290: $21 $20 $C4
@@ -5674,10 +5674,10 @@ jr_036_629E:
     ret                                           ; $629E: $C9
 
 func_036_629F::
-    call func_036_6C23                            ; $629F: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $629F: $CD $23 $6C
     ld   a, [hl]                                  ; $62A2: $7E
     ldh  [hScratch0], a                           ; $62A3: $E0 $D7
-    call func_036_6C28                            ; $62A5: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $62A5: $CD $28 $6C
     ld   a, [hl]                                  ; $62A8: $7E
     ldh  [hScratch1], a                           ; $62A9: $E0 $D8
     ld   de, $00                                  ; $62AB: $11 $00 $00
@@ -5816,7 +5816,7 @@ RotoswitchState2Handler::
     call GetEntityTransitionCountdown             ; $6351: $CD $05 $0C
     jr   nz, jr_036_6381                          ; $6354: $20 $2B
 
-    call func_036_6C02                            ; $6356: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6356: $CD $02 $6C
     ldh  a, [hMapRoom]                            ; $6359: $F0 $F6
     cp   $08                                      ; $635B: $FE $08
     jr   z, jr_036_6364                           ; $635D: $28 $05
@@ -5888,7 +5888,7 @@ ColorGhoulBlueEntityHandler::
     ldh  a, [hActiveEntityStatus]                 ; $63CC: $F0 $EA
     cp   $05                                      ; $63CE: $FE $05
     call func_036_6A40                            ; $63D0: $CD $40 $6A
-    call func_036_6C02                            ; $63D3: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $63D3: $CD $02 $6C
     ld   a, [hl]                                  ; $63D6: $7E
     and  a                                        ; $63D7: $A7
     jr   z, jr_036_63DD                           ; $63D8: $28 $03
@@ -5920,7 +5920,7 @@ ColorGhoulState0Handler::
     ret                                           ; $6400: $C9
 
 ColorGhoulState1Handler::
-    call func_036_6BFD                            ; $6401: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $6401: $CD $FD $6B
     ld   [hl], $00                                ; $6404: $36 $00
     call func_036_6B8A                            ; $6406: $CD $8A $6B
     cp   $28                                      ; $6409: $FE $28
@@ -5950,16 +5950,16 @@ ColorGhoulState2Handler::
     ld   d, $00                                   ; $642F: $16 $00
     add  hl, de                                   ; $6431: $19
     ld   a, [hl]                                  ; $6432: $7E
-    call func_036_6BEE                            ; $6433: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6433: $CD $EE $6B
     ld   [hl], a                                  ; $6436: $77
-    call func_036_6BF3                            ; $6437: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6437: $CD $F3 $6B
     ld   [hl], a                                  ; $643A: $77
-    call func_036_6C23                            ; $643B: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $643B: $CD $23 $6C
     ld   e, [hl]                                  ; $643E: $5E
     call func_036_6C62                            ; $643F: $CD $62 $6C
     sub  e                                        ; $6442: $93
     ldh  [hScratch0], a                           ; $6443: $E0 $D7
-    call func_036_6BEE                            ; $6445: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6445: $CD $EE $6B
     and  a                                        ; $6448: $A7
     jr   nz, jr_036_644C                          ; $6449: $20 $01
 
@@ -5975,12 +5975,12 @@ jr_036_644C:
     ld   [hl], a                                  ; $6453: $77
 
 jr_036_6454:
-    call func_036_6C28                            ; $6454: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6454: $CD $28 $6C
     ld   e, [hl]                                  ; $6457: $5E
     call func_036_6C70                            ; $6458: $CD $70 $6C
     sub  e                                        ; $645B: $93
     ldh  [hScratch1], a                           ; $645C: $E0 $D8
-    call func_036_6BF3                            ; $645E: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $645E: $CD $F3 $6B
     and  a                                        ; $6461: $A7
     jr   nz, jr_036_6465                          ; $6462: $20 $01
 
@@ -6003,7 +6003,7 @@ jr_036_646D:
     and  $FE                                      ; $6474: $E6 $FE
     push af                                       ; $6476: $F5
     push de                                       ; $6477: $D5
-    call func_036_6A62                            ; $6478: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $6478: $CD $62 $6A
     call label_3B23                               ; $647B: $CD $23 $3B
     pop  de                                       ; $647E: $D1
     pop  af                                       ; $647F: $F1
@@ -6016,7 +6016,7 @@ jr_036_646D:
     call SetEntitySpriteVariant                   ; $648A: $CD $0C $3B
     call IncrementEntityState                     ; $648D: $CD $12 $3B
     call func_036_6B8A                            ; $6490: $CD $8A $6B
-    call func_036_6BFD                            ; $6493: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $6493: $CD $FD $6B
     ld   a, e                                     ; $6496: $7B
     xor  $01                                      ; $6497: $EE $01
     ld   [hl], a                                  ; $6499: $77
@@ -6054,7 +6054,7 @@ ColorGhoulState3Handler::
 
     ld   a, $08                                   ; $64C2: $3E $08
     call func_036_6C83                            ; $64C4: $CD $83 $6C
-    call func_036_6C02                            ; $64C7: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $64C7: $CD $02 $6C
     inc  [hl]                                     ; $64CA: $34
     ld   a, [hl]                                  ; $64CB: $7E
     cp   $03                                      ; $64CC: $FE $03
@@ -6081,7 +6081,7 @@ ColorGhoulCommonStateHandler::
     ret  nz                                       ; $64EA: $C0
 
     call IncrementEntityState                     ; $64EB: $CD $12 $3B
-    call func_036_6BFD                            ; $64EE: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $64EE: $CD $FD $6B
     ld   a, [hl]                                  ; $64F1: $7E
     xor  $01                                      ; $64F2: $EE $01
     ld   [hl], a                                  ; $64F4: $77
@@ -6091,7 +6091,7 @@ ColorGhoulCommonStateHandler::
     cp   $0A                                      ; $64FC: $FE $0A
     jr   c, jr_036_6504                           ; $64FE: $38 $04
 
-    call func_036_6C02                            ; $6500: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6500: $CD $02 $6C
     dec  [hl]                                     ; $6503: $35
 
 jr_036_6504:
@@ -6108,7 +6108,7 @@ ColorGhoulStateBHandler::
 
     ld   a, $08                                   ; $650E: $3E $08
     call func_036_6C83                            ; $6510: $CD $83 $6C
-    call func_036_6C02                            ; $6513: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6513: $CD $02 $6C
     dec  [hl]                                     ; $6516: $35
     ld   a, [hl]                                  ; $6517: $7E
     and  a                                        ; $6518: $A7
@@ -6238,7 +6238,7 @@ Data_036_6625::
 func_036_6629::
     push bc                                       ; $6629: $C5
     ld   d, $00                                   ; $662A: $16 $00
-    call func_036_6BFD                            ; $662C: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $662C: $CD $FD $6B
     ld   a, [hl]                                  ; $662F: $7E
     sla  a                                        ; $6630: $CB $27
     ld   e, a                                     ; $6632: $5F
@@ -6250,14 +6250,14 @@ func_036_6629::
     ld   e, a                                     ; $663F: $5F
     call func_036_6C7E                            ; $6640: $CD $7E $6C
     push hl                                       ; $6643: $E5
-    call func_036_6C02                            ; $6644: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6644: $CD $02 $6C
     ld   a, [hl]                                  ; $6647: $7E
     sla  a                                        ; $6648: $CB $27
     ld   e, a                                     ; $664A: $5F
     pop  hl                                       ; $664B: $E1
     call func_036_6C7E                            ; $664C: $CD $7E $6C
     push hl                                       ; $664F: $E5
-    call func_036_6C02                            ; $6650: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6650: $CD $02 $6C
     ld   c, $02                                   ; $6653: $0E $02
     ld   a, [hl]                                  ; $6655: $7E
     cp   $03                                      ; $6656: $FE $03
@@ -6311,7 +6311,7 @@ ColorShellState0Handler::
     call GetRandomByte                            ; $669B: $CD $0D $28
     and  $06                                      ; $669E: $E6 $06
     srl  a                                        ; $66A0: $CB $3F
-    call func_036_6BFD                            ; $66A2: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $66A2: $CD $FD $6B
     ld   [hl], a                                  ; $66A5: $77
     ld   a, $40                                   ; $66A6: $3E $40
     call func_036_6C83                            ; $66A8: $CD $83 $6C
@@ -6334,7 +6334,7 @@ label_036_66C5:
     ret                                           ; $66C5: $C9
 
 func_036_66C6::
-    call func_036_6C23                            ; $66C6: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $66C6: $CD $23 $6C
     ld   a, [hl]                                  ; $66C9: $7E
     cp   $16                                      ; $66CA: $FE $16
     jr   nc, jr_036_66D2                          ; $66CC: $30 $04
@@ -6352,7 +6352,7 @@ jr_036_66D8:
     ld   [hl], a                                  ; $66D8: $77
 
 jr_036_66D9:
-    call func_036_6C28                            ; $66D9: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $66D9: $CD $28 $6C
     ld   a, [hl]                                  ; $66DC: $7E
     cp   $1E                                      ; $66DD: $FE $1E
     jr   nc, jr_036_66E5                          ; $66DF: $30 $04
@@ -6407,12 +6407,12 @@ jr_036_670D:
     call SpawnNewEntity_trampoline                ; $6715: $CD $86 $3B
     ret  c                                        ; $6718: $D8
 
-    call func_036_6C23                            ; $6719: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6719: $CD $23 $6C
     ld   a, [hl]                                  ; $671C: $7E
     ld   hl, wEntitiesPosXTable                   ; $671D: $21 $00 $C2
     add  hl, de                                   ; $6720: $19
     ld   [hl], a                                  ; $6721: $77
-    call func_036_6C28                            ; $6722: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6722: $CD $28 $6C
     ld   a, [hl]                                  ; $6725: $7E
     ld   hl, wEntitiesPosYTable                   ; $6726: $21 $10 $C2
     add  hl, de                                   ; $6729: $19
@@ -6432,21 +6432,21 @@ Data_036_6739::
     db   $00, $00, $FD, $03
 
 ColorShellState1Handler::
-    call func_036_6BFD                            ; $673D: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $673D: $CD $FD $6B
     ld   a, [hl]                                  ; $6740: $7E
     ld   e, a                                     ; $6741: $5F
     ld   d, $00                                   ; $6742: $16 $00
     ld   hl, Data_036_6735                        ; $6744: $21 $35 $67
     add  hl, de                                   ; $6747: $19
     ld   a, [hl]                                  ; $6748: $7E
-    call func_036_6BEE                            ; $6749: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6749: $CD $EE $6B
     ld   [hl], a                                  ; $674C: $77
     ld   hl, Data_036_6739                        ; $674D: $21 $39 $67
     add  hl, de                                   ; $6750: $19
     ld   a, [hl]                                  ; $6751: $7E
-    call func_036_6BF3                            ; $6752: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6752: $CD $F3 $6B
     ld   [hl], a                                  ; $6755: $77
-    call func_036_6A62                            ; $6756: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $6756: $CD $62 $6A
     call label_3B23                               ; $6759: $CD $23 $3B
     call func_036_66C6                            ; $675C: $CD $C6 $66
     call GetEntityTransitionCountdown             ; $675F: $CD $05 $0C
@@ -6507,13 +6507,13 @@ ColorShellState3Handler::
     ld   a, $01                                   ; $67BA: $3E $01
     call func_036_6C07                            ; $67BC: $CD $07 $6C
     xor  a                                        ; $67BF: $AF
-    call func_036_6BEE                            ; $67C0: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $67C0: $CD $EE $6B
     ld   [hl], a                                  ; $67C3: $77
-    call func_036_6BF3                            ; $67C4: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $67C4: $CD $F3 $6B
     ld   [hl], a                                  ; $67C7: $77
 
 jr_036_67C8:
-    call func_036_6A62                            ; $67C8: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $67C8: $CD $62 $6A
     call label_3B23                               ; $67CB: $CD $23 $3B
     call func_036_66C6                            ; $67CE: $CD $C6 $66
 
@@ -6522,7 +6522,7 @@ jr_036_67D1:
     and  $01                                      ; $67D3: $E6 $01
     jr   nz, jr_036_67F1                          ; $67D5: $20 $1A
 
-    call func_036_6C02                            ; $67D7: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $67D7: $CD $02 $6C
     ld   a, [hl]                                  ; $67DA: $7E
     inc  a                                        ; $67DB: $3C
     and  $01                                      ; $67DC: $E6 $01
@@ -6530,7 +6530,7 @@ jr_036_67D1:
     and  a                                        ; $67DF: $A7
     jr   nz, jr_036_67F1                          ; $67E0: $20 $0F
 
-    call func_036_6BFD                            ; $67E2: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $67E2: $CD $FD $6B
     ld   a, [hl]                                  ; $67E5: $7E
     push hl                                       ; $67E6: $E5
     ld   e, a                                     ; $67E7: $5F
@@ -6626,7 +6626,7 @@ jr_036_6856:
 
 ColorShellState6Handler::
     ld   e, $28                                   ; $6857: $1E $28
-    call func_036_6C23                            ; $6859: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6859: $CD $23 $6C
     ld   a, [hl]                                  ; $685C: $7E
     cp   $50                                      ; $685D: $FE $50
     jr   c, jr_036_6863                           ; $685F: $38 $02
@@ -6636,7 +6636,7 @@ ColorShellState6Handler::
 jr_036_6863:
     ld   [hl], e                                  ; $6863: $73
     ld   e, $30                                   ; $6864: $1E $30
-    call func_036_6C28                            ; $6866: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6866: $CD $28 $6C
     ld   a, [hl]                                  ; $6869: $7E
     cp   $48                                      ; $686A: $FE $48
     jr   c, jr_036_6870                           ; $686C: $38 $02
@@ -6645,12 +6645,12 @@ jr_036_6863:
 
 jr_036_6870:
     ld   [hl], e                                  ; $6870: $73
-    call func_036_6BF8                            ; $6871: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $6871: $CD $F8 $6B
     ld   [hl], $10                                ; $6874: $36 $10
     jr   jr_036_688A                              ; $6876: $18 $12
 
 ColorShellState7Handler::
-    call func_036_6BF8                            ; $6878: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $6878: $CD $F8 $6B
     dec  [hl]                                     ; $687B: $35
     call func_036_6AEC                            ; $687C: $CD $EC $6A
     ld   a, [hl]                                  ; $687F: $7E
@@ -6659,7 +6659,7 @@ ColorShellState7Handler::
 
     xor  a                                        ; $6884: $AF
     ld   [hl], a                                  ; $6885: $77
-    call func_036_6BF8                            ; $6886: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $6886: $CD $F8 $6B
     ld   [hl], a                                  ; $6889: $77
 
 jr_036_688A:
@@ -6706,7 +6706,7 @@ jr_036_68C3:
     ld   a, JINGLE_WRONG_ANSWER                   ; $68C3: $3E $1D
     ldh  [hJingle], a                             ; $68C5: $E0 $F2
     ld   e, $10                                   ; $68C7: $1E $10
-    call func_036_6C23                            ; $68C9: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $68C9: $CD $23 $6C
     ld   a, [hl]                                  ; $68CC: $7E
     cp   $50                                      ; $68CD: $FE $50
     jr   c, jr_036_68D3                           ; $68CF: $38 $02
@@ -6715,11 +6715,11 @@ jr_036_68C3:
 
 jr_036_68D3:
     xor  a                                        ; $68D3: $AF
-    call func_036_6BF3                            ; $68D4: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $68D4: $CD $F3 $6B
     ld   [hl], a                                  ; $68D7: $77
-    call func_036_6BEE                            ; $68D8: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $68D8: $CD $EE $6B
     ld   [hl], e                                  ; $68DB: $73
-    call func_036_6BF8                            ; $68DC: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $68DC: $CD $F8 $6B
     ld   [hl], $10                                ; $68DF: $36 $10
     ld   a, $18                                   ; $68E1: $3E $18
     call func_036_6C83                            ; $68E3: $CD $83 $6C
@@ -6733,28 +6733,28 @@ ColorShellState9Handler::
     call GetEntityTransitionCountdown             ; $68EC: $CD $05 $0C
     jr   nz, jr_036_691E                          ; $68EF: $20 $2D
 
-    call func_036_6BEE                            ; $68F1: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $68F1: $CD $EE $6B
     ld   a, [hl]                                  ; $68F4: $7E
     and  a                                        ; $68F5: $A7
     jr   z, jr_036_68FB                           ; $68F6: $28 $03
 
-    call func_036_6A62                            ; $68F8: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $68F8: $CD $62 $6A
 
 jr_036_68FB:
-    call func_036_6BF8                            ; $68FB: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $68FB: $CD $F8 $6B
     dec  [hl]                                     ; $68FE: $35
     call func_036_6AEC                            ; $68FF: $CD $EC $6A
     call label_3B23                               ; $6902: $CD $23 $3B
-    call func_036_6C2D                            ; $6905: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $6905: $CD $2D $6C
     ld   a, [hl]                                  ; $6908: $7E
     bit  7, a                                     ; $6909: $CB $7F
     jr   z, jr_036_691E                           ; $690B: $28 $11
 
     xor  a                                        ; $690D: $AF
     ld   [hl], a                                  ; $690E: $77
-    call func_036_6BF8                            ; $690F: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $690F: $CD $F8 $6B
     ld   [hl], $08                                ; $6912: $36 $08
-    call func_036_6BEE                            ; $6914: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6914: $CD $EE $6B
     sra  [hl]                                     ; $6917: $CB $2E
     ld   a, $0A                                   ; $6919: $3E $0A
     call func_036_6C07                            ; $691B: $CD $07 $6C
@@ -6763,14 +6763,14 @@ jr_036_691E:
     ret                                           ; $691E: $C9
 
 ColorShellStateAHandler::
-    call func_036_6A62                            ; $691F: $CD $62 $6A
-    call func_036_6BF8                            ; $6922: $CD $F8 $6B
+    call UpdateEntityPosWithSpeed_36              ; $691F: $CD $62 $6A
+    call PointHLToEntitySpeedZ                    ; $6922: $CD $F8 $6B
     dec  [hl]                                     ; $6925: $35
     call func_036_6AEC                            ; $6926: $CD $EC $6A
     push bc                                       ; $6929: $C5
     call label_3B23                               ; $692A: $CD $23 $3B
     pop  bc                                       ; $692D: $C1
-    call func_036_6C2D                            ; $692E: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $692E: $CD $2D $6C
     ld   a, [hl]                                  ; $6931: $7E
     bit  7, a                                     ; $6932: $CB $7F
     jr   z, jr_036_693E                           ; $6934: $28 $08
@@ -6788,9 +6788,9 @@ ColorShellStateBHandler::
 
     xor  a                                        ; $6944: $AF
     ld   [hl], a                                  ; $6945: $77
-    call func_036_6BF8                            ; $6946: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $6946: $CD $F8 $6B
     ld   [hl], a                                  ; $6949: $77
-    call func_036_6BEE                            ; $694A: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $694A: $CD $EE $6B
     ld   [hl], a                                  ; $694D: $77
     ld   a, $01                                   ; $694E: $3E $01
     call func_036_6C07                            ; $6950: $CD $07 $6C
@@ -6869,12 +6869,12 @@ ColorShellStateDHandler::
     call func_036_6BCF                            ; $69AF: $CD $CF $6B
     pop  af                                       ; $69B2: $F1
     ld   [hl], a                                  ; $69B3: $77
-    call func_036_6C23                            ; $69B4: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $69B4: $CD $23 $6C
     ld   a, [hl]                                  ; $69B7: $7E
     ldh  [hScratch0], a                           ; $69B8: $E0 $D7
-    call func_036_6C28                            ; $69BA: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $69BA: $CD $28 $6C
     ld   a, [hl]                                  ; $69BD: $7E
-    call func_036_6C2D                            ; $69BE: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $69BE: $CD $2D $6C
     sub  [hl]                                     ; $69C1: $96
     ldh  [hScratch1], a                           ; $69C2: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $69C4: $3E $02
@@ -6900,7 +6900,7 @@ func_036_69D9::
     sla  a                                        ; $69DD: $CB $27
     ldh  [hScratch0], a                           ; $69DF: $E0 $D7
     ld   d, $00                                   ; $69E1: $16 $00
-    call func_036_6C02                            ; $69E3: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $69E3: $CD $02 $6C
     ldh  a, [hActiveEntityState]                  ; $69E6: $F0 $F0
     cp   $06                                      ; $69E8: $FE $06
     jr   nc, jr_036_69F2                          ; $69EA: $30 $06
@@ -6947,7 +6947,7 @@ jr_036_6A0A:
     pop  de                                       ; $6A1F: $D1
 Data_036_6A20::
     push hl                                       ; $6A20: $E5
-    call func_036_6BFD                            ; $6A21: $CD $FD $6B
+    call PointHLToEntityDirection                 ; $6A21: $CD $FD $6B
     ld   a, [hl]                                  ; $6A24: $7E
     ld   l, a                                     ; $6A25: $6F
     sla  a                                        ; $6A26: $CB $27
@@ -6997,42 +6997,58 @@ jr_036_6A60:
 jr_036_6A61:
     ret                                           ; $6A61: $C9
 
-func_036_6A62::
-    call func_036_6A6F                            ; $6A62: $CD $6F $6A
+UpdateEntityPosWithSpeed_36::
+    call AddEntitySpeedToPos_36                   ; $6A62: $CD $6F $6A
     push bc                                       ; $6A65: $C5
     ld   a, c                                     ; $6A66: $79
     add  $10                                      ; $6A67: $C6 $10
     ld   c, a                                     ; $6A69: $4F
-    call func_036_6A6F                            ; $6A6A: $CD $6F $6A
+    call AddEntitySpeedToPos_36                   ; $6A6A: $CD $6F $6A
     pop  bc                                       ; $6A6D: $C1
     ret                                           ; $6A6E: $C9
 
-func_036_6A6F::
-    call func_036_6BEE                            ; $6A6F: $CD $EE $6B
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_36::
+    call PointHLToEntitySpeedX                    ; $6A6F: $CD $EE $6B
     ld   a, [hl]                                  ; $6A72: $7E
     and  a                                        ; $6A73: $A7
+    ; No need to update the position if it's not moving
     ret  z                                        ; $6A74: $C8
 
     push af                                       ; $6A75: $F5
+    ; Multiply speed by 16 so the carry is set if greater than $0F
     swap a                                        ; $6A76: $CB $37
     and  $F0                                      ; $6A78: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $6A7A: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $6A7A: $21 $60 $C2
     add  hl, bc                                   ; $6A7D: $09
     add  [hl]                                     ; $6A7E: $86
     ld   [hl], a                                  ; $6A7F: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $6A80: $CB $12
-    call func_036_6C23                            ; $6A82: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6A82: $CD $23 $6C
     pop  af                                       ; $6A85: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $6A86: $1E $00
     bit  7, a                                     ; $6A88: $CB $7F
-    jr   z, jr_036_6A8E                           ; $6A8A: $28 $02
+    jr   z, .positive                             ; $6A8A: $28 $02
 
     ld   e, $F0                                   ; $6A8C: $1E $F0
 
-jr_036_6A8E:
+.positive
     swap a                                        ; $6A8E: $CB $37
     and  $0F                                      ; $6A90: $E6 $0F
     or   e                                        ; $6A92: $B3
+    ; Get carry back from d
     rr   d                                        ; $6A93: $CB $1A
     adc  [hl]                                     ; $6A95: $8E
     ld   [hl], a                                  ; $6A96: $77
@@ -7095,7 +7111,7 @@ jr_036_6AEA:
     ret                                           ; $6AEB: $C9
 
 func_036_6AEC::
-    call func_036_6BF8                            ; $6AEC: $CD $F8 $6B
+    call PointHLToEntitySpeedZ                    ; $6AEC: $CD $F8 $6B
     ld   a, [hl]                                  ; $6AEF: $7E
     and  a                                        ; $6AF0: $A7
     ret  z                                        ; $6AF1: $C8
@@ -7103,12 +7119,12 @@ func_036_6AEC::
     push af                                       ; $6AF2: $F5
     swap a                                        ; $6AF3: $CB $37
     and  $F0                                      ; $6AF5: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $6AF7: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $6AF7: $21 $30 $C3
     add  hl, bc                                   ; $6AFA: $09
     add  [hl]                                     ; $6AFB: $86
     ld   [hl], a                                  ; $6AFC: $77
     rl   d                                        ; $6AFD: $CB $12
-    call func_036_6C2D                            ; $6AFF: $CD $2D $6C
+    call PointHLToEntityPosZ                      ; $6AFF: $CD $2D $6C
     pop  af                                       ; $6B02: $F1
     ld   e, $00                                   ; $6B03: $1E $00
     bit  7, a                                     ; $6B05: $CB $7F
@@ -7135,23 +7151,23 @@ func_036_6B15::
     dec  a                                        ; $6B1D: $3D
     ld   [hl], a                                  ; $6B1E: $77
     call label_3E8E                               ; $6B1F: $CD $8E $3E
-    call func_036_6BEE                            ; $6B22: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6B22: $CD $EE $6B
     ld   a, [hl]                                  ; $6B25: $7E
     push af                                       ; $6B26: $F5
-    call func_036_6BF3                            ; $6B27: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6B27: $CD $F3 $6B
     ld   a, [hl]                                  ; $6B2A: $7E
     push af                                       ; $6B2B: $F5
     ld   hl, $C3F0                                ; $6B2C: $21 $F0 $C3
     add  hl, bc                                   ; $6B2F: $09
     ld   a, [hl]                                  ; $6B30: $7E
-    call func_036_6BEE                            ; $6B31: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6B31: $CD $EE $6B
     ld   [hl], a                                  ; $6B34: $77
     ld   hl, wEntitiesUnknowTableS                ; $6B35: $21 $00 $C4
     add  hl, bc                                   ; $6B38: $09
     ld   a, [hl]                                  ; $6B39: $7E
-    call func_036_6BF3                            ; $6B3A: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6B3A: $CD $F3 $6B
     ld   [hl], a                                  ; $6B3D: $77
-    call func_036_6A62                            ; $6B3E: $CD $62 $6A
+    call UpdateEntityPosWithSpeed_36              ; $6B3E: $CD $62 $6A
     ld   hl, wEntitiesUnknowTableH                ; $6B41: $21 $30 $C4
     add  hl, bc                                   ; $6B44: $09
     ld   a, [hl]                                  ; $6B45: $7E
@@ -7161,10 +7177,10 @@ func_036_6B15::
     call label_3B23                               ; $6B4A: $CD $23 $3B
 
 jr_036_6B4D:
-    call func_036_6BF3                            ; $6B4D: $CD $F3 $6B
+    call PointHLToEntitySpeedY                    ; $6B4D: $CD $F3 $6B
     pop  af                                       ; $6B50: $F1
     ld   [hl], a                                  ; $6B51: $77
-    call func_036_6BEE                            ; $6B52: $CD $EE $6B
+    call PointHLToEntitySpeedX                    ; $6B52: $CD $EE $6B
     pop  af                                       ; $6B55: $F1
     ld   [hl], a                                  ; $6B56: $77
     pop  af                                       ; $6B57: $F1
@@ -7210,7 +7226,7 @@ jr_036_6B88:
 func_036_6B8A::
     ld   e, $00                                   ; $6B8A: $1E $00
     ldh  a, [hLinkPositionX]                      ; $6B8C: $F0 $98
-    call func_036_6C23                            ; $6B8E: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6B8E: $CD $23 $6C
     sub  [hl]                                     ; $6B91: $96
     bit  7, a                                     ; $6B92: $CB $7F
     jr   z, jr_036_6B99                           ; $6B94: $28 $03
@@ -7225,7 +7241,7 @@ jr_036_6B99:
 func_036_6B9A::
     ld   e, $04                                   ; $6B9A: $1E $04
     ldh  a, [hLinkPositionY]                      ; $6B9C: $F0 $99
-    call func_036_6C28                            ; $6B9E: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6B9E: $CD $28 $6C
     sub  [hl]                                     ; $6BA1: $96
     bit  7, a                                     ; $6BA2: $CB $7F
     jr   z, jr_036_6BAA                           ; $6BA4: $28 $04
@@ -7270,13 +7286,13 @@ jr_036_6BCD:
     ret                                           ; $6BCE: $C9
 
 func_036_6BCF::
-    call func_036_6C23                            ; $6BCF: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6BCF: $CD $23 $6C
     ld   a, [hl]                                  ; $6BD2: $7E
     sub  $01                                      ; $6BD3: $D6 $01
     and  $F0                                      ; $6BD5: $E6 $F0
     swap a                                        ; $6BD7: $CB $37
     ld   e, a                                     ; $6BD9: $5F
-    call func_036_6C28                            ; $6BDA: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6BDA: $CD $28 $6C
     ld   a, [hl]                                  ; $6BDD: $7E
     sub  $07                                      ; $6BDE: $D6 $07
     and  $F0                                      ; $6BE0: $E6 $F0
@@ -7290,39 +7306,39 @@ func_036_6BCF::
     ld   a, [hl]                                  ; $6BEC: $7E
     ret                                           ; $6BED: $C9
 
-func_036_6BEE::
+PointHLToEntitySpeedX::
     ld   hl, wEntitiesSpeedXTable                 ; $6BEE: $21 $40 $C2
     add  hl, bc                                   ; $6BF1: $09
     ret                                           ; $6BF2: $C9
 
-func_036_6BF3::
+PointHLToEntitySpeedY::
     ld   hl, wEntitiesSpeedYTable                 ; $6BF3: $21 $50 $C2
     add  hl, bc                                   ; $6BF6: $09
     ret                                           ; $6BF7: $C9
 
-func_036_6BF8::
+PointHLToEntitySpeedZ::
     ld   hl, wEntitiesSpeedZTable                 ; $6BF8: $21 $20 $C3
     add  hl, bc                                   ; $6BFB: $09
     ret                                           ; $6BFC: $C9
 
-func_036_6BFD::
+PointHLToEntityDirection::
     ld   hl, wEntitiesDirectionTable              ; $6BFD: $21 $80 $C3
     add  hl, bc                                   ; $6C00: $09
     ret                                           ; $6C01: $C9
 
-func_036_6C02::
+PointHLToEntitySpriteVariant::
     ld   hl, wEntitiesSpriteVariantTable          ; $6C02: $21 $B0 $C3
     add  hl, bc                                   ; $6C05: $09
     ret                                           ; $6C06: $C9
 
-func_036_6C07::
+SetEntityState::
     ld   hl, wEntitiesStateTable                  ; $6C07: $21 $90 $C2
     add  hl, bc                                   ; $6C0A: $09
     ld   [hl], a                                  ; $6C0B: $77
     ret                                           ; $6C0C: $C9
 
 func_036_6C0D::
-    call func_036_6C02                            ; $6C0D: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6C0D: $CD $02 $6C
     ld   a, [hl]                                  ; $6C10: $7E
     xor  $01                                      ; $6C11: $EE $01
     ld   [hl], a                                  ; $6C13: $77
@@ -7333,24 +7349,24 @@ func_036_6C15::
     and  $07                                      ; $6C17: $E6 $07
     ret  nz                                       ; $6C19: $C0
 
-    call func_036_6C02                            ; $6C1A: $CD $02 $6C
+    call PointHLToEntitySpriteVariant             ; $6C1A: $CD $02 $6C
     ld   a, [hl]                                  ; $6C1D: $7E
     inc  a                                        ; $6C1E: $3C
     and  $01                                      ; $6C1F: $E6 $01
     ld   [hl], a                                  ; $6C21: $77
     ret                                           ; $6C22: $C9
 
-func_036_6C23::
+PointHLToEntityPosX::
     ld   hl, wEntitiesPosXTable                   ; $6C23: $21 $00 $C2
     add  hl, bc                                   ; $6C26: $09
     ret                                           ; $6C27: $C9
 
-func_036_6C28::
+PointHLToEntityPosY::
     ld   hl, wEntitiesPosYTable                   ; $6C28: $21 $10 $C2
     add  hl, bc                                   ; $6C2B: $09
     ret                                           ; $6C2C: $C9
 
-func_036_6C2D::
+PointHLToEntityPosZ::
     ld   hl, wEntitiesPosZTable                   ; $6C2D: $21 $10 $C3
     add  hl, bc                                   ; $6C30: $09
     ret                                           ; $6C31: $C9
@@ -7439,7 +7455,7 @@ func_036_6C90::
     ld   a, [de]                                  ; $6C93: $1A
     ld   d, a                                     ; $6C94: $57
     ld   e, l                                     ; $6C95: $5D
-    call func_036_6C23                            ; $6C96: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6C96: $CD $23 $6C
     ld   a, [hl]                                  ; $6C99: $7E
     cp   $1C                                      ; $6C9A: $FE $1C
     jr   nc, jr_036_6CA2                          ; $6C9C: $30 $04
@@ -7459,7 +7475,7 @@ jr_036_6CAA:
     ld   [hl], a                                  ; $6CAA: $77
 
 jr_036_6CAB:
-    call func_036_6C28                            ; $6CAB: $CD $28 $6C
+    call PointHLToEntityPosY                      ; $6CAB: $CD $28 $6C
     ld   a, [hl]                                  ; $6CAE: $7E
     cp   $20                                      ; $6CAF: $FE $20
     jr   nc, jr_036_6CB7                          ; $6CB1: $30 $04
@@ -7776,7 +7792,7 @@ PiranhaPlantState0Handler::
     ld   [hl], $40                                ; $6F14: $36 $40
     ld   e, $00                                   ; $6F16: $1E $00
     ldh  a, [hLinkPositionX]                      ; $6F18: $F0 $98
-    call func_036_6C23                            ; $6F1A: $CD $23 $6C
+    call PointHLToEntityPosX                      ; $6F1A: $CD $23 $6C
     sub  [hl]                                     ; $6F1D: $96
     bit  7, a                                     ; $6F1E: $CB $7F
     jr   z, jr_036_6F23                           ; $6F20: $28 $01

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -526,7 +526,7 @@ jr_036_4329:
 
     ld   a, $12                                   ; $4335: $3E $12
     ldh  [hActiveEntityState], a                  ; $4337: $E0 $F0
-    call func_036_6C07                            ; $4339: $CD $07 $6C
+    call SetEntityState                           ; $4339: $CD $07 $6C
 
 jr_036_433C:
     ldh  a, [hActiveEntityState]                  ; $433C: $F0 $F0
@@ -652,7 +652,7 @@ jr_036_4405:
     add  hl, bc                                   ; $4414: $09
     ld   [hl], a                                  ; $4415: $77
     ld   a, $07                                   ; $4416: $3E $07
-    call func_036_6C07                            ; $4418: $CD $07 $6C
+    call SetEntityState                           ; $4418: $CD $07 $6C
     ret                                           ; $441B: $C9
 
 func_036_441C::
@@ -770,7 +770,7 @@ func_036_44A4::
 func_036_44B3::
     call func_036_4365                            ; $44B3: $CD $65 $43
     ld   a, $0C                                   ; $44B6: $3E $0C
-    call func_036_6C07                            ; $44B8: $CD $07 $6C
+    call SetEntityState                           ; $44B8: $CD $07 $6C
     ld   hl, wEntitiesPrivateState1Table          ; $44BB: $21 $B0 $C2
     add  hl, bc                                   ; $44BE: $09
     xor  a                                        ; $44BF: $AF
@@ -870,7 +870,7 @@ jr_036_4542:
 
     call_open_dialog $294                         ; $454C
     ld   a, $07                                   ; $4551: $3E $07
-    call func_036_6C07                            ; $4553: $CD $07 $6C
+    call SetEntityState                           ; $4553: $CD $07 $6C
     ret                                           ; $4556: $C9
 
 func_036_4557::
@@ -1020,7 +1020,7 @@ jr_036_4622:
     ld   a, $07                                   ; $4625: $3E $07
 
 jr_036_4627:
-    call func_036_6C07                            ; $4627: $CD $07 $6C
+    call SetEntityState                           ; $4627: $CD $07 $6C
     ret                                           ; $462A: $C9
 
 func_036_462B::
@@ -2094,7 +2094,7 @@ func_036_4C82::
     ld   a, $20                                   ; $4C91: $3E $20
     call func_036_6C83                            ; $4C93: $CD $83 $6C
     xor  a                                        ; $4C96: $AF
-    call func_036_6C07                            ; $4C97: $CD $07 $6C
+    call SetEntityState                           ; $4C97: $CD $07 $6C
     ld   hl, wEntitiesSpeedZTable                 ; $4C9A: $21 $20 $C3
     add  hl, bc                                   ; $4C9D: $09
     ld   a, [hl]                                  ; $4C9E: $7E
@@ -2484,7 +2484,7 @@ func_036_4EA2::
 
 jr_036_4EE4:
     ld   a, $04                                   ; $4EE4: $3E $04
-    call func_036_6C07                            ; $4EE6: $CD $07 $6C
+    call SetEntityState                           ; $4EE6: $CD $07 $6C
     ret                                           ; $4EE9: $C9
 
 Data_036_4EEA::
@@ -2833,7 +2833,7 @@ func_036_5134::
 jr_036_5148:
     call_open_dialog $25C                         ; $5148
     ld   a, $01                                   ; $514D: $3E $01
-    call func_036_6C07                            ; $514F: $CD $07 $6C
+    call SetEntityState                           ; $514F: $CD $07 $6C
     ret                                           ; $5152: $C9
 
 func_036_5153::
@@ -3521,7 +3521,7 @@ func_036_55B1::
     ld   a, $20                                   ; $55D5: $3E $20
     call func_036_6C83                            ; $55D7: $CD $83 $6C
     ld   a, $07                                   ; $55DA: $3E $07
-    call func_036_6C07                            ; $55DC: $CD $07 $6C
+    call SetEntityState                           ; $55DC: $CD $07 $6C
     ret                                           ; $55DF: $C9
 
 jr_036_55E0:
@@ -3737,7 +3737,7 @@ jr_036_5736:
     xor  a                                        ; $5736: $AF
     ld   [hl], a                                  ; $5737: $77
     ld   a, $05                                   ; $5738: $3E $05
-    call func_036_6C07                            ; $573A: $CD $07 $6C
+    call SetEntityState                           ; $573A: $CD $07 $6C
     ret                                           ; $573D: $C9
 
 func_036_573E::
@@ -3795,7 +3795,7 @@ func_036_5779::
     ld   a, $20                                   ; $5784: $3E $20
     call func_036_6C83                            ; $5786: $CD $83 $6C
     ld   a, $03                                   ; $5789: $3E $03
-    call func_036_6C07                            ; $578B: $CD $07 $6C
+    call SetEntityState                           ; $578B: $CD $07 $6C
     ret                                           ; $578E: $C9
 
 func_036_578F::
@@ -3848,7 +3848,7 @@ func_036_57C8::
     xor  a                                        ; $57D7: $AF
     ld   [hl], a                                  ; $57D8: $77
     ld   a, $09                                   ; $57D9: $3E $09
-    call func_036_6C07                            ; $57DB: $CD $07 $6C
+    call SetEntityState                           ; $57DB: $CD $07 $6C
     call GetEntityTransitionCountdown             ; $57DE: $CD $05 $0C
     jr   nz, jr_036_57E6                          ; $57E1: $20 $03
 
@@ -4080,7 +4080,7 @@ func_036_5912::
 
 jr_036_592A:
     ld   a, $03                                   ; $592A: $3E $03
-    call func_036_6C07                            ; $592C: $CD $07 $6C
+    call SetEntityState                           ; $592C: $CD $07 $6C
 
 jr_036_592F:
     ret                                           ; $592F: $C9
@@ -4092,7 +4092,7 @@ func_036_5930::
 
     call func_036_6C0D                            ; $5936: $CD $0D $6C
     ld   a, $03                                   ; $5939: $3E $03
-    call func_036_6C07                            ; $593B: $CD $07 $6C
+    call SetEntityState                           ; $593B: $CD $07 $6C
 
 jr_036_593E:
     ret                                           ; $593E: $C9
@@ -4182,7 +4182,7 @@ jr_036_59B3:
     ld   a, $01                                   ; $59B8: $3E $01
     ldh  [hLinkInteractiveMotionBlocked], a       ; $59BA: $E0 $A1
     ld   a, $05                                   ; $59BC: $3E $05
-    call func_036_6C07                            ; $59BE: $CD $07 $6C
+    call SetEntityState                           ; $59BE: $CD $07 $6C
     pop  af                                       ; $59C1: $F1
     ret                                           ; $59C2: $C9
 
@@ -4266,12 +4266,12 @@ jr_036_5A2B:
     call SetEntitySpriteVariant                   ; $5A2D: $CD $0C $3B
     call_open_dialog $265                         ; $5A30
     ld   a, $03                                   ; $5A35: $3E $03
-    call func_036_6C07                            ; $5A37: $CD $07 $6C
+    call SetEntityState                           ; $5A37: $CD $07 $6C
     ret                                           ; $5A3A: $C9
 
 func_036_5A3B::
     xor  a                                        ; $5A3B: $AF
-    call func_036_6C07                            ; $5A3C: $CD $07 $6C
+    call SetEntityState                           ; $5A3C: $CD $07 $6C
     ret                                           ; $5A3F: $C9
 
 func_036_5A40::
@@ -4326,7 +4326,7 @@ func_036_5A87::
     jr   nz, jr_036_5A6A                          ; $5A8D: $20 $DB
 
     xor  a                                        ; $5A8F: $AF
-    call func_036_6C07                            ; $5A90: $CD $07 $6C
+    call SetEntityState                           ; $5A90: $CD $07 $6C
     ret                                           ; $5A93: $C9
 
 Data_036_5A94:
@@ -4679,7 +4679,7 @@ jr_036_5CD9:
     add  hl, bc                                   ; $5CE1: $09
     ld   [hl], $06                                ; $5CE2: $36 $06
     ld   a, $08                                   ; $5CE4: $3E $08
-    call func_036_6C07                            ; $5CE6: $CD $07 $6C
+    call SetEntityState                           ; $5CE6: $CD $07 $6C
     and  a                                        ; $5CE9: $A7
     ret                                           ; $5CEA: $C9
 
@@ -4729,7 +4729,7 @@ AvalaunchState3Handler::
     add  hl, bc                                   ; $5D30: $09
     ld   [hl], $00                                ; $5D31: $36 $00
     ld   a, $09                                   ; $5D33: $3E $09
-    call func_036_6C07                            ; $5D35: $CD $07 $6C
+    call SetEntityState                           ; $5D35: $CD $07 $6C
     ret                                           ; $5D38: $C9
 
 jr_036_5D39:
@@ -4812,7 +4812,7 @@ AvalaunchState5Handler::
     ld   a, $30                                   ; $5DB8: $3E $30
     call func_036_6C83                            ; $5DBA: $CD $83 $6C
     ld   a, $03                                   ; $5DBD: $3E $03
-    call func_036_6C07                            ; $5DBF: $CD $07 $6C
+    call SetEntityState                           ; $5DBF: $CD $07 $6C
 
 jr_036_5DC2:
     ret                                           ; $5DC2: $C9
@@ -4869,7 +4869,7 @@ AvalaunchState7Handler::
     ld   a, $30                                   ; $5E11: $3E $30
     call func_036_6C83                            ; $5E13: $CD $83 $6C
     ld   a, $03                                   ; $5E16: $3E $03
-    call func_036_6C07                            ; $5E18: $CD $07 $6C
+    call SetEntityState                           ; $5E18: $CD $07 $6C
     ret                                           ; $5E1B: $C9
 
 AvalaunchState8Handler::
@@ -5089,7 +5089,7 @@ jr_036_5F43:
     and  $01                                      ; $5F50: $E6 $01
     ld   [hl], a                                  ; $5F52: $77
     ld   a, $03                                   ; $5F53: $3E $03
-    call func_036_6C07                            ; $5F55: $CD $07 $6C
+    call SetEntityState                           ; $5F55: $CD $07 $6C
 
 jr_036_5F58:
     ret                                           ; $5F58: $C9
@@ -5280,7 +5280,7 @@ func_036_6065::
     jr   z, jr_036_607A                           ; $606B: $28 $0D
 
     ld   a, $03                                   ; $606D: $3E $03
-    call func_036_6C07                            ; $606F: $CD $07 $6C
+    call SetEntityState                           ; $606F: $CD $07 $6C
     ld   hl, wEntitiesHealthGroup                 ; $6072: $21 $D0 $C4
     add  hl, bc                                   ; $6075: $09
     ld   [hl], $00                                ; $6076: $36 $00
@@ -5325,7 +5325,7 @@ jr_036_60A2:
 
 jr_036_60AD:
     ld   a, $02                                   ; $60AD: $3E $02
-    call func_036_6C07                            ; $60AF: $CD $07 $6C
+    call SetEntityState                           ; $60AF: $CD $07 $6C
 
 jr_036_60B2:
     ret                                           ; $60B2: $C9
@@ -5531,7 +5531,7 @@ jr_036_61AA:
     ld   a, $10                                   ; $61B5: $3E $10
     call func_036_6C83                            ; $61B7: $CD $83 $6C
     xor  a                                        ; $61BA: $AF
-    call func_036_6C07                            ; $61BB: $CD $07 $6C
+    call SetEntityState                           ; $61BB: $CD $07 $6C
     ld   a, [wHasPlacedBomb]                      ; $61BE: $FA $4E $C1
     and  a                                        ; $61C1: $A7
     jr   nz, jr_036_6205                          ; $61C2: $20 $41
@@ -5801,7 +5801,7 @@ jr_036_6335:
     xor  a                                        ; $6342: $AF
     ld   [hl], a                                  ; $6343: $77
     ld   a, $00                                   ; $6344: $3E $00
-    call func_036_6C07                            ; $6346: $CD $07 $6C
+    call SetEntityState                           ; $6346: $CD $07 $6C
     ret                                           ; $6349: $C9
 
 jr_036_634A:
@@ -5845,7 +5845,7 @@ jr_036_636C:
     xor  a                                        ; $6375: $AF
     ld   [hl], a                                  ; $6376: $77
     ld   a, $00                                   ; $6377: $3E $00
-    call func_036_6C07                            ; $6379: $CD $07 $6C
+    call SetEntityState                           ; $6379: $CD $07 $6C
 
 jr_036_637C:
     ld   a, $04                                   ; $637C: $3E $04
@@ -6040,7 +6040,7 @@ jr_036_64A4:
     and  $DF                                      ; $64B1: $E6 $DF
     ld   [hl], a                                  ; $64B3: $77
     ld   a, $01                                   ; $64B4: $3E $01
-    call func_036_6C07                            ; $64B6: $CD $07 $6C
+    call SetEntityState                           ; $64B6: $CD $07 $6C
 
 jr_036_64B9:
     ret                                           ; $64B9: $C9
@@ -6115,7 +6115,7 @@ ColorGhoulStateBHandler::
     jr   nz, label_036_6528                       ; $6519: $20 $0D
 
     ld   a, $01                                   ; $651B: $3E $01
-    call func_036_6C07                            ; $651D: $CD $07 $6C
+    call SetEntityState                           ; $651D: $CD $07 $6C
     ld   hl, wEntitiesPhysicsFlagsTable           ; $6520: $21 $40 $C3
     add  hl, bc                                   ; $6523: $09
     ld   a, [hl]                                  ; $6524: $7E
@@ -6316,7 +6316,7 @@ ColorShellState0Handler::
     ld   a, $40                                   ; $66A6: $3E $40
     call func_036_6C83                            ; $66A8: $CD $83 $6C
     ld   a, $01                                   ; $66AB: $3E $01
-    call func_036_6C07                            ; $66AD: $CD $07 $6C
+    call SetEntityState                           ; $66AD: $CD $07 $6C
 
 jr_036_66B0:
     call func_036_6B8A                            ; $66B0: $CD $8A $6B
@@ -6328,7 +6328,7 @@ jr_036_66B0:
     jp   nc, label_036_66C5                       ; $66BD: $D2 $C5 $66
 
     ld   a, $01                                   ; $66C0: $3E $01
-    call func_036_6C07                            ; $66C2: $CD $07 $6C
+    call SetEntityState                           ; $66C2: $CD $07 $6C
 
 label_036_66C5:
     ret                                           ; $66C5: $C9
@@ -6468,7 +6468,7 @@ ColorShellState1Handler::
     ld   a, $01                                   ; $677D: $3E $01
 
 jr_036_677F:
-    call func_036_6C07                            ; $677F: $CD $07 $6C
+    call SetEntityState                           ; $677F: $CD $07 $6C
     call func_036_6B8A                            ; $6782: $CD $8A $6B
     cp   $20                                      ; $6785: $FE $20
     jr   nc, label_036_679F                       ; $6787: $30 $16
@@ -6482,7 +6482,7 @@ jr_036_677F:
     ld   a, $20                                   ; $6795: $3E $20
     call func_036_6C83                            ; $6797: $CD $83 $6C
     ld   a, $02                                   ; $679A: $3E $02
-    call func_036_6C07                            ; $679C: $CD $07 $6C
+    call SetEntityState                           ; $679C: $CD $07 $6C
 
 label_036_679F:
     call func_036_6C15                            ; $679F: $CD $15 $6C
@@ -6494,7 +6494,7 @@ ColorShellState2Handler::
 
     ld   [hl], $18                                ; $67A8: $36 $18
     ld   a, $03                                   ; $67AA: $3E $03
-    call func_036_6C07                            ; $67AC: $CD $07 $6C
+    call SetEntityState                           ; $67AC: $CD $07 $6C
     jr   jr_036_67D1                              ; $67AF: $18 $20
 
 Data_036_67B1::
@@ -6505,7 +6505,7 @@ ColorShellState3Handler::
     jr   nz, jr_036_67C8                          ; $67B8: $20 $0E
 
     ld   a, $01                                   ; $67BA: $3E $01
-    call func_036_6C07                            ; $67BC: $CD $07 $6C
+    call SetEntityState                           ; $67BC: $CD $07 $6C
     xor  a                                        ; $67BF: $AF
     call PointHLToEntitySpeedX                    ; $67C0: $CD $EE $6B
     ld   [hl], a                                  ; $67C3: $77
@@ -6554,7 +6554,7 @@ jr_036_67F1:
     or   $80                                      ; $67FE: $F6 $80
     ld   [hl], a                                  ; $6800: $77
     ld   a, $04                                   ; $6801: $3E $04
-    call func_036_6C07                            ; $6803: $CD $07 $6C
+    call SetEntityState                           ; $6803: $CD $07 $6C
 
 jr_036_6806:
     ret                                           ; $6806: $C9
@@ -6602,7 +6602,7 @@ ColorShellState5Handler::
     or   $80                                      ; $6835: $F6 $80
     ld   [hl], a                                  ; $6837: $77
     ld   a, $04                                   ; $6838: $3E $04
-    call func_036_6C07                            ; $683A: $CD $07 $6C
+    call SetEntityState                           ; $683A: $CD $07 $6C
     jr   jr_036_6856                              ; $683D: $18 $17
 
 jr_036_683F:
@@ -6619,7 +6619,7 @@ jr_036_683F:
     and  $7F                                      ; $684E: $E6 $7F
     ld   [hl], a                                  ; $6850: $77
     ld   a, $01                                   ; $6851: $3E $01
-    call func_036_6C07                            ; $6853: $CD $07 $6C
+    call SetEntityState                           ; $6853: $CD $07 $6C
 
 jr_036_6856:
     ret                                           ; $6856: $C9
@@ -6687,7 +6687,7 @@ ColorShellState8Handler::
     jr   nz, jr_036_68C3                          ; $68A4: $20 $1D
 
     ld   a, $0C                                   ; $68A6: $3E $0C
-    call func_036_6C07                            ; $68A8: $CD $07 $6C
+    call SetEntityState                           ; $68A8: $CD $07 $6C
     ld   hl, wEntitiesPhysicsFlagsTable           ; $68AB: $21 $40 $C3
     add  hl, bc                                   ; $68AE: $09
     ld   a, [hl]                                  ; $68AF: $7E
@@ -6724,7 +6724,7 @@ jr_036_68D3:
     ld   a, $18                                   ; $68E1: $3E $18
     call func_036_6C83                            ; $68E3: $CD $83 $6C
     ld   a, $09                                   ; $68E6: $3E $09
-    call func_036_6C07                            ; $68E8: $CD $07 $6C
+    call SetEntityState                           ; $68E8: $CD $07 $6C
 
 jr_036_68EB:
     ret                                           ; $68EB: $C9
@@ -6757,7 +6757,7 @@ jr_036_68FB:
     call PointHLToEntitySpeedX                    ; $6914: $CD $EE $6B
     sra  [hl]                                     ; $6917: $CB $2E
     ld   a, $0A                                   ; $6919: $3E $0A
-    call func_036_6C07                            ; $691B: $CD $07 $6C
+    call SetEntityState                           ; $691B: $CD $07 $6C
 
 jr_036_691E:
     ret                                           ; $691E: $C9
@@ -6793,7 +6793,7 @@ ColorShellStateBHandler::
     call PointHLToEntitySpeedX                    ; $694A: $CD $EE $6B
     ld   [hl], a                                  ; $694D: $77
     ld   a, $01                                   ; $694E: $3E $01
-    call func_036_6C07                            ; $6950: $CD $07 $6C
+    call SetEntityState                           ; $6950: $CD $07 $6C
     ld   hl, wEntitiesPhysicsFlagsTable           ; $6953: $21 $40 $C3
     add  hl, bc                                   ; $6956: $09
     ld   a, [hl]                                  ; $6957: $7E

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -137,7 +137,7 @@ func_004_4BC7::
     and  $0E                                      ; $4BCC: $E6 $0E
     ret  nz                                       ; $4BCE: $C0
 
-    call func_004_6DCA                            ; $4BCF: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $4BCF: $CD $CA $6D
     jp   label_3B23                               ; $4BD2: $C3 $23 $3B
 
 jr_004_4BD5:
@@ -391,9 +391,9 @@ func_004_4EEB::
     and  a                                        ; $4EEE: $A7
     jr   nz, jr_004_4F60                          ; $4EEF: $20 $6F
 
-    call func_004_6DCA                            ; $4EF1: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $4EF1: $CD $CA $6D
     call label_3B23                               ; $4EF4: $CD $23 $3B
-    call func_004_6E03                            ; $4EF7: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $4EF7: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                 ; $4EFA: $21 $20 $C3
     add  hl, bc                                   ; $4EFD: $09
     dec  [hl]                                     ; $4EFE: $35
@@ -468,7 +468,7 @@ func_004_4F65::
     ld   hl, wEntitiesSpeedZTable                 ; $4F65: $21 $20 $C3
     add  hl, bc                                   ; $4F68: $09
     ld   [hl], $60                                ; $4F69: $36 $60
-    call func_004_6E03                            ; $4F6B: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $4F6B: $CD $03 $6E
     ld   hl, wEntitiesPosZTable                   ; $4F6E: $21 $10 $C3
     add  hl, bc                                   ; $4F71: $09
     ld   a, [hl]                                  ; $4F72: $7E
@@ -1266,7 +1266,7 @@ jr_004_557E:
     jp   ApplyVectorTowardsLink_trampoline        ; $5583: $C3 $AA $3B
 
 func_004_5586::
-    call func_004_6DCA                            ; $5586: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $5586: $CD $CA $6D
     call label_3B23                               ; $5589: $CD $23 $3B
     call label_3B39                               ; $558C: $CD $39 $3B
     ld   hl, wEntitiesCollisionsTable             ; $558F: $21 $A0 $C2
@@ -1328,7 +1328,7 @@ jr_004_55D8:
     jp   ApplyVectorTowardsLink_trampoline        ; $55DD: $C3 $AA $3B
 
 func_004_55E0::
-    call func_004_6DCA                            ; $55E0: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $55E0: $CD $CA $6D
     call label_3B23                               ; $55E3: $CD $23 $3B
     call label_3B39                               ; $55E6: $CD $39 $3B
     ld   hl, wEntitiesCollisionsTable             ; $55E9: $21 $A0 $C2
@@ -2002,7 +2002,7 @@ func_004_5AE6::
     and  a                                        ; $5AEB: $A7
     jr   nz, jr_004_5AF1                          ; $5AEC: $20 $03
 
-    call func_004_6DCA                            ; $5AEE: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $5AEE: $CD $CA $6D
 
 jr_004_5AF1:
     call label_3B23                               ; $5AF1: $CD $23 $3B
@@ -2248,8 +2248,8 @@ jr_004_5C5A:
     call label_3B70                               ; $5C60: $CD $70 $3B
 
 func_004_5C63::
-    call func_004_6DCA                            ; $5C63: $CD $CA $6D
-    call func_004_6E03                            ; $5C66: $CD $03 $6E
+    call UpdateEntityPosWithSpeed_04              ; $5C63: $CD $CA $6D
+    call AddEntityZSpeedToPos_04                  ; $5C66: $CD $03 $6E
     call func_004_5D08                            ; $5C69: $CD $08 $5D
     ld   hl, wEntitiesPrivateCountdown2Table      ; $5C6C: $21 $00 $C3
     add  hl, bc                                   ; $5C6F: $09
@@ -2632,7 +2632,7 @@ PairoddProjectileEntityHandler::
     rra                                           ; $5F09: $1F
     and  $01                                      ; $5F0A: $E6 $01
     call SetEntitySpriteVariant                   ; $5F0C: $CD $0C $3B
-    call func_004_6DCA                            ; $5F0F: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $5F0F: $CD $CA $6D
     call label_3B2E                               ; $5F12: $CD $2E $3B
     call CheckLinkCollisionWithProjectile_trampoline; $5F15: $CD $4F $3B
     call label_3B70                               ; $5F18: $CD $70 $3B
@@ -2669,8 +2669,8 @@ FishermanFishingGameEntityHandler::
     ldh  [hActiveEntityVisualPosY], a             ; $5F68: $E0 $EC
     ld   de, Data_004_5F58                        ; $5F6A: $11 $58 $5F
     call RenderActiveEntitySpritesPair            ; $5F6D: $CD $C0 $3B
-    call func_004_6DCA                            ; $5F70: $CD $CA $6D
-    call func_004_6E03                            ; $5F73: $CD $03 $6E
+    call UpdateEntityPosWithSpeed_04              ; $5F70: $CD $CA $6D
+    call AddEntityZSpeedToPos_04                  ; $5F73: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                 ; $5F76: $21 $20 $C3
     add  hl, bc                                   ; $5F79: $09
     dec  [hl]                                     ; $5F7A: $35
@@ -3147,7 +3147,7 @@ func_004_6281::
 
 func_004_629F::
     call func_004_6DD7
-    call func_004_6DCD                            ; $62A2: $CD $CD $6D
+    call UpdateEntityYPosWithSpeed_04             ; $62A2: $CD $CD $6D
     ldh  a, [hPressedButtonsMask]                 ; $62A5: $F0 $CB
     and  $01                                      ; $62A7: $E6 $01
     jr   z, jr_004_62BC                           ; $62A9: $28 $11
@@ -3248,7 +3248,7 @@ jr_004_6321:
     rra                                           ; $6326: $1F
     and  $01                                      ; $6327: $E6 $01
     call SetEntitySpriteVariant                   ; $6329: $CD $0C $3B
-    call func_004_6DCA                            ; $632C: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $632C: $CD $CA $6D
     ldh  a, [hFrameCounter]                       ; $632F: $F0 $E7
     and  $07                                      ; $6331: $E6 $07
     jr   nz, jr_004_6354                          ; $6333: $20 $1F
@@ -3446,7 +3446,7 @@ jr_004_6448:
 
 label_004_644E:
     call func_004_7FA3                            ; $644E: $CD $A3 $7F
-    call func_004_6DCA                            ; $6451: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $6451: $CD $CA $6D
     ldh  a, [hActiveEntityState]                  ; $6454: $F0 $F0
     JP_TABLE                                      ; $6456
 ._00 dw func_004_6463                             ; $6457
@@ -3603,7 +3603,7 @@ jr_004_6504:
     ldh  [hLinkPositionY], a                      ; $6525: $E0 $99
     pop  af                                       ; $6527: $F1
     ldh  [hLinkPositionX], a                      ; $6528: $E0 $98
-    jp   func_004_6DCA                            ; $652A: $C3 $CA $6D
+    jp   UpdateEntityPosWithSpeed_04              ; $652A: $C3 $CA $6D
 
 func_004_652D::
     ldh  a, [hFrameCounter]                       ; $652D: $F0 $E7
@@ -3627,7 +3627,7 @@ func_004_652D::
     ldh  [hLinkPositionY], a                      ; $6550: $E0 $99
     pop  af                                       ; $6552: $F1
     ldh  [hLinkPositionX], a                      ; $6553: $E0 $98
-    call func_004_6DCA                            ; $6555: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $6555: $CD $CA $6D
     ld   a, [wIsFileSelectionArrowShifted]        ; $6558: $FA $00 $D0
     ld   hl, hActiveEntityPosX                    ; $655B: $21 $EE $FF
     sub  [hl]                                     ; $655E: $96
@@ -3785,7 +3785,7 @@ jr_004_6626:
     ld   [hl], $10                                ; $662F: $36 $10
 
 jr_004_6631:
-    call func_004_6DCA                            ; $6631: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $6631: $CD $CA $6D
     ld   hl, wEntitiesSpeedXTable                 ; $6634: $21 $40 $C2
     add  hl, bc                                   ; $6637: $09
     ld   a, [hl]                                  ; $6638: $7E
@@ -3842,7 +3842,7 @@ jr_004_6677:
 func_004_6689::
     ld   hl, wEntitiesSpriteVariantTable          ; $6689: $21 $B0 $C3
     ld   [hl], $01                                ; $668C: $36 $01
-    call func_004_6DCA                            ; $668E: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $668E: $CD $CA $6D
     ld   hl, wEntitiesSpeedYTable                 ; $6691: $21 $50 $C2
     add  hl, bc                                   ; $6694: $09
     inc  [hl]                                     ; $6695: $34
@@ -4336,7 +4336,7 @@ jr_004_6969:
     add  hl, bc                                   ; $696C: $09
     ld   [hl], a                                  ; $696D: $77
     call CopyEntityPositionToActivePosition       ; $696E: $CD $8A $3D
-    call func_004_6DCA                            ; $6971: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $6971: $CD $CA $6D
     call label_3B23                               ; $6974: $CD $23 $3B
     ldh  a, [hActiveEntityPosX]                   ; $6977: $F0 $EE
     ld   hl, hLinkPositionX                       ; $6979: $21 $98 $FF
@@ -4434,7 +4434,7 @@ func_004_69F3::
     call ApplyVectorTowardsLink_trampoline        ; $6A01: $CD $AA $3B
 
 jr_004_6A04:
-    call func_004_6DCA                            ; $6A04: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $6A04: $CD $CA $6D
     call label_3B23                               ; $6A07: $CD $23 $3B
     call func_004_6E35                            ; $6A0A: $CD $35 $6E
     add  $30                                      ; $6A0D: $C6 $30
@@ -5017,7 +5017,7 @@ func_004_6D80::
     ld   hl, wEntitiesSpeedYTable                 ; $6DA8: $21 $50 $C2
     add  hl, bc                                   ; $6DAB: $09
     ld   [hl], a                                  ; $6DAC: $77
-    call func_004_6DCA                            ; $6DAD: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $6DAD: $CD $CA $6D
     ld   hl, wEntitiesUnknowTableH                ; $6DB0: $21 $30 $C4
     add  hl, bc                                   ; $6DB3: $09
     ld   a, [hl]                                  ; $6DB4: $7E
@@ -5040,72 +5040,87 @@ jr_004_6DBC:
 jr_004_6DC9:
     ret                                           ; $6DC9: $C9
 
-func_004_6DCA::
-    call func_004_6DD7                            ; $6DCA: $CD $D7 $6D
+UpdateEntityPosWithSpeed_04::
+    call AddEntitySpeedToPos_04                   ; $6DCA: $CD $D7 $6D
 
-func_004_6DCD::
+UpdateEntityYPosWithSpeed_04::
     push bc                                       ; $6DCD: $C5
     ld   a, c                                     ; $6DCE: $79
     add  $10                                      ; $6DCF: $C6 $10
     ld   c, a                                     ; $6DD1: $4F
-    call func_004_6DD7                            ; $6DD2: $CD $D7 $6D
+    call AddEntitySpeedToPos_04                   ; $6DD2: $CD $D7 $6D
     pop  bc                                       ; $6DD5: $C1
     ret                                           ; $6DD6: $C9
 
-func_004_6DD7::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_04::
     ld   hl, wEntitiesSpeedXTable                 ; $6DD7: $21 $40 $C2
     add  hl, bc                                   ; $6DDA: $09
     ld   a, [hl]                                  ; $6DDB: $7E
     and  a                                        ; $6DDC: $A7
-    jr   z, jr_004_6E02                           ; $6DDD: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $6DDD: $28 $23
 
     push af                                       ; $6DDF: $F5
     swap a                                        ; $6DE0: $CB $37
     and  $F0                                      ; $6DE2: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $6DE4: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $6DE4: $21 $60 $C2
     add  hl, bc                                   ; $6DE7: $09
     add  [hl]                                     ; $6DE8: $86
     ld   [hl], a                                  ; $6DE9: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $6DEA: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $6DEC: $21 $00 $C2
 
-label_004_6DEF:
+.updatePosition
     add  hl, bc                                   ; $6DEF: $09
     pop  af                                       ; $6DF0: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $6DF1: $1E $00
     bit  7, a                                     ; $6DF3: $CB $7F
-    jr   z, jr_004_6DF9                           ; $6DF5: $28 $02
+    jr   z, .positive                             ; $6DF5: $28 $02
 
     ld   e, $F0                                   ; $6DF7: $1E $F0
 
-jr_004_6DF9:
+.positive
     swap a                                        ; $6DF9: $CB $37
     and  $0F                                      ; $6DFB: $E6 $0F
     or   e                                        ; $6DFD: $B3
+    ; Get carry back from d
     rr   d                                        ; $6DFE: $CB $1A
     adc  [hl]                                     ; $6E00: $8E
     ld   [hl], a                                  ; $6E01: $77
 
-jr_004_6E02:
+.return
     ret                                           ; $6E02: $C9
 
-func_004_6E03::
+AddEntityZSpeedToPos_04::
     ld   hl, wEntitiesSpeedZTable                 ; $6E03: $21 $20 $C3
     add  hl, bc                                   ; $6E06: $09
     ld   a, [hl]                                  ; $6E07: $7E
     and  a                                        ; $6E08: $A7
-    jr   z, jr_004_6E02                           ; $6E09: $28 $F7
+    jr   z, AddEntitySpeedToPos_04.return         ; $6E09: $28 $F7
 
     push af                                       ; $6E0B: $F5
     swap a                                        ; $6E0C: $CB $37
     and  $F0                                      ; $6E0E: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $6E10: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $6E10: $21 $30 $C3
     add  hl, bc                                   ; $6E13: $09
     add  [hl]                                     ; $6E14: $86
     ld   [hl], a                                  ; $6E15: $77
     rl   d                                        ; $6E16: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $6E18: $21 $10 $C3
-    jr   label_004_6DEF                           ; $6E1B: $18 $D2
+    jr   AddEntitySpeedToPos_04.updatePosition    ; $6E1B: $18 $D2
 
 func_004_6E1D::
     ld   hl, wEntitiesPrivateState1Table          ; $6E1D: $21 $B0 $C2
@@ -5587,7 +5602,7 @@ jr_004_70CA:
     ld   hl, wEntitiesSpeedXTable                 ; $70CD: $21 $40 $C2
     add  hl, bc                                   ; $70D0: $09
     ld   [hl], $F8                                ; $70D1: $36 $F8
-    call func_004_6DD7                            ; $70D3: $CD $D7 $6D
+    call AddEntitySpeedToPos_04                   ; $70D3: $CD $D7 $6D
     ld   hl, wEntitiesPosXTable                   ; $70D6: $21 $00 $C2
     add  hl, bc                                   ; $70D9: $09
     pop  bc                                       ; $70DA: $C1
@@ -5920,7 +5935,7 @@ func_004_7296::
     ld   c, $01                                   ; $72BB: $0E $01
     ld   a, $04                                   ; $72BD: $3E $04
     call ApplyVectorTowardsLink_trampoline        ; $72BF: $CD $AA $3B
-    call func_004_6DCA                            ; $72C2: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $72C2: $CD $CA $6D
     ld   a, [wEntitiesPosXTable + $01]            ; $72C5: $FA $01 $C2
     ld   [$D204], a                               ; $72C8: $EA $04 $D2
     ld   a, [$C211]                               ; $72CB: $FA $11 $C2
@@ -6298,7 +6313,7 @@ jr_004_7517:
 ._05 dw func_004_7698                             ; $7527
 
 func_004_7529::
-    call func_004_6DCA                            ; $7529: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $7529: $CD $CA $6D
     ld   hl, wEntitiesDirectionTable              ; $752C: $21 $80 $C3
     add  hl, bc                                   ; $752F: $09
     ld   a, [hl]                                  ; $7530: $7E
@@ -6354,7 +6369,7 @@ func_004_7566::
     ldh  [hLinkInteractiveMotionBlocked], a       ; $756E: $E0 $A1
 
 jr_004_7570:
-    call func_004_6E03                            ; $7570: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $7570: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                 ; $7573: $21 $20 $C3
     add  hl, bc                                   ; $7576: $09
     dec  [hl]                                     ; $7577: $35
@@ -6420,7 +6435,7 @@ func_004_75BC::
     ldh  [hLinkInteractiveMotionBlocked], a       ; $75C4: $E0 $A1
 
 jr_004_75C6:
-    call func_004_6E03                            ; $75C6: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $75C6: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                 ; $75C9: $21 $20 $C3
     add  hl, bc                                   ; $75CC: $09
     dec  [hl]                                     ; $75CD: $35
@@ -7641,7 +7656,7 @@ jr_004_7D2B:
 
 jr_004_7D51:
     call func_004_6D80                            ; $7D51: $CD $80 $6D
-    call func_004_6DCA                            ; $7D54: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $7D54: $CD $CA $6D
     call label_3B23                               ; $7D57: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $7D5A: $F0 $F0
     JP_TABLE                                      ; $7D5C
@@ -7781,7 +7796,7 @@ jr_004_7E19:
     call label_3B39                               ; $7E27: $CD $39 $3B
 
 jr_004_7E2A:
-    call func_004_6DCA                            ; $7E2A: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $7E2A: $CD $CA $6D
     call label_3B23                               ; $7E2D: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $7E30: $F0 $F0
     JP_TABLE                                      ; $7E32
@@ -7921,7 +7936,7 @@ LeeverEntityHandler::
     call RenderActiveEntitySpritesPair            ; $7EF8: $CD $C0 $3B
     call func_004_7FA3                            ; $7EFB: $CD $A3 $7F
     call func_004_6D80                            ; $7EFE: $CD $80 $6D
-    call func_004_6DCA                            ; $7F01: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $7F01: $CD $CA $6D
     call label_3B23                               ; $7F04: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $7F07: $F0 $F0
     and  $03                                      ; $7F09: $E6 $03

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -5135,7 +5135,7 @@ func_004_6E1D::
     ld   [hl], a                                  ; $6E2C: $77
     rl   d                                        ; $6E2D: $CB $12
     ld   hl, wEntitiesUnknownTableD               ; $6E2F: $21 $D0 $C2
-    jp   label_004_6DEF                           ; $6E32: $C3 $EF $6D
+    jp   AddEntitySpeedToPos_04.updatePosition    ; $6E32: $C3 $EF $6D
 
 func_004_6E35::
     ld   e, $00                                   ; $6E35: $1E $00

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -5062,7 +5062,7 @@ func_004_6DD7::
     push af                                       ; $6DDF: $F5
     swap a                                        ; $6DE0: $CB $37
     and  $F0                                      ; $6DE2: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $6DE4: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $6DE4: $21 $60 $C2
     add  hl, bc                                   ; $6DE7: $09
     add  [hl]                                     ; $6DE8: $86
     ld   [hl], a                                  ; $6DE9: $77
@@ -5099,7 +5099,7 @@ func_004_6E03::
     push af                                       ; $6E0B: $F5
     swap a                                        ; $6E0C: $CB $37
     and  $F0                                      ; $6E0E: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $6E10: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $6E10: $21 $30 $C3
     add  hl, bc                                   ; $6E13: $09
     add  [hl]                                     ; $6E14: $86
     ld   [hl], a                                  ; $6E15: $77

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -3146,7 +3146,7 @@ func_004_6281::
 ._01 dw func_004_6308                             ; $629D
 
 func_004_629F::
-    call func_004_6DD7
+    call AddEntitySpeedToPos_04
     call UpdateEntityYPosWithSpeed_04             ; $62A2: $CD $CD $6D
     ldh  a, [hPressedButtonsMask]                 ; $62A5: $F0 $CB
     and  $01                                      ; $62A7: $E6 $01

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -270,7 +270,7 @@ func_006_654E::
     push af                                       ; $6556: $F5
     swap a                                        ; $6557: $CB $37
     and  $F0                                      ; $6559: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $655B: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $655B: $21 $60 $C2
     add  hl, bc                                   ; $655E: $09
     add  [hl]                                     ; $655F: $86
     ld   [hl], a                                  ; $6560: $77
@@ -307,7 +307,7 @@ func_006_657A::
     push af                                       ; $6582: $F5
     swap a                                        ; $6583: $CB $37
     and  $F0                                      ; $6585: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $6587: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $6587: $21 $30 $C3
     add  hl, bc                                   ; $658A: $09
     add  [hl]                                     ; $658B: $86
     ld   [hl], a                                  ; $658C: $77

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -286,7 +286,7 @@ jr_007_41BE:
     ret                                           ; $41C7: $C9
 
 jr_007_41C8:
-    call func_007_7E0A                            ; $41C8: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $41C8: $CD $0A $7E
     call label_3B23                               ; $41CB: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $41CE: $21 $A0 $C2
     add  hl, bc                                   ; $41D1: $09
@@ -321,7 +321,7 @@ label_007_41F0:
     rra                                           ; $4200: $1F
     and  $01                                      ; $4201: $E6 $01
     call SetEntitySpriteVariant                   ; $4203: $CD $0C $3B
-    call func_007_7E0A                            ; $4206: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $4206: $CD $0A $7E
     call label_3B23                               ; $4209: $CD $23 $3B
     call label_3B39                               ; $420C: $CD $39 $3B
     call GetEntityTransitionCountdown             ; $420F: $CD $05 $0C
@@ -695,7 +695,7 @@ func_007_4475::
     jp   IncrementEntityState                     ; $448E: $C3 $12 $3B
 
 jr_007_4491:
-    call func_007_7E0A                            ; $4491: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $4491: $CD $0A $7E
     call GetEntitySpeedYAddress                   ; $4494: $CD $05 $40
     inc  [hl]                                     ; $4497: $34
     ret                                           ; $4498: $C9
@@ -1292,8 +1292,8 @@ jr_007_487D:
     jp   func_007_733F                            ; $488B: $C3 $3F $73
 
 func_007_488E::
-    call func_007_7E0A                            ; $488E: $CD $0A $7E
-    call func_007_7E43                            ; $4891: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $488E: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $4891: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $4894: $21 $20 $C3
     add  hl, bc                                   ; $4897: $09
     dec  [hl]                                     ; $4898: $35
@@ -1428,8 +1428,8 @@ func_007_4945::
 func_007_4959::
     call func_007_49DC                            ; $4959: $CD $DC $49
     call func_007_7D96                            ; $495C: $CD $96 $7D
-    call func_007_7E0A                            ; $495F: $CD $0A $7E
-    call func_007_7E43                            ; $4962: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $495F: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $4962: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $4965: $21 $20 $C3
     add  hl, bc                                   ; $4968: $09
     dec  [hl]                                     ; $4969: $35
@@ -1987,7 +1987,7 @@ func_007_4D4E::
     call GetEntityTransitionCountdown             ; $4D4E: $CD $05 $0C
     ret  nz                                       ; $4D51: $C0
 
-    call func_007_7E43                            ; $4D52: $CD $43 $7E
+    call AddEntityZSpeedToPos_07                  ; $4D52: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $4D55: $21 $20 $C3
     add  hl, bc                                   ; $4D58: $09
     dec  [hl]                                     ; $4D59: $35
@@ -2091,7 +2091,7 @@ jr_007_4DCB:
     ld   [hl], a                                  ; $4DE9: $77
 
 jr_007_4DEA:
-    call func_007_7E0A                            ; $4DEA: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $4DEA: $CD $0A $7E
     ld   a, [$D202]                               ; $4DED: $FA $02 $D2
     and  a                                        ; $4DF0: $A7
     jp   nz, IncrementEntityState                 ; $4DF1: $C2 $12 $3B
@@ -2176,7 +2176,7 @@ jr_007_4E3E:
     ldh  [hLinkPositionX], a                      ; $4E87: $E0 $98
 
 jr_007_4E89:
-    jp   func_007_7E0A                            ; $4E89: $C3 $0A $7E
+    jp   UpdateEntityPosWithSpeed_07              ; $4E89: $C3 $0A $7E
 
 func_007_4E8C::
     ret                                           ; $4E8C: $C9
@@ -2209,7 +2209,7 @@ jr_007_4EC5:
     ld   de, Data_007_4E8D                        ; $4ECD: $11 $8D $4E
     call RenderActiveEntitySpritesPair            ; $4ED0: $CD $C0 $3B
     call func_007_7D96                            ; $4ED3: $CD $96 $7D
-    call func_007_7E43                            ; $4ED6: $CD $43 $7E
+    call AddEntityZSpeedToPos_07                  ; $4ED6: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $4ED9: $21 $20 $C3
     add  hl, bc                                   ; $4EDC: $09
     dec  [hl]                                     ; $4EDD: $35
@@ -2314,7 +2314,7 @@ jr_007_4F7B:
     ld   [hl], $FE                                ; $4F87: $36 $FE
     call GetEntitySpeedYAddress                   ; $4F89: $CD $05 $40
     ld   [hl], $F4                                ; $4F8C: $36 $F4
-    call func_007_7E0A                            ; $4F8E: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $4F8E: $CD $0A $7E
     call GetEntityTransitionCountdown             ; $4F91: $CD $05 $0C
     jr   nz, jr_007_4FA5                          ; $4F94: $20 $0F
 
@@ -2490,7 +2490,7 @@ jr_007_5071:
 
 jr_007_509A:
     ldh  [hLinkDirection], a                      ; $509A: $E0 $9E
-    call func_007_7E0A                            ; $509C: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $509C: $CD $0A $7E
     ld   hl, wEntitiesDirectionTable              ; $509F: $21 $80 $C3
     add  hl, bc                                   ; $50A2: $09
     ld   e, [hl]                                  ; $50A3: $5E
@@ -2517,7 +2517,7 @@ func_007_50B4::
     ld   [hl], $E4                                ; $50C3: $36 $E4
     call GetEntitySpeedYAddress                   ; $50C5: $CD $05 $40
     ld   [hl], $08                                ; $50C8: $36 $08
-    call func_007_7E0A                            ; $50CA: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $50CA: $CD $0A $7E
     ldh  a, [hActiveEntityPosX]                   ; $50CD: $F0 $EE
     cp   $C0                                      ; $50CF: $FE $C0
     jr   c, label_007_50DF                        ; $50D1: $38 $0C
@@ -2674,7 +2674,7 @@ jr_007_519F:
     ld   [hl], e                                  ; $51A9: $73
 
 jr_007_51AA:
-    call func_007_7E0A                            ; $51AA: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $51AA: $CD $0A $7E
     ld   hl, wEntitiesPosXTable                   ; $51AD: $21 $00 $C2
     add  hl, bc                                   ; $51B0: $09
     ld   a, [hl]                                  ; $51B1: $7E
@@ -2988,7 +2988,7 @@ jr_007_53B8:
     jp   SetEntitySpriteVariant                   ; $53BA: $C3 $0C $3B
 
 func_007_53BD::
-    call func_007_7E0A                            ; $53BD: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $53BD: $CD $0A $7E
     call GetEntityTransitionCountdown             ; $53C0: $CD $05 $0C
     jr   nz, jr_007_53CA                          ; $53C3: $20 $05
 
@@ -3052,7 +3052,7 @@ jr_007_541F:
     ldh  [hLinkPositionY], a                      ; $5420: $E0 $99
     pop  af                                       ; $5422: $F1
     ldh  [hLinkPositionX], a                      ; $5423: $E0 $98
-    call func_007_7E0A                            ; $5425: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $5425: $CD $0A $7E
     jp   label_3B39                               ; $5428: $C3 $39 $3B
 
 Data_007_542B::
@@ -3367,8 +3367,8 @@ WingedOctorockEntityHandler::
 
 jr_007_566F:
     call func_007_7DC3                            ; $566F: $CD $C3 $7D
-    call func_007_7E0A                            ; $5672: $CD $0A $7E
-    call func_007_7E43                            ; $5675: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $5672: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $5675: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $5678: $21 $20 $C3
     add  hl, bc                                   ; $567B: $09
     dec  [hl]                                     ; $567C: $35
@@ -3680,7 +3680,7 @@ jr_007_5857:
 
 jr_007_5874:
     call func_007_7D96                            ; $5874: $CD $96 $7D
-    call func_007_7E43                            ; $5877: $CD $43 $7E
+    call AddEntityZSpeedToPos_07                  ; $5877: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $587A: $21 $20 $C3
     add  hl, bc                                   ; $587D: $09
     dec  [hl]                                     ; $587E: $35
@@ -4119,7 +4119,7 @@ jr_007_5B19:
     jp   SetEntitySpriteVariant                   ; $5B22: $C3 $0C $3B
 
 func_007_5B25::
-    call func_007_7E0A                            ; $5B25: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $5B25: $CD $0A $7E
     ldh  a, [hActiveEntityPosY]                   ; $5B28: $F0 $EF
     cp   $08                                      ; $5B2A: $FE $08
     jp   c, func_007_7EA4                         ; $5B2C: $DA $A4 $7E
@@ -4251,7 +4251,7 @@ func_007_5BD9::
 jr_007_5BE8:
     ld   a, $03                                   ; $5BE8: $3E $03
     call SetEntitySpriteVariant                   ; $5BEA: $CD $0C $3B
-    jp   func_007_7E0A                            ; $5BED: $C3 $0A $7E
+    jp   UpdateEntityPosWithSpeed_07              ; $5BED: $C3 $0A $7E
 
 func_007_5BF0::
     ret                                           ; $5BF0: $C9
@@ -4265,7 +4265,7 @@ BlooperEntityHandler::
     call func_007_7D96                            ; $5BFF: $CD $96 $7D
     call func_007_7DC3                            ; $5C02: $CD $C3 $7D
     call label_3B39                               ; $5C05: $CD $39 $3B
-    call func_007_7E0A                            ; $5C08: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $5C08: $CD $0A $7E
 
 jr_007_5C0B:
     call label_3B23                               ; $5C0B: $CD $23 $3B
@@ -4799,8 +4799,8 @@ label_007_5FAB:
 jr_007_5FB1:
     ld   de, Data_007_5F9B                        ; $5FB1: $11 $9B $5F
     call RenderActiveEntitySprite                 ; $5FB4: $CD $77 $3C
-    call func_007_7E0A                            ; $5FB7: $CD $0A $7E
-    call func_007_7E43                            ; $5FBA: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $5FB7: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $5FBA: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $5FBD: $21 $20 $C3
     add  hl, bc                                   ; $5FC0: $09
     dec  [hl]                                     ; $5FC1: $35
@@ -4917,8 +4917,8 @@ jr_007_602A:
 
     call DecrementEntityIgnoreHitsCountdown       ; $604E: $CD $56 $0C
     call label_3B70                               ; $6051: $CD $70 $3B
-    call func_007_7E0A                            ; $6054: $CD $0A $7E
-    call func_007_7E43                            ; $6057: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $6054: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $6057: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $605A: $21 $20 $C3
     add  hl, bc                                   ; $605D: $09
     dec  [hl]                                     ; $605E: $35
@@ -5510,7 +5510,7 @@ func_007_639E::
     ld   [hl], b                                  ; $63A2: $70
     ldh  a, [hActiveEntityPosX]                   ; $63A3: $F0 $EE
     push af                                       ; $63A5: $F5
-    call func_007_7E0A                            ; $63A6: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $63A6: $CD $0A $7E
     pop  af                                       ; $63A9: $F1
     ld   e, a                                     ; $63AA: $5F
     ld   hl, wEntitiesPosXTable                   ; $63AB: $21 $00 $C2
@@ -5948,7 +5948,7 @@ func_007_6649::
     ld   [hl], b                                  ; $6659: $70
 
 jr_007_665A:
-    call func_007_7E0A                            ; $665A: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $665A: $CD $0A $7E
     call label_3B23                               ; $665D: $CD $23 $3B
 
 label_007_6660:
@@ -6011,7 +6011,7 @@ jr_007_66B0:
     jp   IncrementEntityState                     ; $66B5: $C3 $12 $3B
 
 func_007_66B8::
-    call func_007_7E0A                            ; $66B8: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $66B8: $CD $0A $7E
     call GetEntitySpeedYAddress                   ; $66BB: $CD $05 $40
     inc  [hl]                                     ; $66BE: $34
     inc  [hl]                                     ; $66BF: $34
@@ -6072,8 +6072,8 @@ PeaHatEntityHandler::
     call func_007_7D96                            ; $670F: $CD $96 $7D
     call func_007_7DC3                            ; $6712: $CD $C3 $7D
     call label_3B39                               ; $6715: $CD $39 $3B
-    call func_007_7E0A                            ; $6718: $CD $0A $7E
-    call func_007_7E43                            ; $671B: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $6718: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $671B: $CD $43 $7E
     call label_3B23                               ; $671E: $CD $23 $3B
     ld   hl, wEntitiesHitboxFlagsTable            ; $6721: $21 $50 $C3
     add  hl, bc                                   ; $6724: $09
@@ -6296,7 +6296,7 @@ SnakeEntityHandler::
     call func_007_7D96                            ; $685D: $CD $96 $7D
     call func_007_7DC3                            ; $6860: $CD $C3 $7D
     call label_3B39                               ; $6863: $CD $39 $3B
-    call func_007_7E0A                            ; $6866: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $6866: $CD $0A $7E
     call label_3B23                               ; $6869: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $686C: $21 $A0 $C2
     add  hl, bc                                   ; $686F: $09
@@ -6655,7 +6655,7 @@ jr_007_6A84:
 
 jr_007_6A89:
     call func_007_7DC3                            ; $6A89: $CD $C3 $7D
-    call func_007_7E43                            ; $6A8C: $CD $43 $7E
+    call AddEntityZSpeedToPos_07                  ; $6A8C: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $6A8F: $21 $20 $C3
     add  hl, bc                                   ; $6A92: $09
     dec  [hl]                                     ; $6A93: $35
@@ -6927,7 +6927,7 @@ jr_007_6C27:
     ld   [$D209], a                               ; $6C30: $EA $09 $D2
 
 func_007_6C33::
-    call func_007_7E0A                            ; $6C33: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $6C33: $CD $0A $7E
     jp   label_3B23                               ; $6C36: $C3 $23 $3B
 
 func_007_6C39::
@@ -7868,7 +7868,7 @@ StarEntityHandler::
     call func_007_7D96                            ; $7261: $CD $96 $7D
     call func_007_7DC3                            ; $7264: $CD $C3 $7D
     call label_3B39                               ; $7267: $CD $39 $3B
-    call func_007_7E0A                            ; $726A: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $726A: $CD $0A $7E
     call label_3B23                               ; $726D: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $7270: $21 $A0 $C2
     add  hl, bc                                   ; $7273: $09
@@ -7928,7 +7928,7 @@ jr_007_72BD:
 jr_007_72C3:
     call func_007_7D96                            ; $72C3: $CD $96 $7D
     call func_007_7DC3                            ; $72C6: $CD $C3 $7D
-    call func_007_7E43                            ; $72C9: $CD $43 $7E
+    call AddEntityZSpeedToPos_07                  ; $72C9: $CD $43 $7E
     ld   hl, wEntitiesSpeedZTable                 ; $72CC: $21 $20 $C3
     add  hl, bc                                   ; $72CF: $09
     dec  [hl]                                     ; $72D0: $35
@@ -8046,11 +8046,11 @@ jr_007_7374:
     ld   hl, wEntitiesSpeedXTable                 ; $7374: $21 $40 $C2
     add  hl, bc                                   ; $7377: $09
     ld   [hl], e                                  ; $7378: $73
-    jp   func_007_7E17                            ; $7379: $C3 $17 $7E
+    jp   AddEntitySpeedToPos_07                   ; $7379: $C3 $17 $7E
 
 func_007_737C::
     call label_3B39                               ; $737C: $CD $39 $3B
-    call func_007_7E0A                            ; $737F: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $737F: $CD $0A $7E
     call func_007_73F7                            ; $7382: $CD $F7 $73
     call GetEntityTransitionCountdown             ; $7385: $CD $05 $0C
     jr   nz, jr_007_739B                          ; $7388: $20 $11
@@ -8069,7 +8069,7 @@ jr_007_739B:
 
 func_007_73A0::
     call label_3B39                               ; $73A0: $CD $39 $3B
-    call func_007_7E0A                            ; $73A3: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $73A3: $CD $0A $7E
     call func_007_73F7                            ; $73A6: $CD $F7 $73
     ldh  a, [hFFE8]                               ; $73A9: $F0 $E8
     and  a                                        ; $73AB: $A7
@@ -8268,7 +8268,7 @@ WaterTektiteEntityHandler::
 jr_007_7547:
     and  $01                                      ; $7547: $E6 $01
     call SetEntitySpriteVariant                   ; $7549: $CD $0C $3B
-    call func_007_7E0A                            ; $754C: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $754C: $CD $0A $7E
     call label_3B23                               ; $754F: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $7552: $21 $A0 $C2
     add  hl, bc                                   ; $7555: $09
@@ -8393,8 +8393,8 @@ jr_007_75FE:
     ld   de, Data_007_75DE                        ; $75FE: $11 $DE $75
     call RenderActiveEntitySpritesPair            ; $7601: $CD $C0 $3B
     call func_007_7D96                            ; $7604: $CD $96 $7D
-    call func_007_7E0A                            ; $7607: $CD $0A $7E
-    call func_007_7E43                            ; $760A: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $7607: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $760A: $CD $43 $7E
     call label_3B23                               ; $760D: $CD $23 $3B
     ld   hl, wEntitiesSpeedZTable                 ; $7610: $21 $20 $C3
     add  hl, bc                                   ; $7613: $09
@@ -8681,8 +8681,8 @@ jr_007_77B6:
 jr_007_77C1:
     call func_007_7DC3                            ; $77C1: $CD $C3 $7D
     call label_3B39                               ; $77C4: $CD $39 $3B
-    call func_007_7E0A                            ; $77C7: $CD $0A $7E
-    call func_007_7E43                            ; $77CA: $CD $43 $7E
+    call UpdateEntityPosWithSpeed_07              ; $77C7: $CD $0A $7E
+    call AddEntityZSpeedToPos_07                  ; $77CA: $CD $43 $7E
     call label_3B23                               ; $77CD: $CD $23 $3B
     ld   hl, wEntitiesSpeedZTable                 ; $77D0: $21 $20 $C3
     add  hl, bc                                   ; $77D3: $09
@@ -9042,7 +9042,7 @@ func_007_79B4::
     call func_007_7996                            ; $79BF: $CD $96 $79
 
 jr_007_79C2:
-    call func_007_7E0A                            ; $79C2: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $79C2: $CD $0A $7E
     call label_3B23                               ; $79C5: $CD $23 $3B
     call func_007_7D1A                            ; $79C8: $CD $1A $7D
     call GetEntityTransitionCountdown             ; $79CB: $CD $05 $0C
@@ -9093,7 +9093,7 @@ jr_007_79F9:
 jr_007_7A07:
     call func_007_7D1A                            ; $7A07: $CD $1A $7D
     call func_007_7D1A                            ; $7A0A: $CD $1A $7D
-    call func_007_7E0A                            ; $7A0D: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $7A0D: $CD $0A $7E
     call label_3B23                               ; $7A10: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $7A13: $F0 $E7
     xor  c                                        ; $7A15: $A9
@@ -9460,7 +9460,7 @@ func_007_7DC3::
     ld   a, [hl]                                  ; $7DE9: $7E
     call GetEntitySpeedYAddress                   ; $7DEA: $CD $05 $40
     ld   [hl], a                                  ; $7DED: $77
-    call func_007_7E0A                            ; $7DEE: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $7DEE: $CD $0A $7E
     ld   hl, wEntitiesUnknowTableH                ; $7DF1: $21 $30 $C4
     add  hl, bc                                   ; $7DF4: $09
     ld   a, [hl]                                  ; $7DF5: $7E
@@ -9482,70 +9482,85 @@ jr_007_7DFD:
 label_007_7E09:
     ret                                           ; $7E09: $C9
 
-func_007_7E0A::
-    call func_007_7E17                            ; $7E0A: $CD $17 $7E
+UpdateEntityPosWithSpeed_07::
+    call AddEntitySpeedToPos_07                   ; $7E0A: $CD $17 $7E
     push bc                                       ; $7E0D: $C5
     ld   a, c                                     ; $7E0E: $79
     add  $10                                      ; $7E0F: $C6 $10
     ld   c, a                                     ; $7E11: $4F
-    call func_007_7E17                            ; $7E12: $CD $17 $7E
+    call AddEntitySpeedToPos_07                   ; $7E12: $CD $17 $7E
     pop  bc                                       ; $7E15: $C1
     ret                                           ; $7E16: $C9
 
-func_007_7E17::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_07::
     ld   hl, wEntitiesSpeedXTable                 ; $7E17: $21 $40 $C2
     add  hl, bc                                   ; $7E1A: $09
     ld   a, [hl]                                  ; $7E1B: $7E
     and  a                                        ; $7E1C: $A7
-    jr   z, jr_007_7E42                           ; $7E1D: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7E1D: $28 $23
 
     push af                                       ; $7E1F: $F5
     swap a                                        ; $7E20: $CB $37
     and  $F0                                      ; $7E22: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7E24: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7E24: $21 $60 $C2
     add  hl, bc                                   ; $7E27: $09
     add  [hl]                                     ; $7E28: $86
     ld   [hl], a                                  ; $7E29: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7E2A: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7E2C: $21 $00 $C2
 
-jr_007_7E2F:
+.updatePosition
     add  hl, bc                                   ; $7E2F: $09
     pop  af                                       ; $7E30: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7E31: $1E $00
     bit  7, a                                     ; $7E33: $CB $7F
-    jr   z, jr_007_7E39                           ; $7E35: $28 $02
+    jr   z, .positive                             ; $7E35: $28 $02
 
     ld   e, $F0                                   ; $7E37: $1E $F0
 
-jr_007_7E39:
+.positive
     swap a                                        ; $7E39: $CB $37
     and  $0F                                      ; $7E3B: $E6 $0F
     or   e                                        ; $7E3D: $B3
+    ; Get carry back from d
     rr   d                                        ; $7E3E: $CB $1A
     adc  [hl]                                     ; $7E40: $8E
     ld   [hl], a                                  ; $7E41: $77
 
-jr_007_7E42:
+.return
     ret                                           ; $7E42: $C9
 
-func_007_7E43::
+AddEntityZSpeedToPos_07::
     ld   hl, wEntitiesSpeedZTable                 ; $7E43: $21 $20 $C3
     add  hl, bc                                   ; $7E46: $09
     ld   a, [hl]                                  ; $7E47: $7E
     and  a                                        ; $7E48: $A7
-    jr   z, jr_007_7E42                           ; $7E49: $28 $F7
+    jr   z, AddEntitySpeedToPos_07.return         ; $7E49: $28 $F7
 
     push af                                       ; $7E4B: $F5
     swap a                                        ; $7E4C: $CB $37
     and  $F0                                      ; $7E4E: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7E50: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7E50: $21 $30 $C3
     add  hl, bc                                   ; $7E53: $09
     add  [hl]                                     ; $7E54: $86
     ld   [hl], a                                  ; $7E55: $77
     rl   d                                        ; $7E56: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7E58: $21 $10 $C3
-    jr   jr_007_7E2F                              ; $7E5B: $18 $D2
+    jr   AddEntitySpeedToPos_07.updatePosition    ; $7E5B: $18 $D2
 
 func_007_7E5D::
     ld   e, $00                                   ; $7E5D: $1E $00

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -9502,7 +9502,7 @@ func_007_7E17::
     push af                                       ; $7E1F: $F5
     swap a                                        ; $7E20: $CB $37
     and  $F0                                      ; $7E22: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7E24: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7E24: $21 $60 $C2
     add  hl, bc                                   ; $7E27: $09
     add  [hl]                                     ; $7E28: $86
     ld   [hl], a                                  ; $7E29: $77
@@ -9539,7 +9539,7 @@ func_007_7E43::
     push af                                       ; $7E4B: $F5
     swap a                                        ; $7E4C: $CB $37
     and  $F0                                      ; $7E4E: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7E50: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7E50: $21 $30 $C3
     add  hl, bc                                   ; $7E53: $09
     add  [hl]                                     ; $7E54: $86
     ld   [hl], a                                  ; $7E55: $77

--- a/src/code/entities/big_fairy.asm
+++ b/src/code/entities/big_fairy.asm
@@ -97,7 +97,7 @@ jr_006_7100:
     ld   [hl], a                                  ; $711F: $77
 
 jr_006_7120:
-    jp   func_006_6541                            ; $7120: $C3 $41 $65
+    jp   UpdateEntityPosWithSpeed_06              ; $7120: $C3 $41 $65
 
 label_006_7123:
     ld   hl, Data_006_7071                        ; $7123: $21 $71 $70
@@ -127,7 +127,7 @@ jr_006_714A:
     ld   hl, wEntitiesSpeedZTable                 ; $714A: $21 $20 $C3
     add  hl, bc                                   ; $714D: $09
     ld   [hl], e                                  ; $714E: $73
-    call func_006_657A                            ; $714F: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $714F: $CD $7A $65
     call func_006_64C6                            ; $7152: $CD $C6 $64
     ldh  a, [hActiveEntityState]                  ; $7155: $F0 $F0
     JP_TABLE                                      ; $7157

--- a/src/code/entities/boo_buddy.asm
+++ b/src/code/entities/boo_buddy.asm
@@ -7,7 +7,7 @@ BooBuddyEntityHandler::
     call RenderActiveEntitySpritesPair            ; $79AC: $CD $C0 $3B
     call func_006_64C6                            ; $79AF: $CD $C6 $64
     call func_006_64F7                            ; $79B2: $CD $F7 $64
-    call func_006_6541                            ; $79B5: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $79B5: $CD $41 $65
     call func_006_5E54                            ; $79B8: $CD $54 $5E
     ldh  a, [hActiveEntityState]                  ; $79BB: $F0 $F0
     JP_TABLE                                      ; $79BD

--- a/src/code/entities/boomerang.asm
+++ b/src/code/entities/boomerang.asm
@@ -28,7 +28,7 @@ jr_019_4481:
     call label_3B7B                               ; $4486: $CD $7B $3B
 
 jr_019_4489:
-    call func_019_7DB8                            ; $4489: $CD $B8 $7D
+    call UpdateEntityPosWithSpeed_19              ; $4489: $CD $B8 $7D
     call label_3B2E                               ; $448C: $CD $2E $3B
     call func_019_44CC                            ; $448F: $CD $CC $44
     ldh  a, [hActiveEntityState]                  ; $4492: $F0 $F0

--- a/src/code/entities/bow_wow.asm
+++ b/src/code/entities/bow_wow.asm
@@ -187,7 +187,7 @@ jr_005_4137:
     add  hl, bc                                   ; $4142: $09
     ld   a, [hl]                                  ; $4143: $7E
     ld   [$D151], a                               ; $4144: $EA $51 $D1
-    call func_005_7AEA                            ; $4147: $CD $EA $7A
+    call AddEntityZSpeedToPos_05                  ; $4147: $CD $EA $7A
     ld   hl, wEntitiesSpeedZTable                 ; $414A: $21 $20 $C3
     add  hl, bc                                   ; $414D: $09
     dec  [hl]                                     ; $414E: $35
@@ -289,14 +289,14 @@ jr_005_41DA:
     ld   [hl], $10                                ; $41E3: $36 $10
 
 jr_005_41E5:
-    call func_005_7AB1                            ; $41E5: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $41E5: $CD $B1 $7A
     jp   func_005_4228                            ; $41E8: $C3 $28 $42
 
 func_005_41EB::
     call GetEntityTransitionCountdown             ; $41EB: $CD $05 $0C
     jr   z, jr_005_41F9                           ; $41EE: $28 $09
 
-    call func_005_7AB1                            ; $41F0: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $41F0: $CD $B1 $7A
     call func_005_4228                            ; $41F3: $CD $28 $42
     dec  e                                        ; $41F6: $1D
     jr   z, jr_005_4206                           ; $41F7: $28 $0D

--- a/src/code/entities/butterfly.asm
+++ b/src/code/entities/butterfly.asm
@@ -42,7 +42,7 @@ ButterflyEntityHandler::
     rra                                           ; $6BED: $1F
     and  $01                                      ; $6BEE: $E6 $01
     call SetEntitySpriteVariant                   ; $6BF0: $CD $0C $3B
-    call func_006_6541                            ; $6BF3: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $6BF3: $CD $41 $65
 
     ; If [hActiveEntityState] & $1F == 0…
     ldh  a, [hActiveEntityState]                  ; $6BF6: $F0 $F0

--- a/src/code/entities/chest_with_item.asm
+++ b/src/code/entities/chest_with_item.asm
@@ -145,7 +145,7 @@ jr_007_7C5E:
     and  a                                        ; $7C61: $A7
     ret  nz                                       ; $7C62: $C0
 
-    call func_007_7E0A                            ; $7C63: $CD $0A $7E
+    call UpdateEntityPosWithSpeed_07              ; $7C63: $CD $0A $7E
     ld   hl, wEntitiesUnknowTableY                ; $7C66: $21 $D0 $C3
     add  hl, bc                                   ; $7C69: $09
     ld   a, [hl]                                  ; $7C6A: $7E

--- a/src/code/entities/crow.asm
+++ b/src/code/entities/crow.asm
@@ -215,7 +215,7 @@ jr_006_5DBA:
     ld   hl, wEntitiesSpeedZTable                 ; $5DBD: $21 $20 $C3
     add  hl, bc                                   ; $5DC0: $09
     ld   [hl], $08                                ; $5DC1: $36 $08
-    call func_006_657A                            ; $5DC3: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $5DC3: $CD $7A $65
     jr   jr_006_5E08                              ; $5DC6: $18 $40
 
 CrowState2Handler::
@@ -261,7 +261,7 @@ jr_006_5DF5:
     ld   [hl], a                                  ; $5E01: $77
 
 func_006_5E02::
-    call func_006_6541                            ; $5E02: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $5E02: $CD $41 $65
     call func_006_5E14                            ; $5E05: $CD $14 $5E
 
 jr_006_5E08:

--- a/src/code/entities/cucco.asm
+++ b/src/code/entities/cucco.asm
@@ -44,7 +44,7 @@ jr_005_4557:
     cp   $03                                      ; $4562: $FE $03
     jr   z, jr_005_4580                           ; $4564: $28 $1A
 
-    call func_005_7AEA                            ; $4566: $CD $EA $7A
+    call AddEntityZSpeedToPos_05                  ; $4566: $CD $EA $7A
     ld   hl, wEntitiesSpeedZTable                 ; $4569: $21 $20 $C3
     add  hl, bc                                   ; $456C: $09
     dec  [hl]                                     ; $456D: $35
@@ -206,7 +206,7 @@ func_005_4624::
     jp   IncrementEntityState                     ; $4660: $C3 $12 $3B
 
 func_005_4663::
-    call func_005_7AB1                            ; $4663: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $4663: $CD $B1 $7A
     call label_3B23                               ; $4666: $CD $23 $3B
     ldh  a, [hFFE8]                               ; $4669: $F0 $E8
     and  a                                        ; $466B: $A7
@@ -269,7 +269,7 @@ jr_005_46CD:
     ld   [hl], a                                  ; $46D1: $77
 
 jr_005_46D2:
-    call func_005_7AB1                            ; $46D2: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $46D2: $CD $B1 $7A
     call label_3B23                               ; $46D5: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $46D8: $F0 $E7
     rra                                           ; $46DA: $1F
@@ -345,7 +345,7 @@ jr_005_474D:
 
 func_005_474E::
     call label_3B44                               ; $474E: $CD $44 $3B
-    call func_005_7AB1                            ; $4751: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $4751: $CD $B1 $7A
     ldh  a, [hActiveEntityPosX]                   ; $4754: $F0 $EE
     cp   $A9                                      ; $4756: $FE $A9
     jp   nc, func_005_7B4B                        ; $4758: $D2 $4B $7B

--- a/src/code/entities/cue_ball.asm
+++ b/src/code/entities/cue_ball.asm
@@ -33,7 +33,7 @@ jr_006_4B98:
     call BossIntro                                ; $4BA8: $CD $E8 $3E
     call DecrementEntityIgnoreHitsCountdown       ; $4BAB: $CD $56 $0C
     call label_3B44                               ; $4BAE: $CD $44 $3B
-    call func_006_6541                            ; $4BB1: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $4BB1: $CD $41 $65
     ld   a, [wIsLinkInTheAir]                     ; $4BB4: $FA $46 $C1
     and  a                                        ; $4BB7: $A7
     jr   nz, jr_006_4BE1                          ; $4BB8: $20 $27
@@ -364,4 +364,4 @@ label_006_4E88:
     cp   $06                                      ; $4E97: $FE $06
     ret  nz                                       ; $4E99: $C0
 
-    jp   func_006_6541                            ; $4E9A: $C3 $41 $65
+    jp   UpdateEntityPosWithSpeed_06              ; $4E9A: $C3 $41 $65

--- a/src/code/entities/desert_lanmola.asm
+++ b/src/code/entities/desert_lanmola.asm
@@ -346,8 +346,8 @@ func_006_57ED::
     call IncrementEntityState                     ; $5800: $CD $12 $3B
 
 jr_006_5803:
-    call func_006_6541                            ; $5803: $CD $41 $65
-    call func_006_657A                            ; $5806: $CD $7A $65
+    call UpdateEntityPosWithSpeed_06              ; $5803: $CD $41 $65
+    call AddEntityZSpeedToPos_06                  ; $5806: $CD $7A $65
     jp   label_3B39                               ; $5809: $C3 $39 $3B
 
 func_006_580C::
@@ -378,8 +378,8 @@ jr_006_582B:
     dec  [hl]                                     ; $582B: $35
 
 jr_006_582C:
-    call func_006_6541                            ; $582C: $CD $41 $65
-    call func_006_657A                            ; $582F: $CD $7A $65
+    call UpdateEntityPosWithSpeed_06              ; $582C: $CD $41 $65
+    call AddEntityZSpeedToPos_06                  ; $582F: $CD $7A $65
     jp   label_3B39                               ; $5832: $C3 $39 $3B
 
 func_006_5835::
@@ -451,8 +451,8 @@ jr_006_5887:
     dec  [hl]                                     ; $5887: $35
 
 jr_006_5888:
-    call func_006_6541                            ; $5888: $CD $41 $65
-    call func_006_657A                            ; $588B: $CD $7A $65
+    call UpdateEntityPosWithSpeed_06              ; $5888: $CD $41 $65
+    call AddEntityZSpeedToPos_06                  ; $588B: $CD $7A $65
     ld   hl, wEntitiesPosZTable                   ; $588E: $21 $10 $C3
     add  hl, bc                                   ; $5891: $09
     ld   a, [hl]                                  ; $5892: $7E
@@ -619,7 +619,7 @@ label_006_5988:
     ld   de, Data_006_5980                        ; $5988: $11 $80 $59
     call RenderActiveEntitySprite                 ; $598B: $CD $77 $3C
     call func_006_64C6                            ; $598E: $CD $C6 $64
-    call func_006_6541                            ; $5991: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $5991: $CD $41 $65
     ld   hl, wEntitiesSpeedYTable                 ; $5994: $21 $50 $C2
     add  hl, bc                                   ; $5997: $09
     inc  [hl]                                     ; $5998: $34

--- a/src/code/entities/dodongo_snake.asm
+++ b/src/code/entities/dodongo_snake.asm
@@ -140,7 +140,7 @@ jr_005_689B:
     add  hl, de                                   ; $68E9: $19
     ldh  a, [hActiveEntityVisualPosY]             ; $68EA: $F0 $EC
     ld   [hl], a                                  ; $68EC: $77
-    call func_005_7AB1                            ; $68ED: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $68ED: $CD $B1 $7A
     call label_3B23                               ; $68F0: $CD $23 $3B
     ld   e, $0F                                   ; $68F3: $1E $0F
     ld   d, b                                     ; $68F5: $50

--- a/src/code/entities/droppable_fairy.asm
+++ b/src/code/entities/droppable_fairy.asm
@@ -15,10 +15,10 @@ DroppableFairyEntityHandler::
     rlca                                          ; $6175: $07
     and  $01                                      ; $6176: $E6 $01
     call SetEntitySpriteVariant                   ; $6178: $CD $0C $3B
-    call func_003_7F25                            ; $617B: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $617B: $CD $25 $7F
     call func_003_61C0                            ; $617E: $CD $C0 $61
     call func_003_7893                            ; $6181: $CD $93 $78
-    call func_003_7ED9                            ; $6184: $CD $D9 $7E
+    call GetEntityXDistanceAwayFromLink           ; $6184: $CD $D9 $7E
     ld   a, d                                     ; $6187: $7A
     bit  7, a                                     ; $6188: $CB $7F
     jr   z, jr_003_618C                           ; $618A: $28 $00
@@ -27,7 +27,7 @@ jr_003_618C:
     cp   $20                                      ; $618C: $FE $20
     jr   c, jr_003_619C                           ; $618E: $38 $0C
 
-    call func_003_7EE9                            ; $6190: $CD $E9 $7E
+    call GetEntityYDistanceAwayFromLink           ; $6190: $CD $E9 $7E
     ld   a, d                                     ; $6193: $7A
     bit  7, a                                     ; $6194: $CB $7F
     jr   z, jr_003_6198                           ; $6196: $28 $00

--- a/src/code/entities/droppable_fairy.asm
+++ b/src/code/entities/droppable_fairy.asm
@@ -15,7 +15,7 @@ DroppableFairyEntityHandler::
     rlca                                          ; $6175: $07
     and  $01                                      ; $6176: $E6 $01
     call SetEntitySpriteVariant                   ; $6178: $CD $0C $3B
-    call UpdateEntityPosWithSpeed                 ; $617B: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $617B: $CD $25 $7F
     call func_003_61C0                            ; $617E: $CD $C0 $61
     call func_003_7893                            ; $6181: $CD $93 $78
     call GetEntityXDistanceAwayFromLink           ; $6184: $CD $D9 $7E

--- a/src/code/entities/evil_eagle.asm
+++ b/src/code/entities/evil_eagle.asm
@@ -215,7 +215,7 @@ func_005_5B38::
 func_005_5B3B::
     call func_005_5B5A                            ; $5B3B: $CD $5A $5B
     call func_005_7A3A                            ; $5B3E: $CD $3A $7A
-    call func_005_7AB1                            ; $5B41: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5B41: $CD $B1 $7A
     ld   hl, wEntitiesSpeedYTable                 ; $5B44: $21 $50 $C2
     add  hl, bc                                   ; $5B47: $09
     inc  [hl]                                     ; $5B48: $34
@@ -311,7 +311,7 @@ jr_005_5BB7:
 ._0E dw func_005_6028                             ; $5BD6
 
 func_005_5BD8::
-    call func_005_7AB1                            ; $5BD8: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5BD8: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $5BDB: $CD $05 $0C
     ret  nz                                       ; $5BDE: $C0
 
@@ -371,7 +371,7 @@ jr_005_5C25:
     ret                                           ; $5C31: $C9
 
 func_005_5C32::
-    call func_005_7AB1                            ; $5C32: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5C32: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $5C35: $CD $05 $0C
 
 jr_005_5C38:
@@ -479,7 +479,7 @@ func_005_5CB9::
     jp   SetEntitySpriteVariant                   ; $5CCC: $C3 $0C $3B
 
 func_005_5CCF::
-    call func_005_7AB1                            ; $5CCF: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5CCF: $CD $B1 $7A
     ld   hl, wEntitiesSpeedXTable                 ; $5CD2: $21 $40 $C2
     add  hl, bc                                   ; $5CD5: $09
     ld   a, [hl]                                  ; $5CD6: $7E
@@ -681,7 +681,7 @@ jr_005_5DE1:
 func_005_5DEC::
     ld   a, $01                                   ; $5DEC: $3E $01
     call SetEntitySpriteVariant                   ; $5DEE: $CD $0C $3B
-    call func_005_7AB1                            ; $5DF1: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5DF1: $CD $B1 $7A
     ld   hl, wEntitiesSpeedYTable                 ; $5DF4: $21 $50 $C2
     call func_005_5E01                            ; $5DF7: $CD $01 $5E
     ld   a, [hl]                                  ; $5DFA: $7E
@@ -909,7 +909,7 @@ Data_005_5F39::
     db   $E0, $20
 
 func_005_5F3B::
-    call func_005_7AB1                            ; $5F3B: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5F3B: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $5F3E: $CD $05 $0C
     jr   z, label_005_5F78                        ; $5F41: $28 $35
 
@@ -974,7 +974,7 @@ jr_005_5F90:
     ret                                           ; $5F92: $C9
 
 func_005_5F93::
-    call func_005_7AB1                            ; $5F93: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5F93: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $5F96: $CD $05 $0C
     jr   nz, jr_005_5FA3                          ; $5F99: $20 $08
 
@@ -989,7 +989,7 @@ Data_005_5FA6::
     db   $E0, $20
 
 func_005_5FA8::
-    call func_005_7AB1                            ; $5FA8: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $5FA8: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $5FAB: $CD $05 $0C
     jr   nz, jr_005_5FEA                          ; $5FAE: $20 $3A
 
@@ -1060,7 +1060,7 @@ jr_005_6008:
 func_005_6017::
     xor  a                                        ; $6017: $AF
     call SetEntitySpriteVariant                   ; $6018: $CD $0C $3B
-    call func_005_7AB1                            ; $601B: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $601B: $CD $B1 $7A
     call label_3B39                               ; $601E: $CD $39 $3B
     call GetEntityTransitionCountdown             ; $6021: $CD $05 $0C
     jp   z, label_005_5F78                        ; $6024: $CA $78 $5F
@@ -1100,7 +1100,7 @@ jr_005_6040:
     dec  [hl]                                     ; $6052: $35
 
 jr_005_6053:
-    call func_005_7AB1                            ; $6053: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $6053: $CD $B1 $7A
     ldh  a, [hActiveEntityVisualPosY]             ; $6056: $F0 $EC
     and  $F0                                      ; $6058: $E6 $F0
     cp   $C0                                      ; $605A: $FE $C0
@@ -1340,7 +1340,7 @@ jr_005_6298:
     ret                                           ; $6298: $C9
 
 func_005_6299::
-    call func_005_7AB1                            ; $6299: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $6299: $CD $B1 $7A
     ld   hl, wEntitiesSpeedXTable                 ; $629C: $21 $40 $C2
     add  hl, bc                                   ; $629F: $09
     ld   a, [hl]                                  ; $62A0: $7E
@@ -1372,7 +1372,7 @@ func_005_62C8::
     ld   de, Data_005_62B8                        ; $62C8: $11 $B8 $62
     call RenderActiveEntitySpritesPair            ; $62CB: $CD $C0 $3B
     call func_005_7A3A                            ; $62CE: $CD $3A $7A
-    call func_005_7AB1                            ; $62D1: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $62D1: $CD $B1 $7A
     ldh  a, [hActiveEntityState]                  ; $62D4: $F0 $F0
     JP_TABLE                                      ; $62D6
 ._00 dw func_005_62DB                             ; $62D7

--- a/src/code/entities/gel.asm
+++ b/src/code/entities/gel.asm
@@ -31,7 +31,7 @@ jr_006_7C2E:
     ld   hl, $C1AE                                ; $7C2E: $21 $AE $C1
     inc  [hl]                                     ; $7C31: $34
     call func_006_64C6                            ; $7C32: $CD $C6 $64
-    call func_006_657A                            ; $7C35: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $7C35: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $7C38: $21 $20 $C3
     add  hl, bc                                   ; $7C3B: $09
     dec  [hl]                                     ; $7C3C: $35
@@ -175,7 +175,7 @@ jr_006_7D0B:
     ld   [hl], b                                  ; $7D0E: $70
 
 func_006_7D0F::
-    call func_006_6541                            ; $7D0F: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $7D0F: $CD $41 $65
     call GetEntityPrivateCountdown1               ; $7D12: $CD $00 $0C
     ret  nz                                       ; $7D15: $C0
 

--- a/src/code/entities/genie.asm
+++ b/src/code/entities/genie.asm
@@ -176,7 +176,7 @@ jr_004_410F:
     ldh  [hLinkPositionY], a                      ; $4110: $E0 $99
     pop  af                                       ; $4112: $F1
     ldh  [hLinkPositionX], a                      ; $4113: $E0 $98
-    call func_004_6DCA                            ; $4115: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $4115: $CD $CA $6D
 
 jr_004_4118:
     call GetEntityTransitionCountdown                 ; $4118: $CD $05 $0C
@@ -275,7 +275,7 @@ jr_004_41A1:
     ld   [hl], e                                  ; $41A5: $73
 
 jr_004_41A6:
-    call func_004_6DCA                            ; $41A6: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $41A6: $CD $CA $6D
 
 jr_004_41A9:
     call label_3B23                               ; $41A9: $CD $23 $3B
@@ -401,7 +401,7 @@ jr_004_4245:
     call ApplyVectorTowardsLink_trampoline        ; $4275: $CD $AA $3B
 
 jr_004_4278:
-    call func_004_6DCA                            ; $4278: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $4278: $CD $CA $6D
     call label_3B23                               ; $427B: $CD $23 $3B
     jp   label_004_4144                           ; $427E: $C3 $44 $41
 
@@ -770,7 +770,7 @@ func_004_449F::
     ldh  [hLinkPositionY], a                      ; $44B8: $E0 $99
     ld   a, $10                                   ; $44BA: $3E $10
     call ApplyVectorTowardsLink_trampoline        ; $44BC: $CD $AA $3B
-    call func_004_6DCA                            ; $44BF: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $44BF: $CD $CA $6D
     ld   hl, hLinkPositionX                       ; $44C2: $21 $98 $FF
     ldh  a, [hActiveEntityPosX]                               ; $44C5: $F0 $EE
     sub  [hl]                                     ; $44C7: $96
@@ -846,7 +846,7 @@ func_004_4517::
 jr_004_4535:
     call func_004_6D80                            ; $4535: $CD $80 $6D
     call label_3B70                               ; $4538: $CD $70 $3B
-    call func_004_6DCA                            ; $453B: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $453B: $CD $CA $6D
     call label_3B23                               ; $453E: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $4541: $F0 $E7
     and  $03                                      ; $4543: $E6 $03
@@ -1001,7 +1001,7 @@ jr_004_45F1:
     ldh  [hLinkPositionY], a                      ; $4626: $E0 $99
     pop  af                                       ; $4628: $F1
     ldh  [hLinkPositionX], a                      ; $4629: $E0 $98
-    call func_004_6DCA                            ; $462B: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $462B: $CD $CA $6D
     call func_004_4634                            ; $462E: $CD $34 $46
     jp   label_004_4568                           ; $4631: $C3 $68 $45
 
@@ -1264,7 +1264,7 @@ GenieState3Handler::
     ld   a, [wIntroTimer]                         ; $48FD: $FA $01 $D0
     add  [hl]                                     ; $4900: $86
     ld   [hl], a                                  ; $4901: $77
-    call func_004_6DCA                            ; $4902: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $4902: $CD $CA $6D
     pop  af                                       ; $4905: $F1
     ld   hl, wEntitiesSpeedYTable                                ; $4906: $21 $50 $C2
     add  hl, bc                                   ; $4909: $09
@@ -1314,7 +1314,7 @@ GenieState4Handler::
     and  $01                                      ; $494C: $E6 $01
     call SetEntitySpriteVariant                   ; $494E: $CD $0C $3B
     call label_3B44                               ; $4951: $CD $44 $3B
-    call func_004_6DCA                            ; $4954: $CD $CA $6D
+    call UpdateEntityPosWithSpeed_04              ; $4954: $CD $CA $6D
     call func_004_6E03                            ; $4957: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                                ; $495A: $21 $20 $C3
     add  hl, bc                                   ; $495D: $09

--- a/src/code/entities/genie.asm
+++ b/src/code/entities/genie.asm
@@ -66,7 +66,7 @@ jr_004_404E:
     ld   hl, wEntitiesHitboxFlagsTable                ; $4064: $21 $50 $C3
     add  hl, bc                                   ; $4067: $09
     ld   [hl], $80                                ; $4068: $36 $80
-    call func_004_6E03                            ; $406A: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $406A: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                                ; $406D: $21 $20 $C3
     add  hl, bc                                   ; $4070: $09
     dec  [hl]                                     ; $4071: $35
@@ -1277,7 +1277,7 @@ GenieState3Handler::
     and  a                                        ; $4913: $A7
     jr   nz, jr_004_4938                          ; $4914: $20 $22
 
-    call func_004_6E03                            ; $4916: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $4916: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                                ; $4919: $21 $20 $C3
     add  hl, bc                                   ; $491C: $09
     dec  [hl]                                     ; $491D: $35
@@ -1315,7 +1315,7 @@ GenieState4Handler::
     call SetEntitySpriteVariant                   ; $494E: $CD $0C $3B
     call label_3B44                               ; $4951: $CD $44 $3B
     call UpdateEntityPosWithSpeed_04              ; $4954: $CD $CA $6D
-    call func_004_6E03                            ; $4957: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                  ; $4957: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                                ; $495A: $21 $20 $C3
     add  hl, bc                                   ; $495D: $09
     dec  [hl]                                     ; $495E: $35

--- a/src/code/entities/ghoma.asm
+++ b/src/code/entities/ghoma.asm
@@ -53,7 +53,7 @@ jr_005_7BF6:
 jr_005_7C1C:
     call BossIntro                                ; $7C1C: $CD $E8 $3E
     call label_3B39                               ; $7C1F: $CD $39 $3B
-    call func_005_7AB1                            ; $7C22: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $7C22: $CD $B1 $7A
     call label_3B23                               ; $7C25: $CD $23 $3B
     call DecrementEntityIgnoreHitsCountdown       ; $7C28: $CD $56 $0C
     ldh  a, [hActiveEntityState]                  ; $7C2B: $F0 $F0

--- a/src/code/entities/gibdo.asm
+++ b/src/code/entities/gibdo.asm
@@ -22,7 +22,7 @@ jr_006_7E91:
     call label_3B39                               ; $7E9A: $CD $39 $3B
 
 label_006_7E9D:
-    call func_006_6541                            ; $7E9D: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $7E9D: $CD $41 $65
     call label_3B23                               ; $7EA0: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $7EA3: $21 $A0 $C2
     add  hl, bc                                   ; $7EA6: $09

--- a/src/code/entities/goponga_projectile.asm
+++ b/src/code/entities/goponga_projectile.asm
@@ -73,5 +73,5 @@ jr_006_63DD:
     and  $01                                      ; $63E6: $E6 $01
     call SetEntitySpriteVariant                   ; $63E8: $CD $0C $3B
     call label_3B39                               ; $63EB: $CD $39 $3B
-    call func_006_6541                            ; $63EE: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $63EE: $CD $41 $65
     jp   func_006_5E54                            ; $63F1: $C3 $54 $5E

--- a/src/code/entities/hard_hat_beetle.asm
+++ b/src/code/entities/hard_hat_beetle.asm
@@ -17,7 +17,7 @@ jr_006_4F48:
     call func_006_64C6                            ; $4F4B: $CD $C6 $64
     call func_006_64F7                            ; $4F4E: $CD $F7 $64
     call label_3B39                               ; $4F51: $CD $39 $3B
-    call func_006_6541                            ; $4F54: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $4F54: $CD $41 $65
     call label_3B23                               ; $4F57: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $4F5A: $F0 $E7
     rra                                           ; $4F5C: $1F

--- a/src/code/entities/hinox.asm
+++ b/src/code/entities/hinox.asm
@@ -145,7 +145,7 @@ jr_006_5085:
     call ClearEntitySpeed                         ; $5090: $CD $7F $3D
 
 jr_006_5093:
-    call func_006_6541                            ; $5093: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $5093: $CD $41 $65
     call label_3B23                               ; $5096: $CD $23 $3B
 
 func_006_5099::
@@ -192,7 +192,7 @@ HinoxState3Handler::
     ld   [hl], b                                  ; $50D6: $70
 
 jr_006_50D7:
-    call func_006_6541                            ; $50D7: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $50D7: $CD $41 $65
     call label_3B23                               ; $50DA: $CD $23 $3B
     call func_006_6594                            ; $50DD: $CD $94 $65
     add  $18                                      ; $50E0: $C6 $18

--- a/src/code/entities/hookshot_chain.asm
+++ b/src/code/entities/hookshot_chain.asm
@@ -68,7 +68,7 @@ jr_018_7C21:
     jr   jr_018_7C46                              ; $7C37: $18 $0D
 
 jr_018_7C39:
-    call func_018_7E5F                            ; $7C39: $CD $5F $7E
+    call UpdateEntityPosWithSpeed_18              ; $7C39: $CD $5F $7E
     call GetEntityTransitionCountdown             ; $7C3C: $CD $05 $0C
     jr   nz, jr_018_7C54                          ; $7C3F: $20 $13
 

--- a/src/code/entities/hot_head.asm
+++ b/src/code/entities/hot_head.asm
@@ -203,8 +203,8 @@ jr_005_6443:
     ret                                           ; $6443: $C9
 
 jr_005_6444:
-    call func_005_7AB1                            ; $6444: $CD $B1 $7A
-    call func_005_7AEA                            ; $6447: $CD $EA $7A
+    call UpdateEntityPosWithSpeed_05              ; $6444: $CD $B1 $7A
+    call AddEntityZSpeedToPos_05                  ; $6447: $CD $EA $7A
     ld   hl, wEntitiesSpeedZTable                 ; $644A: $21 $20 $C3
     add  hl, bc                                   ; $644D: $09
     dec  [hl]                                     ; $644E: $35
@@ -268,7 +268,7 @@ jr_005_64A0:
     ld   a, [hl]                                  ; $64A5: $7E
     push af                                       ; $64A6: $F5
     ld   [hl], e                                  ; $64A7: $73
-    call func_005_7ABE                            ; $64A8: $CD $BE $7A
+    call AddEntitySpeedToPos_05                   ; $64A8: $CD $BE $7A
     pop  af                                       ; $64AB: $F1
     pop  hl                                       ; $64AC: $E1
     ld   [hl], a                                  ; $64AD: $77
@@ -335,7 +335,7 @@ jr_005_64F7:
     cp   $0B                                      ; $64FC: $FE $0B
     ret  nc                                       ; $64FE: $D0
 
-    call func_005_7AB1                            ; $64FF: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $64FF: $CD $B1 $7A
     call label_3B23                               ; $6502: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $6505: $21 $A0 $C2
     add  hl, bc                                   ; $6508: $09
@@ -398,7 +398,7 @@ jr_005_654C:
     ld   a, [hl]                                  ; $6551: $7E
     push af                                       ; $6552: $F5
     ld   [hl], e                                  ; $6553: $73
-    call func_005_7ABE                            ; $6554: $CD $BE $7A
+    call AddEntitySpeedToPos_05                   ; $6554: $CD $BE $7A
     pop  af                                       ; $6557: $F1
     pop  hl                                       ; $6558: $E1
     ld   [hl], a                                  ; $6559: $77
@@ -704,8 +704,8 @@ label_005_6798:
 ._01 dw func_005_67D2                             ; $67A9
 
 func_005_67AB::
-    call func_005_7AB1
-    call func_005_7AEA                            ; $67AE: $CD $EA $7A
+    call UpdateEntityPosWithSpeed_05
+    call AddEntityZSpeedToPos_05                  ; $67AE: $CD $EA $7A
     ld   hl, wEntitiesSpeedZTable                 ; $67B1: $21 $20 $C3
     add  hl, bc                                   ; $67B4: $09
     dec  [hl]                                     ; $67B5: $35
@@ -747,8 +747,8 @@ label_005_67EA:
     ld   de, Data_005_67E2                        ; $67EA: $11 $E2 $67
     call RenderActiveEntitySpritesPair            ; $67ED: $CD $C0 $3B
     call func_005_7A3A                            ; $67F0: $CD $3A $7A
-    call func_005_7AB1                            ; $67F3: $CD $B1 $7A
-    call func_005_7AEA                            ; $67F6: $CD $EA $7A
+    call UpdateEntityPosWithSpeed_05              ; $67F3: $CD $B1 $7A
+    call AddEntityZSpeedToPos_05                  ; $67F6: $CD $EA $7A
     ld   hl, wEntitiesSpeedZTable                 ; $67F9: $21 $20 $C3
     add  hl, bc                                   ; $67FC: $09
     dec  [hl]                                     ; $67FD: $35

--- a/src/code/entities/keese.asm
+++ b/src/code/entities/keese.asm
@@ -67,7 +67,7 @@ jr_006_6773:
     jp   label_006_67E6                           ; $678C: $C3 $E6 $67
 
 KeeseFlyingHandler::
-    call func_006_6541                            ; $678F: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $678F: $CD $41 $65
     call label_3B23                               ; $6792: $CD $23 $3B
     call GetEntityTransitionCountdown             ; $6795: $CD $05 $0C
     jr   nz, jr_006_67A2                          ; $6798: $20 $08

--- a/src/code/entities/kid_71_72.asm
+++ b/src/code/entities/kid_71_72.asm
@@ -21,8 +21,8 @@ Kid72EntityHandler::
     ld   de, Data_006_607D                        ; $6087: $11 $7D $60
     call RenderActiveEntitySprite                 ; $608A: $CD $77 $3C
     call func_006_64C6                            ; $608D: $CD $C6 $64
-    call func_006_6541                            ; $6090: $CD $41 $65
-    call func_006_657A                            ; $6093: $CD $7A $65
+    call UpdateEntityPosWithSpeed_06              ; $6090: $CD $41 $65
+    call AddEntityZSpeedToPos_06                  ; $6093: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $6096: $21 $20 $C3
     add  hl, bc                                   ; $6099: $09
     dec  [hl]                                     ; $609A: $35
@@ -127,7 +127,7 @@ jr_006_6110:
 jr_006_6124:
     ld   a, $08                                   ; $6124: $3E $08
     call ApplyVectorTowardsLink_trampoline        ; $6126: $CD $AA $3B
-    call func_006_6541                            ; $6129: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $6129: $CD $41 $65
     ld   a, $02                                   ; $612C: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $612E: $E0 $A1
     ld   [wC167], a                               ; $6130: $EA $67 $C1
@@ -146,7 +146,7 @@ func_006_6134::
     call_open_dialog $220                         ; $6147
 
 jr_006_614C:
-    call func_006_657A                            ; $614C: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $614C: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $614F: $21 $20 $C3
     add  hl, bc                                   ; $6152: $09
     dec  [hl]                                     ; $6153: $35
@@ -184,7 +184,7 @@ label_006_6170:
     call RenderActiveEntitySpritesPair            ; $617C: $CD $C0 $3B
     call func_006_64C6                            ; $617F: $CD $C6 $64
     call func_006_6230                            ; $6182: $CD $30 $62
-    call func_006_657A                            ; $6185: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $6185: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $6188: $21 $20 $C3
     add  hl, bc                                   ; $618B: $09
     dec  [hl]                                     ; $618C: $35

--- a/src/code/entities/madam_meow_meow.asm
+++ b/src/code/entities/madam_meow_meow.asm
@@ -29,7 +29,7 @@ jr_006_5B91:
     cp   $80                                      ; $5B9D: $FE $80
     jr   nz, jr_006_5BC4                          ; $5B9F: $20 $23
 
-    call func_006_657A                            ; $5BA1: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $5BA1: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $5BA4: $21 $20 $C3
     add  hl, bc                                   ; $5BA7: $09
     dec  [hl]                                     ; $5BA8: $35

--- a/src/code/entities/mr_write_bird.asm
+++ b/src/code/entities/mr_write_bird.asm
@@ -44,7 +44,7 @@ jr_006_7266:
     and  a                                        ; $726F: $A7
     jp   z, label_006_7372                        ; $7270: $CA $72 $73
 
-    call func_006_657A                            ; $7273: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $7273: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $7276: $21 $20 $C3
     add  hl, bc                                   ; $7279: $09
     dec  [hl]                                     ; $727A: $35
@@ -115,7 +115,7 @@ jr_006_72E0:
 
 MrWriteBirdState1Handler::
     call func_006_7335                            ; $72E3: $CD $35 $73
-    call func_006_6541                            ; $72E6: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $72E6: $CD $41 $65
     call label_3B23                               ; $72E9: $CD $23 $3B
     ldh  a, [hFFE8]                               ; $72EC: $F0 $E8
     and  a                                        ; $72EE: $A7
@@ -146,7 +146,7 @@ label_006_7308:
     jp   SetEntitySpriteVariant                   ; $730F: $C3 $0C $3B
 
 MrWriteBirdState2Handler::
-    call func_006_6541                            ; $7312: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $7312: $CD $41 $65
     call label_3B23                               ; $7315: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $7318: $F0 $E7
     and  $01                                      ; $731A: $E6 $01

--- a/src/code/entities/musical_note.asm
+++ b/src/code/entities/musical_note.asm
@@ -28,4 +28,4 @@ jr_005_7F10:
     ld   [hl], a                                  ; $7F1A: $77
 
 jr_005_7F1B:
-    jp   func_005_7AB1                            ; $7F1B: $C3 $B1 $7A
+    jp   UpdateEntityPosWithSpeed_05              ; $7F1B: $C3 $B1 $7A

--- a/src/code/entities/owl_event.asm
+++ b/src/code/entities/owl_event.asm
@@ -235,7 +235,7 @@ OwlState1Handler::
     ld   a, $05                                   ; $693B: $3E $05
     ld   [wC111], a                               ; $693D: $EA $11 $C1
     call func_006_69BD                            ; $6940: $CD $BD $69
-    call func_006_6541                            ; $6943: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $6943: $CD $41 $65
     ld   hl, wEntitiesPosZTable                   ; $6946: $21 $10 $C3
     add  hl, bc                                   ; $6949: $09
     ld   a, [hl]                                  ; $694A: $7E
@@ -248,7 +248,7 @@ jr_006_6951:
     ld   hl, wEntitiesSpeedZTable                 ; $6951: $21 $20 $C3
     add  hl, bc                                   ; $6954: $09
     ld   [hl], $FC                                ; $6955: $36 $FC
-    call func_006_657A                            ; $6957: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $6957: $CD $7A $65
     call PlayBoomerangSfx_trampoline              ; $695A: $CD $F8 $29
     ldh  a, [hFrameCounter]                       ; $695D: $F0 $E7
     and  $03                                      ; $695F: $E6 $03
@@ -322,12 +322,12 @@ func_006_69BD::
 OwlState4Handler::
     call func_006_64C6                            ; $69CA: $CD $C6 $64
     call func_006_69BD                            ; $69CD: $CD $BD $69
-    call func_006_6541                            ; $69D0: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $69D0: $CD $41 $65
     call func_006_5E54                            ; $69D3: $CD $54 $5E
     ld   hl, wEntitiesSpeedZTable                 ; $69D6: $21 $20 $C3
     add  hl, bc                                   ; $69D9: $09
     ld   [hl], $04                                ; $69DA: $36 $04
-    call func_006_657A                            ; $69DC: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $69DC: $CD $7A $65
     ld   hl, wEntitiesStatusTable                 ; $69DF: $21 $80 $C2
     add  hl, bc                                   ; $69E2: $09
     ld   a, [hl]                                  ; $69E3: $7E

--- a/src/code/entities/pols_voice.asm
+++ b/src/code/entities/pols_voice.asm
@@ -36,7 +36,7 @@ jr_006_73AD:
     call RenderActiveEntitySpritesPair            ; $73B0: $CD $C0 $3B
     call func_006_64C6                            ; $73B3: $CD $C6 $64
     call func_006_64F7                            ; $73B6: $CD $F7 $64
-    call func_006_6541                            ; $73B9: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $73B9: $CD $41 $65
     ld   hl, wEntitiesIgnoreHitsCountdownTable    ; $73BC: $21 $10 $C4
     add  hl, bc                                   ; $73BF: $09
     ld   [hl], $01                                ; $73C0: $36 $01
@@ -101,7 +101,7 @@ jr_006_741F:
     jp   SetEntitySpriteVariant                   ; $7420: $C3 $0C $3B
 
 func_006_7423::
-    call func_006_657A                            ; $7423: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $7423: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $7426: $21 $20 $C3
     add  hl, bc                                   ; $7429: $09
     dec  [hl]                                     ; $742A: $35

--- a/src/code/entities/pushed_block.asm
+++ b/src/code/entities/pushed_block.asm
@@ -26,7 +26,7 @@ PushedBlockEntityHandler::
 jr_003_525D:
     call RenderActiveEntitySpritesPair            ; $525D: $CD $C0 $3B
     call func_003_7F78                            ; $5260: $CD $78 $7F
-    call func_003_7F25                            ; $5263: $CD $25 $7F
+    call UpdateEntityPosWithSpeed                 ; $5263: $CD $25 $7F
     call func_003_52D4                            ; $5266: $CD $D4 $52
     call CheckLinkCollisionWithEnemy.collisionEvenInTheAir  ; $5269: $CD $77 $6C
     jr   nc, jr_003_5276                          ; $526C: $30 $08

--- a/src/code/entities/pushed_block.asm
+++ b/src/code/entities/pushed_block.asm
@@ -26,7 +26,7 @@ PushedBlockEntityHandler::
 jr_003_525D:
     call RenderActiveEntitySpritesPair            ; $525D: $CD $C0 $3B
     call func_003_7F78                            ; $5260: $CD $78 $7F
-    call UpdateEntityPosWithSpeed                 ; $5263: $CD $25 $7F
+    call UpdateEntityPosWithSpeed_03              ; $5263: $CD $25 $7F
     call func_003_52D4                            ; $5266: $CD $D4 $52
     call CheckLinkCollisionWithEnemy.collisionEvenInTheAir  ; $5269: $CD $77 $6C
     jr   nc, jr_003_5276                          ; $526C: $30 $08

--- a/src/code/entities/racoon.asm
+++ b/src/code/entities/racoon.asm
@@ -232,7 +232,7 @@ jr_005_4A9E:
     inc  [hl]                                     ; $4AAD: $34
 
 jr_005_4AAE:
-    call func_005_7AB1                            ; $4AAE: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $4AAE: $CD $B1 $7A
     call label_3B23                               ; $4AB1: $CD $23 $3B
     call GetEntityDropTimer                       ; $4AB4: $CD $FB $0B
     cp   $06                                      ; $4AB7: $FE $06
@@ -282,7 +282,7 @@ jr_005_4AE8:
     dec  [hl]                                     ; $4AE8: $35
 
 jr_005_4AE9:
-    jp   func_005_7AEA                            ; $4AE9: $C3 $EA $7A
+    jp   AddEntityZSpeedToPos_05                  ; $4AE9: $C3 $EA $7A
 
 jr_005_4AEC:
     ld   hl, wEntitiesCollisionsTable             ; $4AEC: $21 $A0 $C2
@@ -354,7 +354,7 @@ jr_005_4B40:
 func_005_4B41::
     ld   a, $02                                   ; $4B41: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $4B43: $E0 $A1
-    call func_005_7AEA                            ; $4B45: $CD $EA $7A
+    call AddEntityZSpeedToPos_05                  ; $4B45: $CD $EA $7A
     ld   hl, wEntitiesSpeedZTable                 ; $4B48: $21 $20 $C3
     add  hl, bc                                   ; $4B4B: $09
     dec  [hl]                                     ; $4B4C: $35
@@ -444,7 +444,7 @@ label_005_4BC1:
     ld   de, Data_005_4BBF                        ; $4BC9: $11 $BF $4B
     call RenderActiveEntitySprite                 ; $4BCC: $CD $77 $3C
     call func_005_7A3A                            ; $4BCF: $CD $3A $7A
-    call func_005_7AB1                            ; $4BD2: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $4BD2: $CD $B1 $7A
     call GetEntityTransitionCountdown             ; $4BD5: $CD $05 $0C
     jp   z, func_005_7B4B                         ; $4BD8: $CA $4B $7B
 

--- a/src/code/entities/richard.asm
+++ b/src/code/entities/richard.asm
@@ -130,7 +130,7 @@ jr_006_40E0:
     ld   hl, wEntitiesSpeedXTable                 ; $40E0: $21 $40 $C2
     add  hl, bc                                   ; $40E3: $09
     ld   [hl], $F8                                ; $40E4: $36 $F8
-    jp   func_006_654E                            ; $40E6: $C3 $4E $65
+    jp   AddEntitySpeedToPos_06                   ; $40E6: $C3 $4E $65
 
 RichardState4Handler::
     call func_006_645D                            ; $40E9: $CD $5D $64

--- a/src/code/entities/rolling_bones.asm
+++ b/src/code/entities/rolling_bones.asm
@@ -111,7 +111,7 @@ jr_006_6D08:
     ld   [hl], e                                  ; $6D0C: $73
 
 jr_006_6D0D:
-    call func_006_657A                            ; $6D0D: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $6D0D: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $6D10: $21 $20 $C3
     add  hl, bc                                   ; $6D13: $09
     dec  [hl]                                     ; $6D14: $35
@@ -174,7 +174,7 @@ jr_006_6D55:
     jp   IncrementEntityState                     ; $6D65: $C3 $12 $3B
 
 jr_006_6D68:
-    call func_006_654E                            ; $6D68: $CD $4E $65
+    call AddEntitySpeedToPos_06                   ; $6D68: $CD $4E $65
     ldh  a, [hFFE8]                               ; $6D6B: $F0 $E8
     and  a                                        ; $6D6D: $A7
     jr   z, jr_006_6D76                           ; $6D6E: $28 $06
@@ -292,7 +292,7 @@ jr_006_6DFF:
     ld   [hl], a                                  ; $6E03: $77
 
 jr_006_6E04:
-    call func_006_6541                            ; $6E04: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $6E04: $CD $41 $65
     call label_3B23                               ; $6E07: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $6E0A: $21 $A0 $C2
     add  hl, bc                                   ; $6E0D: $09

--- a/src/code/entities/rolling_bones_bar.asm
+++ b/src/code/entities/rolling_bones_bar.asm
@@ -85,7 +85,7 @@ jr_006_6F48:
     call label_3B39                               ; $6F50: $CD $39 $3B
 
 jr_006_6F53:
-    call func_006_654E                            ; $6F53: $CD $4E $65
+    call AddEntitySpeedToPos_06                   ; $6F53: $CD $4E $65
     call label_3B23                               ; $6F56: $CD $23 $3B
     ld   hl, wEntitiesSpeedXTable                 ; $6F59: $21 $40 $C2
     add  hl, bc                                   ; $6F5C: $09

--- a/src/code/entities/slime_eel.asm
+++ b/src/code/entities/slime_eel.asm
@@ -1795,7 +1795,7 @@ func_005_7ABE::
     push af                                       ; $7AC6: $F5
     swap a                                        ; $7AC7: $CB $37
     and  $F0                                      ; $7AC9: $E6 $F0
-    ld   hl, wEntitiesUnknowTableN                ; $7ACB: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXCountTable            ; $7ACB: $21 $60 $C2
     add  hl, bc                                   ; $7ACE: $09
     add  [hl]                                     ; $7ACF: $86
     ld   [hl], a                                  ; $7AD0: $77
@@ -1832,7 +1832,7 @@ func_005_7AEA::
     push af                                       ; $7AF2: $F5
     swap a                                        ; $7AF3: $CB $37
     and  $F0                                      ; $7AF5: $E6 $F0
-    ld   hl, wEntitiesUnknowTableK                ; $7AF7: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZCountTable            ; $7AF7: $21 $30 $C3
     add  hl, bc                                   ; $7AFA: $09
     add  [hl]                                     ; $7AFB: $86
     ld   [hl], a                                  ; $7AFC: $77

--- a/src/code/entities/slime_eel.asm
+++ b/src/code/entities/slime_eel.asm
@@ -1120,7 +1120,7 @@ jr_005_74C5:
     ld   hl, wEntitiesSpeedYTable                 ; $74F6: $21 $50 $C2
     add  hl, bc                                   ; $74F9: $09
     ld   [hl], a                                  ; $74FA: $77
-    call func_005_7AB1                            ; $74FB: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $74FB: $CD $B1 $7A
     ldh  a, [hLinkPositionY]                      ; $74FE: $F0 $99
     ld   hl, hActiveEntityVisualPosY              ; $7500: $21 $EC $FF
     sub  [hl]                                     ; $7503: $96
@@ -1345,7 +1345,7 @@ jr_005_7635:
     and  a                                        ; $7653: $A7
     jr   z, jr_005_765B                           ; $7654: $28 $05
 
-    call func_005_7AB1                            ; $7656: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $7656: $CD $B1 $7A
     jr   jr_005_765E                              ; $7659: $18 $03
 
 jr_005_765B:
@@ -1441,7 +1441,7 @@ Data_005_76F2::
     db   $10, $0E, $0C, $06, $00, $FA, $F4, $F2, $F0, $F2, $F4, $FA, $00, $06, $0C, $0E
 
 func_005_7702::
-    call func_005_7AB1                            ; $7702: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $7702: $CD $B1 $7A
     call label_3B44                               ; $7705: $CD $44 $3B
     call label_3B23                               ; $7708: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $770B: $21 $A0 $C2
@@ -1750,7 +1750,7 @@ jr_005_7A66:
     ld   hl, wEntitiesSpeedYTable                 ; $7A8F: $21 $50 $C2
     add  hl, bc                                   ; $7A92: $09
     ld   [hl], a                                  ; $7A93: $77
-    call func_005_7AB1                            ; $7A94: $CD $B1 $7A
+    call UpdateEntityPosWithSpeed_05              ; $7A94: $CD $B1 $7A
     ld   hl, wEntitiesUnknowTableH                ; $7A97: $21 $30 $C4
     add  hl, bc                                   ; $7A9A: $09
     ld   a, [hl]                                  ; $7A9B: $7E
@@ -1773,72 +1773,87 @@ jr_005_7AA3:
 jr_005_7AB0:
     ret                                           ; $7AB0: $C9
 
-func_005_7AB1::
-    call func_005_7ABE                            ; $7AB1: $CD $BE $7A
+UpdateEntityPosWithSpeed_05::
+    call AddEntitySpeedToPos_05                   ; $7AB1: $CD $BE $7A
 
-func_005_7AB4::
+UpdateEntityYPosWithSpeed_05::
     push bc                                       ; $7AB4: $C5
     ld   a, c                                     ; $7AB5: $79
     add  $10                                      ; $7AB6: $C6 $10
     ld   c, a                                     ; $7AB8: $4F
-    call func_005_7ABE                            ; $7AB9: $CD $BE $7A
+    call AddEntitySpeedToPos_05                   ; $7AB9: $CD $BE $7A
     pop  bc                                       ; $7ABC: $C1
     ret                                           ; $7ABD: $C9
 
-func_005_7ABE::
+; Update the entity's position using its speed.
+;
+; The low nibble of the value in the entity speed tables is the
+; number of pixels to move within 16 frames. For example, if it's
+; 8, the entity will move 1 pixel every other frame (8/16).
+;
+; The high nibble of the value is the number of pixels to normally
+; move, in addition to the carry from the SpeedAccTables.
+;
+; Inputs:
+;   bc  entity index
+AddEntitySpeedToPos_05::
     ld   hl, wEntitiesSpeedXTable                 ; $7ABE: $21 $40 $C2
     add  hl, bc                                   ; $7AC1: $09
     ld   a, [hl]                                  ; $7AC2: $7E
     and  a                                        ; $7AC3: $A7
-    jr   z, jr_005_7AE9                           ; $7AC4: $28 $23
+    ; No need to update the position if it's not moving
+    jr   z, .return                               ; $7AC4: $28 $23
 
     push af                                       ; $7AC6: $F5
     swap a                                        ; $7AC7: $CB $37
     and  $F0                                      ; $7AC9: $E6 $F0
-    ld   hl, wEntitiesSpeedXCountTable            ; $7ACB: $21 $60 $C2
+    ld   hl, wEntitiesSpeedXAccTable              ; $7ACB: $21 $60 $C2
     add  hl, bc                                   ; $7ACE: $09
     add  [hl]                                     ; $7ACF: $86
     ld   [hl], a                                  ; $7AD0: $77
+    ; Save carry in bit 0 of d
     rl   d                                        ; $7AD1: $CB $12
     ld   hl, wEntitiesPosXTable                   ; $7AD3: $21 $00 $C2
 
-jr_005_7AD6:
+.updatePosition
     add  hl, bc                                   ; $7AD6: $09
     pop  af                                       ; $7AD7: $F1
+    ; Sign extension for high nibble
     ld   e, $00                                   ; $7AD8: $1E $00
     bit  7, a                                     ; $7ADA: $CB $7F
-    jr   z, jr_005_7AE0                           ; $7ADC: $28 $02
+    jr   z, .positive                             ; $7ADC: $28 $02
 
     ld   e, $F0                                   ; $7ADE: $1E $F0
 
-jr_005_7AE0:
+.positive
     swap a                                        ; $7AE0: $CB $37
     and  $0F                                      ; $7AE2: $E6 $0F
     or   e                                        ; $7AE4: $B3
+    ; Get carry back from d
     rr   d                                        ; $7AE5: $CB $1A
     adc  [hl]                                     ; $7AE7: $8E
     ld   [hl], a                                  ; $7AE8: $77
 
-jr_005_7AE9:
+.return
     ret                                           ; $7AE9: $C9
 
-func_005_7AEA::
+AddEntityZSpeedToPos_05::
     ld   hl, wEntitiesSpeedZTable                 ; $7AEA: $21 $20 $C3
     add  hl, bc                                   ; $7AED: $09
     ld   a, [hl]                                  ; $7AEE: $7E
     and  a                                        ; $7AEF: $A7
-    jr   z, jr_005_7AE9                           ; $7AF0: $28 $F7
+    jr   z, AddEntitySpeedToPos_05.return         ; $7AF0: $28 $F7
 
     push af                                       ; $7AF2: $F5
     swap a                                        ; $7AF3: $CB $37
     and  $F0                                      ; $7AF5: $E6 $F0
-    ld   hl, wEntitiesSpeedZCountTable            ; $7AF7: $21 $30 $C3
+    ld   hl, wEntitiesSpeedZAccTable              ; $7AF7: $21 $30 $C3
     add  hl, bc                                   ; $7AFA: $09
     add  [hl]                                     ; $7AFB: $86
     ld   [hl], a                                  ; $7AFC: $77
     rl   d                                        ; $7AFD: $CB $12
     ld   hl, wEntitiesPosZTable                   ; $7AFF: $21 $10 $C3
-    jr   jr_005_7AD6                              ; $7B02: $18 $D2
+    jr   AddEntitySpeedToPos_05.updatePosition    ; $7B02: $18 $D2
 
 func_005_7B04::
     ld   e, $00                                   ; $7B04: $1E $00

--- a/src/code/entities/slime_eye.asm
+++ b/src/code/entities/slime_eye.asm
@@ -124,7 +124,7 @@ jr_004_4A2C:
 SlimeEyeState1Handler::
     call func_004_4DB5                            ; $4A2D: $CD $B5 $4D
     call func_004_7FA3                            ; $4A30: $CD $A3 $7F
-    call func_004_6E03                            ; $4A33: $CD $03 $6E
+    call AddEntityZSpeedToPos_04                            ; $4A33: $CD $03 $6E
     ld   hl, wEntitiesSpeedZTable                                ; $4A36: $21 $20 $C3
     add  hl, bc                                   ; $4A39: $09
     ld   a, [hl]                                  ; $4A3A: $7E

--- a/src/code/entities/smasher.asm
+++ b/src/code/entities/smasher.asm
@@ -42,7 +42,7 @@ jr_006_453F:
     call func_006_64C6                            ; $454C: $CD $C6 $64
     call func_006_64F7                            ; $454F: $CD $F7 $64
     call label_3B39                               ; $4552: $CD $39 $3B
-    call func_006_657A                            ; $4555: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $4555: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $4558: $21 $20 $C3
     add  hl, bc                                   ; $455B: $09
     dec  [hl]                                     ; $455C: $35
@@ -93,7 +93,7 @@ SmasherState0Handler::
     ldh  [hLinkPositionY], a                      ; $459D: $E0 $99
     ld   a, $10                                   ; $459F: $3E $10
     call ApplyVectorTowardsLink_trampoline        ; $45A1: $CD $AA $3B
-    call func_006_6541                            ; $45A4: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $45A4: $CD $41 $65
     call label_3B23                               ; $45A7: $CD $23 $3B
     call func_006_6594                            ; $45AA: $CD $94 $65
     ld   hl, wEntitiesDirectionTable              ; $45AD: $21 $80 $C3
@@ -194,7 +194,7 @@ jr_006_4614:
     ld   [hl], a                                  ; $463D: $77
 
 jr_006_463E:
-    call func_006_6541                            ; $463E: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $463E: $CD $41 $65
     call label_3B23                               ; $4641: $CD $23 $3B
     call func_006_45E5                            ; $4644: $CD $E5 $45
     ldh  a, [hFrameCounter]                       ; $4647: $F0 $E7
@@ -314,7 +314,7 @@ jr_006_46FB:
     add  hl, bc                                   ; $4709: $09
     ld   [hl], e                                  ; $470A: $73
     call func_006_46BD                            ; $470B: $CD $BD $46
-    call func_006_6541                            ; $470E: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $470E: $CD $41 $65
     jp   label_3B23                               ; $4711: $C3 $23 $3B
 
 SmasherState4Handler::
@@ -369,8 +369,8 @@ label_006_4781:
     call func_006_64C6                            ; $4793: $CD $C6 $64
     call DecrementEntityIgnoreHitsCountdown       ; $4796: $CD $56 $0C
     call label_3B70                               ; $4799: $CD $70 $3B
-    call func_006_6541                            ; $479C: $CD $41 $65
-    call func_006_657A                            ; $479F: $CD $7A $65
+    call UpdateEntityPosWithSpeed_06              ; $479C: $CD $41 $65
+    call AddEntityZSpeedToPos_06                  ; $479F: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $47A2: $21 $20 $C3
     add  hl, bc                                   ; $47A5: $09
     dec  [hl]                                     ; $47A6: $35

--- a/src/code/entities/spark.asm
+++ b/src/code/entities/spark.asm
@@ -23,7 +23,7 @@ SparkCounterClockwiseEntityHandler::
     call func_006_64C6                            ; $6646: $CD $C6 $64
     call func_006_64F7                            ; $6649: $CD $F7 $64
     call label_3B44                               ; $664C: $CD $44 $3B
-    call func_006_6541                            ; $664F: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $664F: $CD $41 $65
     call func_006_66CC                            ; $6652: $CD $CC $66
     ld   hl, wEntitiesPrivateState1Table          ; $6655: $21 $B0 $C2
     add  hl, bc                                   ; $6658: $09

--- a/src/code/entities/spike_trap.asm
+++ b/src/code/entities/spike_trap.asm
@@ -105,7 +105,7 @@ jr_006_759A:
     jp   IncrementEntityState                     ; $759E: $C3 $12 $3B
 
 SpikeTrapState2Handler::
-    call func_006_6541                            ; $75A1: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $75A1: $CD $41 $65
     call GetEntityTransitionCountdown             ; $75A4: $CD $05 $0C
     jr   nz, jr_006_75B5                          ; $75A7: $20 $0C
 
@@ -146,7 +146,7 @@ SpikeTrapState3Handler::
     ld   hl, wEntitiesSpeedYTable                 ; $75DB: $21 $50 $C2
     add  hl, bc                                   ; $75DE: $09
     ld   [hl], a                                  ; $75DF: $77
-    call func_006_6541                            ; $75E0: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $75E0: $CD $41 $65
     ld   hl, wEntitiesPrivateState1Table          ; $75E3: $21 $B0 $C2
     add  hl, bc                                   ; $75E6: $09
     ld   a, [hl]                                  ; $75E7: $7E

--- a/src/code/entities/stalfos_aggressive.asm
+++ b/src/code/entities/stalfos_aggressive.asm
@@ -57,7 +57,7 @@ jr_006_4AEC:
     call IncrementEntityState                     ; $4B09: $CD $12 $3B
 
 jr_006_4B0C:
-    call func_006_6541                            ; $4B0C: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $4B0C: $CD $41 $65
     call label_3B23                               ; $4B0F: $CD $23 $3B
     ldh  a, [hFrameCounter]                       ; $4B12: $F0 $E7
     rra                                           ; $4B14: $1F
@@ -66,9 +66,9 @@ jr_006_4B0C:
     jp   SetEntitySpriteVariant                   ; $4B18: $C3 $0C $3B
 
 StalfosAggressiveState2Handler::
-    call func_006_6541                            ; $4B1B: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $4B1B: $CD $41 $65
     call label_3B23                               ; $4B1E: $CD $23 $3B
-    call func_006_657A                            ; $4B21: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $4B21: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $4B24: $21 $20 $C3
     add  hl, bc                                   ; $4B27: $09
     dec  [hl]                                     ; $4B28: $35
@@ -91,7 +91,7 @@ StalfosAggressiveState3Handler::
     call GetEntityTransitionCountdown             ; $4B41: $CD $05 $0C
     ret  nz                                       ; $4B44: $C0
 
-    call func_006_657A                            ; $4B45: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $4B45: $CD $7A $65
     ld   hl, wEntitiesPosZTable                   ; $4B48: $21 $10 $C3
     add  hl, bc                                   ; $4B4B: $09
     ld   a, [hl]                                  ; $4B4C: $7E

--- a/src/code/entities/tektite.asm
+++ b/src/code/entities/tektite.asm
@@ -15,7 +15,7 @@ jr_006_78CD:
     call func_006_64C6                            ; $78CD: $CD $C6 $64
     call func_006_64F7                            ; $78D0: $CD $F7 $64
     call label_3B39                               ; $78D3: $CD $39 $3B
-    call func_006_6541                            ; $78D6: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $78D6: $CD $41 $65
     call label_3B23                               ; $78D9: $CD $23 $3B
     ld   hl, wEntitiesCollisionsTable             ; $78DC: $21 $A0 $C2
     add  hl, bc                                   ; $78DF: $09
@@ -58,7 +58,7 @@ jr_006_78F0:
     jp   SetEntitySpriteVariant                   ; $7915: $C3 $0C $3B
 
 jr_006_7918:
-    call func_006_657A                            ; $7918: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $7918: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $791B: $21 $20 $C3
     add  hl, bc                                   ; $791E: $09
     dec  [hl]                                     ; $791F: $35
@@ -87,7 +87,7 @@ jr_006_7921:
     ld   hl, wEntitiesSpeedZTable                 ; $7941: $21 $20 $C3
     add  hl, bc                                   ; $7944: $09
     ld   [hl], a                                  ; $7945: $77
-    call func_006_657A                            ; $7946: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $7946: $CD $7A $65
     call GetRandomByte                            ; $7949: $CD $0D $28
     and  $03                                      ; $794C: $E6 $03
     ld   e, a                                     ; $794E: $5F

--- a/src/code/entities/three_of_a_kind.asm
+++ b/src/code/entities/three_of_a_kind.asm
@@ -10,7 +10,7 @@ ThreeOfAKindEntityHandler::
     call RenderActiveEntitySpritesPair            ; $493A: $CD $C0 $3B
     call func_006_64C6                            ; $493D: $CD $C6 $64
     call DecrementEntityIgnoreHitsCountdown       ; $4940: $CD $56 $0C
-    call func_006_6541                            ; $4943: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $4943: $CD $41 $65
     call label_3B23                               ; $4946: $CD $23 $3B
     ldh  a, [hActiveEntityState]                  ; $4949: $F0 $F0
     JP_TABLE                                      ; $494B

--- a/src/code/entities/wizrobe.asm
+++ b/src/code/entities/wizrobe.asm
@@ -19,7 +19,7 @@ WizrobeEntityHandler::
     call RenderActiveEntitySpritesPair            ; $762B: $CD $C0 $3B
     call func_006_64C6                            ; $762E: $CD $C6 $64
     call func_006_64F7                            ; $7631: $CD $F7 $64
-    call func_006_6541                            ; $7634: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $7634: $CD $41 $65
     call label_3B23                               ; $7637: $CD $23 $3B
     ld   hl, wEntitiesStateTable                  ; $763A: $21 $90 $C2
     add  hl, bc                                   ; $763D: $09

--- a/src/code/entities/wizrobe_projectile.asm
+++ b/src/code/entities/wizrobe_projectile.asm
@@ -13,7 +13,7 @@ WizrobeProjectileEntityHandler::
     call RenderActiveEntitySpritesPair            ; $65FC: $CD $C0 $3B
     call func_006_64C6                            ; $65FF: $CD $C6 $64
     call CheckLinkCollisionWithProjectile_trampoline; $6602: $CD $4F $3B
-    call func_006_6541                            ; $6605: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $6605: $CD $41 $65
     call label_3B2E                               ; $6608: $CD $2E $3B
     ld   hl, wEntitiesCollisionsTable             ; $660B: $21 $A0 $C2
     add  hl, bc                                   ; $660E: $09

--- a/src/code/entities/yip_yip.asm
+++ b/src/code/entities/yip_yip.asm
@@ -74,7 +74,7 @@ jr_006_5A43:
     call RenderActiveEntitySpritesPair            ; $5A43: $CD $C0 $3B
     call func_006_64C6                            ; $5A46: $CD $C6 $64
     call DecrementEntityIgnoreHitsCountdown       ; $5A49: $CD $56 $0C
-    call func_006_657A                            ; $5A4C: $CD $7A $65
+    call AddEntityZSpeedToPos_06                  ; $5A4C: $CD $7A $65
     ld   hl, wEntitiesSpeedZTable                 ; $5A4F: $21 $20 $C3
     add  hl, bc                                   ; $5A52: $09
     dec  [hl]                                     ; $5A53: $35
@@ -217,7 +217,7 @@ jr_006_5B27:
     jp   label_006_5B4C                           ; $5B27: $C3 $4C $5B
 
 YipYipState1Handler::
-    call func_006_6541                            ; $5B2A: $CD $41 $65
+    call UpdateEntityPosWithSpeed_06              ; $5B2A: $CD $41 $65
     call label_3B23                               ; $5B2D: $CD $23 $3B
     ldh  a, [hFFE8]                               ; $5B30: $F0 $E8
     and  a                                        ; $5B32: $A7

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -432,15 +432,17 @@ wEntitiesPosYSignTable:: ; C230
   ds $10
 
 wEntitiesSpeedXTable:: ; C240
-  ; X Velocity / 16 of visible entities. Value is the number of pixels to move
-  ; within 16 frames. For example, if it's 8, the entity will move 1 pixel every
-  ; other frame (8/16).
+  ; X Velocity of visible entities
+  ;
+  ; bits 0-3: Number of pixels to move every 16 frames
+  ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
   ds $10
 
 wEntitiesSpeedYTable:: ; C250
-  ; Y Velocity / 16 of visible entities. Value is the number of pixels to move
-  ; within 16 frames. For example, if it's 8, the entity will move 1 pixel every
-  ; other frame (8/16).
+  ; Y Velocity of visible entities
+  ;
+  ; bits 0-3: Number of pixels to move every 16 frames
+  ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
   ds $10
 
 wEntitiesSpeedXCountTable:: ; C260
@@ -520,10 +522,10 @@ wEntitiesPosZTable:: ; C310
   ds $10
 
 wEntitiesSpeedZTable:: ; C320
-  ; Z Velocity / 16 of visible entities. Value is the number of pixels to move
-  ; within 16 frames. For example, if it's 8, the entity will move 1 pixel every
-  ; other frame (8/16).
-  ; Positive numbers increase the altitude, negative numbers decrease it
+  ; Z Velocity of visible entities
+  ;
+  ; bits 0-3: Number of pixels to move every 16 frames
+  ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
   ds $10
 
 wEntitiesSpeedZCountTable:: ; C330

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -445,14 +445,14 @@ wEntitiesSpeedYTable:: ; C250
   ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
   ds $10
 
-wEntitiesSpeedXCountTable:: ; C260
+wEntitiesSpeedXAccTable:: ; C260
   ; Used as a way to give entities speeds divided by 16. (EntitySpeedX * 16) is
-  ; added to EntitySpeedXCount and the carry is used to move the entity.
+  ; added to EntitySpeedXAcc and the carry is used to move the entity.
   ds $10
 
-wEntitiesSpeedYCountTable:: ; C270
+wEntitiesSpeedYAccTable:: ; C270
   ; Used as a way to give entities speeds divided by 16. (EntitySpeedY * 16) is
-  ; added to EntitySpeedYCount and the carry is used to move the entity.
+  ; added to EntitySpeedYAcc and the carry is used to move the entity.
   ds $10
 
 wEntitiesStatusTable:: ; C280
@@ -528,7 +528,9 @@ wEntitiesSpeedZTable:: ; C320
   ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
   ds $10
 
-wEntitiesSpeedZCountTable:: ; C330
+wEntitiesSpeedZAccTable:: ; C330
+  ; Used as a way to give entities speeds divided by 16. (EntitySpeedZ * 16) is
+  ; added to EntitySpeedZAcc and the carry is used to move the entity.
   ds $10
 
 wEntitiesPhysicsFlagsTable:: ; C340

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -432,23 +432,25 @@ wEntitiesPosYSignTable:: ; C230
   ds $10
 
 wEntitiesSpeedXTable:: ; C240
-  ; X Velocity of visible entities
+  ; X Velocity / 16 of visible entities. Value is the number of pixels to move
+  ; within 16 frames. For example, if it's 8, the entity will move 1 pixel every
+  ; other frame (8/16).
   ds $10
 
 wEntitiesSpeedYTable:: ; C250
-  ; X Velocity of visible entities
+  ; Y Velocity / 16 of visible entities. Value is the number of pixels to move
+  ; within 16 frames. For example, if it's 8, the entity will move 1 pixel every
+  ; other frame (8/16).
   ds $10
 
-wEntitiesUnknowTableN:: ; C260
-  ; Unlabeled entity attributes table
-  ; Related to speed X: many code occurence do somethinkg like:
-  ;   [wEntitiesUnknowTableN + entity index] = [wEntitiesUnknowTableN + entity index] + (EntitySpeedX * 16)
+wEntitiesSpeedXCountTable:: ; C260
+  ; Used as a way to give entities speeds divided by 16. (EntitySpeedX * 16) is
+  ; added to EntitySpeedXCount and the carry is used to move the entity.
   ds $10
 
-wEntitiesUnknowTableO:: ; C270
-  ; Unlabeled entity attributes table
-  ; Related to speed Y: many code occurence do somethinkg like:
-  ;   [wEntitiesUnknowTableN + entity index] = [wEntitiesUnknowTableN + entity index] + (EntitySpeedY * 16)
+wEntitiesSpeedYCountTable:: ; C270
+  ; Used as a way to give entities speeds divided by 16. (EntitySpeedY * 16) is
+  ; added to EntitySpeedYCount and the carry is used to move the entity.
   ds $10
 
 wEntitiesStatusTable:: ; C280
@@ -518,10 +520,13 @@ wEntitiesPosZTable:: ; C310
   ds $10
 
 wEntitiesSpeedZTable:: ; C320
+  ; Z Velocity / 16 of visible entities. Value is the number of pixels to move
+  ; within 16 frames. For example, if it's 8, the entity will move 1 pixel every
+  ; other frame (8/16).
   ; Positive numbers increase the altitude, negative numbers decrease it
   ds $10
 
-wEntitiesUnknowTableK:: ; C330
+wEntitiesSpeedZCountTable:: ; C330
   ds $10
 
 wEntitiesPhysicsFlagsTable:: ; C340


### PR DESCRIPTION
I updated some labels and added some comments for the code to update an entity's position using its speed and the code to move an entity towards Link. I'm not able to build on Windows so I'm just hoping I didn't miss any references to the old labels...

I only labelled and added comments to the copy of the speed code in bank 3. I'm not sure how to label the other copies of that code in the other banks. Maybe add the bank number it's in at the end of the label?

The entity's speed &times; 16 is added to the value in `wEntitiesUnknowTableN`, `wEntitiesUnknowTableO`, or `wEntitiesUnknowTableK`. The entity does not move unless the addition sets the carry flag (or in the case of a negative speed, it's the other way around). So I decided to rename them to `wEntitiesSpeedXCountTable`, `wEntitiesSpeedYCountTable`, and `wEntitiesSpeedZCountTable`. Are these fitting names?