### PR TITLE
Document entity speed

### DIFF
--- a/src/code/bank27.asm
+++ b/src/code/bank27.asm
@@ -745,12 +745,10 @@ UpdateEntityPosWithSpeed_27::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -6620,12 +6620,10 @@ UpdateEntityYPosWithSpeed_17::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -7627,12 +7627,10 @@ UpdateEntityYPosWithSpeed_15::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -8762,12 +8762,10 @@ UpdateEntityYPosWithSpeed_18::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -8170,12 +8170,10 @@ UpdateEntityYPosWithSpeed_19::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -9471,12 +9471,10 @@ UpdateEntityPosWithSpeed_03::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -7009,12 +7009,10 @@ UpdateEntityPosWithSpeed_36::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -5054,12 +5054,10 @@ UpdateEntityYPosWithSpeed_04::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -262,12 +262,10 @@ UpdateEntityPosWithSpeed_06::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -9494,12 +9494,10 @@ UpdateEntityPosWithSpeed_07::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/code/entities/slime_eel.asm
+++ b/src/code/entities/slime_eel.asm
@@ -1787,12 +1787,10 @@ UpdateEntityYPosWithSpeed_05::
 
 ; Update the entity's position using its speed.
 ;
-; The low nibble of the value in the entity speed tables is the
-; number of pixels to move within 16 frames. For example, if it's
-; 8, the entity will move 1 pixel every other frame (8/16).
-;
-; The high nibble of the value is the number of pixels to normally
-; move, in addition to the carry from the SpeedAccTables.
+; The values in the entity speed tables are the number of pixels to
+; move within 16 frames. For example, if it's 8, the entity will move
+; 1 pixel every other frame (8/16). If it's -16, the entity will move
+; -1 pixel every frame (-16/16).
 ;
 ; Inputs:
 ;   bc  entity index

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -432,17 +432,17 @@ wEntitiesPosYSignTable:: ; C230
   ds $10
 
 wEntitiesSpeedXTable:: ; C240
-  ; X Velocity of visible entities
+  ; X Velocity of visible entities / 16.
   ;
-  ; bits 0-3: Number of pixels to move every 16 frames
-  ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
+  ; The entity will move this number of pixels every 16 frames. For example, if it's 8,
+  ; the entity will move 1 pixel every other frame (8/16).
   ds $10
 
 wEntitiesSpeedYTable:: ; C250
-  ; Y Velocity of visible entities
+  ; Y Velocity of visible entities / 16.
   ;
-  ; bits 0-3: Number of pixels to move every 16 frames
-  ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
+  ; The entity will move this number of pixels every 16 frames. For example, if it's 8,
+  ; the entity will move 1 pixel every other frame (8/16).
   ds $10
 
 wEntitiesSpeedXAccTable:: ; C260
@@ -522,10 +522,10 @@ wEntitiesPosZTable:: ; C310
   ds $10
 
 wEntitiesSpeedZTable:: ; C320
-  ; Z Velocity of visible entities
+  ; Z Velocity of visible entities / 16.
   ;
-  ; bits 0-3: Number of pixels to move every 16 frames
-  ; bits 4-7: Number of pixels to move every frame, plus value calculated from low nibble
+  ; The entity will move this number of pixels every 16 frames. For example, if it's 8,
+  ; the entity will move 1 pixel every other frame (8/16).
   ds $10
 
 wEntitiesSpeedZAccTable:: ; C330


### PR DESCRIPTION
I've been thinking about it and it makes more sense for the entity speeds to be thought of as plain pixel speeds divided over 16 frames, and not 2 different values for the 2 nibbles. For example, if you take a look at `GetVectorTowardsLink`, the delta X and Y are divided normally without anything to deal with the 2 nibbles, and after the routine returns, the results in `hScratch0` and `hScratch1` are written directly to the speed tables without any modification (except for when they're negated in some places). I probably just thought this at first because the nibbles are handled differently in `AddEntitySpeedToPos`, but that's only because it's dividing by 16.

All I changed are some comments.