### PR TITLE
Label the palette color memory locations.

### DIFF
--- a/revisions/J0/src/data/backgrounds/background_tile_commands.asm
+++ b/revisions/J0/src/data/backgrounds/background_tile_commands.asm
@@ -1,7 +1,7 @@
 ; File generated automatically by `tools/generate_background_data.py`
 
 
-BackgroundTileCommands24 ; $4DD4
+BackgroundTileCommands24:: ; $4DD4
   db    $9B, $E0, $53, $7C ; draw row of 20x the same tile
   db    $98, $00, $53, $7C ; draw row of 20x the same tile
   db    $98, $20, $53, $7C ; draw row of 20x the same tile

--- a/src/code/background_colors.asm
+++ b/src/code/background_colors.asm
@@ -134,9 +134,9 @@ jr_024_7436:
     and  $01                                      ; $7456: $E6 $01
     swap a                                        ; $7458: $CB $37
 
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $745A: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a ; $745A: $EA $D3 $DD
     ld   a, $10                                   ; $745D: $3E $10
-    ld   [wPaletteParticalCopyColorCount], a      ; $745F: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a      ; $745F: $EA $D4 $DD
     ld   a, $81                                   ; $7462: $3E $81
     ld   [wPaletteDataFlags], a                    ; $7464: $EA $D1 $DD
     ld   a, [wDDD6]                               ; $7467: $FA $D6 $DD

--- a/src/code/background_colors.asm
+++ b/src/code/background_colors.asm
@@ -70,12 +70,12 @@ include "data/backgrounds/attributes.asm"
 include "data/backgrounds/palette_pointers.asm"
 
 BGPaletteDestinationsTable::
-    dw   $DC10                                    ; $73F9
-    dw   $DC30                                    ; $73FB
-    dw   $DC10                                    ; $73FD
-    dw   $DC30                                    ; $73FF
-    dw   $DC10                                    ; $7401
-    dw   $DC30                                    ; $7403
+    dw   wBGPal1                                  ; $73F9
+    dw   wBGPal5                                  ; $73FB
+    dw   wBGPal1                                  ; $73FD
+    dw   wBGPal5                                  ; $73FF
+    dw   wBGPal1                                  ; $7401
+    dw   wBGPal5                                  ; $7403
 
 LoadBGPalettes::
     ld   a, [wIsIndoor]                           ; $7405: $FA $A5 $DB
@@ -134,9 +134,9 @@ jr_024_7436:
     and  $01                                      ; $7456: $E6 $01
     swap a                                        ; $7458: $CB $37
 
-    ld   [wPaletteUnknownC], a                    ; $745A: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $745A: $EA $D3 $DD
     ld   a, $10                                   ; $745D: $3E $10
-    ld   [wPaletteUnknownD], a                    ; $745F: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $745F: $EA $D4 $DD
     ld   a, $81                                   ; $7462: $3E $81
     ld   [wPaletteDataFlags], a                    ; $7464: $EA $D1 $DD
     ld   a, [wDDD6]                               ; $7467: $FA $D6 $DD

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -477,9 +477,9 @@ func_036_703E_trampoline::
     callsb func_036_703E                          ; $0AC7: $3E $36 $EA $00 $21 $CD $3E $70
     jp   RestoreStackedBankAndReturn              ; $0ACF: $C3 $73 $09
 
-func_036_70D6_trampoline::
+cycleInstrumentItemColor_trampoline::
     push af                                       ; $0AD2: $F5
-    callsb func_036_70D6                          ; $0AD3: $3E $36 $EA $00 $21 $CD $D6 $70
+    callsb cycleInstrumentItemColor               ; $0AD3: $3E $36 $EA $00 $21 $CD $D6 $70
     jp   RestoreStackedBankAndReturn              ; $0ADB: $C3 $73 $09
 
 func_036_4A77_trampoline::

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -748,7 +748,7 @@ FileSaveFadeOut::
     ldh  a, [hIsGBC]                              ; $582F: $F0 $FE
     and  a                                        ; $5831: $A7
     jr   z, jr_001_5854                           ; $5832: $28 $20
-    ld   hl, wDC10                                ; $5834: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $5834: $21 $10 $DC
     ld   c, $80                                   ; $5837: $0E $80
     di                                            ; $5839: $F3
 
@@ -2335,7 +2335,7 @@ PeachPictureState0Handler::
     ldh  a, [hIsGBC]                              ; $680B: $F0 $FE
     and  a                                        ; $680D: $A7
     jr   z, PeachPictureState1Handler             ; $680E: $28 $19
-    ld   hl, wDC10                                ; $6810: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6810: $21 $10 $DC
     ld   c, $80                                   ; $6813: $0E $80
     di                                            ; $6815: $F3
 

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -355,7 +355,7 @@ func_014_4BA7::
     jr   z, jr_014_4BBE                           ; $4BAD: $28 $0F
 
     ld   de, Data_014_4B8F                        ; $4BAF: $11 $8F $4B
-    ld   hl, wDC10                                ; $4BB2: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $4BB2: $21 $10 $DC
     ld   b, $40                                   ; $4BB5: $06 $40
     call func_014_4BDA                            ; $4BB7: $CD $DA $4B
     ld   a, $01                                   ; $4BBA: $3E $01
@@ -363,11 +363,11 @@ func_014_4BA7::
 
 jr_014_4BBE:
     ld   de, Data_014_4B97                        ; $4BBE: $11 $97 $4B
-    ld   hl, wDC50                                ; $4BC1: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $4BC1: $21 $50 $DC
     ld   b, $20                                   ; $4BC4: $06 $20
     call func_014_4BDA                            ; $4BC6: $CD $DA $4B
     ld   de, Data_014_4B9F                        ; $4BC9: $11 $9F $4B
-    ld   hl, wDC70                                ; $4BCC: $21 $70 $DC
+    ld   hl, wObjPal5                             ; $4BCC: $21 $70 $DC
     ld   b, $20                                   ; $4BCF: $06 $20
     call func_014_4BDA                            ; $4BD1: $CD $DA $4B
     ld   a, $02                                   ; $4BD4: $3E $02
@@ -406,13 +406,13 @@ func_014_4BEF::
 
     jr   z, jr_014_4C04                           ; $4BF8: $28 $0A
 
-    ld   hl, wDC10                                ; $4BFA: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $4BFA: $21 $10 $DC
     call func_014_4C10                            ; $4BFD: $CD $10 $4C
     ld   a, $01                                   ; $4C00: $3E $01
     jr   jr_014_4BD6                              ; $4C02: $18 $D2
 
 jr_014_4C04:
-    ld   hl, wDC50                                ; $4C04: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $4C04: $21 $50 $DC
     call func_014_4C10                            ; $4C07: $CD $10 $4C
     ld   a, $02                                   ; $4C0A: $3E $02
     ld   [wPaletteDataFlags], a                   ; $4C0C: $EA $D1 $DD
@@ -646,9 +646,9 @@ jr_014_4D4A:
     ld   a, [wDDD7]                               ; $4D4A: $FA $D7 $DD
     xor  $01                                      ; $4D4D: $EE $01
     swap a                                        ; $4D4F: $CB $37
-    ld   [wPaletteUnknownC], a                    ; $4D51: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $4D51: $EA $D3 $DD
     ld   a, $10                                   ; $4D54: $3E $10
-    ld   [wPaletteUnknownD], a                    ; $4D56: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $4D56: $EA $D4 $DD
     ld   a, $81                                   ; $4D59: $3E $81
     ld   [wPaletteDataFlags], a                   ; $4D5B: $EA $D1 $DD
     ld   a, [wDDD7]                               ; $4D5E: $FA $D7 $DD

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -646,9 +646,9 @@ jr_014_4D4A:
     ld   a, [wDDD7]                               ; $4D4A: $FA $D7 $DD
     xor  $01                                      ; $4D4D: $EE $01
     swap a                                        ; $4D4F: $CB $37
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $4D51: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $4D51: $EA $D3 $DD
     ld   a, $10                                   ; $4D54: $3E $10
-    ld   [wPaletteParticalCopyColorCount], a      ; $4D56: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $4D56: $EA $D4 $DD
     ld   a, $81                                   ; $4D59: $3E $81
     ld   [wPaletteDataFlags], a                   ; $4D5B: $EA $D1 $DD
     ld   a, [wDDD7]                               ; $4D5E: $FA $D7 $DD

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -2038,7 +2038,7 @@ jr_002_4DCB:
 func_002_4DFC::
     push bc                                       ; $4DFC: $C5
     push de                                       ; $4DFD: $D5
-    ld   hl, wDC50                                ; $4DFE: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $4DFE: $21 $50 $DC
     ld   c, $00                                   ; $4E01: $0E $00
     di                                            ; $4E03: $F3
 
@@ -2072,7 +2072,7 @@ func_002_4E2C::
     di                                            ; $4E2D: $F3
     ld   hl, Data_002_4E1C                        ; $4E2E: $21 $1C $4E
     add  hl, de                                   ; $4E31: $19
-    ld   de, wDC88                                ; $4E32: $11 $88 $DC
+    ld   de, wObjPal8                             ; $4E32: $11 $88 $DC
     ld   c, $00                                   ; $4E35: $0E $00
 
 jr_002_4E37:
@@ -2093,7 +2093,7 @@ jr_002_4E37:
 ; Copy data from RAM bank 2 to RAM bank 0
 func_002_4E48::
     di                                            ; $4E48: $F3
-    ld   hl, wDC88                                ; $4E49: $21 $88 $DC
+    ld   hl, wObjPal8                             ; $4E49: $21 $88 $DC
     ld   e, $00                                   ; $4E4C: $1E $00
 
 .loop

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5088,9 +5088,9 @@ jr_020_6CB5:
     ld   a, [wC3CA]                               ; $6CBA: $FA $CA $C3
     and  $01                                      ; $6CBD: $E6 $01
     swap a                                        ; $6CBF: $CB $37
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $6CC1: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $6CC1: $EA $D3 $DD
     ld   a, $10                                   ; $6CC4: $3E $10
-    ld   [wPaletteParticalCopyColorCount], a      ; $6CC6: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $6CC6: $EA $D4 $DD
     pop  af                                       ; $6CC9: $F1
     inc  a                                        ; $6CCA: $3C
     ld   [wC3CA], a                               ; $6CCB: $EA $CA $C3
@@ -5821,9 +5821,9 @@ func_020_78ED::
     call CopyData                                 ; $7903: $CD $14 $29
 
     xor  a                                        ; $7906: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7907: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7907: $EA $D3 $DD
     ld   a, $1C                                   ; $790A: $3E $1C
-    ld   [wPaletteParticalCopyColorCount], a      ; $790C: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $790C: $EA $D4 $DD
     ld   a, $81                                   ; $790F: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7911: $EA $D1 $DD
     ret                                           ; $7914: $C9
@@ -6005,9 +6005,9 @@ jr_020_7C50:
     ld   a, $20                                   ; $7C59: $3E $20
 
 jr_020_7C5B:
-    ld   [wPaletteParticalCopyColorCount], a      ; $7C5B: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $7C5B: $EA $D4 $DD
     xor  a                                        ; $7C5E: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7C5F: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7C5F: $EA $D3 $DD
     ld   a, $81                                   ; $7C62: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7C64: $EA $D1 $DD
     ret                                           ; $7C67: $C9

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -2329,7 +2329,7 @@ InventoryInitialHandler::
     and  a
     jr   z, jr_020_5940                           ; $5925: $28 $19
 
-    ld   hl, wDC10                                ; $5927: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $5927: $21 $10 $DC
     ld   c, $80                                   ; $592A: $0E $80
     di                                            ; $592C: $F3
 
@@ -3164,7 +3164,7 @@ InventoryLoad5Handler::
     jr   z, jr_020_5E6D                           ; $5E26: $28 $45
 
     ld   bc, InventoryPalettes                        ; $5E28: $01 $61 $5D
-    ld   hl, wDC10                                ; $5E2B: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $5E2B: $21 $10 $DC
     di                                            ; $5E2E: $F3
     ld   a, $02                                   ; $5E2F: $3E $02
     ldh  [rSVBK], a                               ; $5E31: $E0 $70
@@ -3196,7 +3196,7 @@ InventoryLoad5Handler::
     ld   a, [hl+]                                 ; $5E54: $2A
     ld   h, [hl]                                  ; $5E55: $66
     ld   l, a                                     ; $5E56: $6F
-    ld   de, wDC3A                                ; $5E57: $11 $3A $DC
+    ld   de, wBGPal6 + 2                          ; $5E57: $11 $3A $DC
     ld   c, $04                                   ; $5E5A: $0E $04
     di                                            ; $5E5C: $F3
     ld   a, $02                                   ; $5E5D: $3E $02
@@ -3265,7 +3265,7 @@ jr_020_5ED6:
     ld   b, $00                                   ; $5ED6: $06 $00
     ld   hl, InventoryInstrumentCyclingColors                        ; $5ED8: $21 $75 $5E
     add  hl, bc                                   ; $5EDB: $09
-    ld   bc, wDC4A                                ; $5EDC: $01 $4A $DC
+    ld   bc, wBGPal8 + 1*2                        ; $5EDC: $01 $4A $DC
     ld   e, $04                                   ; $5EDF: $1E $04
 
 jr_020_5EE1:
@@ -4401,7 +4401,7 @@ jr_020_6630:
     and  a                                        ; $6650: $A7
     jr   z, jr_020_6682                           ; $6651: $28 $2F
 
-    ld   hl, wDC10                                ; $6653: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6653: $21 $10 $DC
     ld   c, $80                                   ; $6656: $0E $80
     di                                            ; $6658: $F3
 
@@ -4608,7 +4608,7 @@ func_020_6A30::
     ldh  [hMultiPurposeE], a                           ; $6A40: $E0 $E5
     ld   a, $04                                   ; $6A42: $3E $04
     ldh  [hFreeWarpDataAddress], a                ; $6A44: $E0 $E6
-    ld   hl, wDC10                                ; $6A46: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6A46: $21 $10 $DC
     ld   d, $40                                   ; $6A49: $16 $40
     ld   a, e                                     ; $6A4B: $7B
     cp   $06                                      ; $6A4C: $FE $06
@@ -4714,7 +4714,7 @@ func_020_6AC1::
     ldh  [hMultiPurposeE], a                           ; $6AD1: $E0 $E5
     ld   a, $04                                   ; $6AD3: $3E $04
     ldh  [hFreeWarpDataAddress], a                ; $6AD5: $E0 $E6
-    ld   hl, wDC10                                ; $6AD7: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6AD7: $21 $10 $DC
     ld   a, $40                                   ; $6ADA: $3E $40
     ldh  [hMultiPurpose3], a                           ; $6ADC: $E0 $DA
     ld   a, e                                     ; $6ADE: $7B
@@ -4896,7 +4896,7 @@ jr_020_6BB4:
     add  hl, de                                   ; $6BB9: $19
     push hl                                       ; $6BBA: $E5
     pop  bc                                       ; $6BBB: $C1
-    ld   hl, wDC10                                ; $6BBC: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6BBC: $21 $10 $DC
     ld   a, $08                                   ; $6BBF: $3E $08
     ldh  [hMultiPurpose0], a                           ; $6BC1: $E0 $D7
 
@@ -4923,8 +4923,8 @@ func_020_6BDC::
     and  a                                        ; $6BDE: $A7
     ret  z                                        ; $6BDF: $C8
 
-    ld   hl, wDC10                                ; $6BE0: $21 $10 $DC
-    ld   bc, wDC50                                ; $6BE3: $01 $50 $DC
+    ld   hl, wBGPal1                              ; $6BE0: $21 $10 $DC
+    ld   bc, wObjPal1                             ; $6BE3: $01 $50 $DC
     ld   d, $20                                   ; $6BE6: $16 $20
 
 jr_020_6BE8:
@@ -4952,7 +4952,7 @@ LoadFileMenuBG::
     jp   z, label_020_6B81                        ; $6C03: $CA $81 $6B
 
     ld   c, $80                                   ; $6C06: $0E $80
-    ld   hl, wDC10                                ; $6C08: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6C08: $21 $10 $DC
 
 jr_020_6C0B:
     ld   a, $02                                   ; $6C0B: $3E $02
@@ -4980,7 +4980,7 @@ CopyLinkTunicPalette::
     and  a                                        ; $6C26: $A7
     jr   z, .return                               ; $6C27: $28 $25
 
-    ld   hl, wDC50                                ; $6C29: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $6C29: $21 $50 $DC
     ld   a, [wTunicType]                          ; $6C2C: $FA $0F $DC
     and  a                                        ; $6C2F: $A7
     jr   z, .specialTunicEnd                      ; $6C30: $28 $0B
@@ -5033,7 +5033,7 @@ jr_020_6C60:
     ldh  [hMultiPurposeE], a                           ; $6C66: $E0 $E5
     ld   a, $10                                   ; $6C68: $3E $10
     ldh  [hFreeWarpDataAddress], a                ; $6C6A: $E0 $E6
-    ld   hl, wDC10                                ; $6C6C: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6C6C: $21 $10 $DC
     ld   d, $40                                   ; $6C6F: $16 $40
     call func_020_6A68                            ; $6C71: $CD $68 $6A
     ld   a, $01                                   ; $6C74: $3E $01
@@ -5061,7 +5061,7 @@ jr_020_6C8B:
     ldh  [hMultiPurposeE], a                           ; $6C91: $E0 $E5
     ld   a, $10                                   ; $6C93: $3E $10
     ldh  [hFreeWarpDataAddress], a                ; $6C95: $E0 $E6
-    ld   hl, wDC10                                ; $6C97: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6C97: $21 $10 $DC
     ld   a, $40                                   ; $6C9A: $3E $40
     ldh  [hMultiPurpose3], a                           ; $6C9C: $E0 $DA
     call func_020_6AF5                            ; $6C9E: $CD $F5 $6A
@@ -5088,9 +5088,9 @@ jr_020_6CB5:
     ld   a, [wC3CA]                               ; $6CBA: $FA $CA $C3
     and  $01                                      ; $6CBD: $E6 $01
     swap a                                        ; $6CBF: $CB $37
-    ld   [wPaletteUnknownC], a                    ; $6CC1: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $6CC1: $EA $D3 $DD
     ld   a, $10                                   ; $6CC4: $3E $10
-    ld   [wPaletteUnknownD], a                    ; $6CC6: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $6CC6: $EA $D4 $DD
     pop  af                                       ; $6CC9: $F1
     inc  a                                        ; $6CCA: $3C
     ld   [wC3CA], a                               ; $6CCB: $EA $CA $C3
@@ -5100,7 +5100,7 @@ jr_020_6CB5:
     ldh  [hMultiPurposeE], a                           ; $6CD4: $E0 $E5
     ld   a, $20                                   ; $6CD6: $3E $20
     ldh  [hFreeWarpDataAddress], a                ; $6CD8: $E0 $E6
-    ld   hl, wDC10                                ; $6CDA: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6CDA: $21 $10 $DC
     ld   a, $40                                   ; $6CDD: $3E $40
     ldh  [hMultiPurpose3], a                           ; $6CDF: $E0 $DA
     ld   a, [wTransitionGfx]                      ; $6CE1: $FA $7F $C1
@@ -5157,9 +5157,9 @@ jr_020_6D1E:
     ld   a, $04                                   ; $6D2C: $3E $04
     ldh  [hFreeWarpDataAddress], a                ; $6D2E: $E0 $E6
 IF __PATCH_3__
-    ld   hl, wDC50
+    ld   hl, wObjPal1
 ELSE
-    ld   hl, wDC30                                ; $6D30: $21 $30 $DC
+    ld   hl, wBGPal5                              ; $6D30: $21 $30 $DC
 ENDC
     ld   d, $20                                   ; $6D33: $16 $20
     call func_020_6A68                            ; $6D35: $CD $68 $6A
@@ -5171,7 +5171,7 @@ jr_020_6D38:
     ldh  [hMultiPurposeE], a                           ; $6D3E: $E0 $E5
     ld   a, $04                                   ; $6D40: $3E $04
     ldh  [hFreeWarpDataAddress], a                ; $6D42: $E0 $E6
-    ld   hl, wDC10                                ; $6D44: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6D44: $21 $10 $DC
     ld   d, $20                                   ; $6D47: $16 $20
     call func_020_6A68                            ; $6D49: $CD $68 $6A
     ld   a, $01                                   ; $6D4C: $3E $01
@@ -5188,12 +5188,12 @@ func_020_6D52::
     cp   $30                                      ; $6D55: $FE $30
     jr   c, jr_020_6D60                           ; $6D57: $38 $07
 
-    ld   hl, wDC50                                ; $6D59: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $6D59: $21 $50 $DC
     ld   a, $02                                   ; $6D5C: $3E $02
     jr   jr_020_6D65                              ; $6D5E: $18 $05
 
 jr_020_6D60:
-    ld   hl, wDC10                                ; $6D60: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6D60: $21 $10 $DC
     ld   a, $01                                   ; $6D63: $3E $01
 
 jr_020_6D65:
@@ -5817,13 +5817,13 @@ func_020_78ED::
     ld   l, b                                     ; $78FC: $68
 
     ld   bc, $38                                  ; $78FD: $01 $38 $00
-    ld   de, wDC10                                ; $7900: $11 $10 $DC
+    ld   de, wBGPal1                              ; $7900: $11 $10 $DC
     call CopyData                                 ; $7903: $CD $14 $29
 
     xor  a                                        ; $7906: $AF
-    ld   [wPaletteUnknownC], a                    ; $7907: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7907: $EA $D3 $DD
     ld   a, $1C                                   ; $790A: $3E $1C
-    ld   [wPaletteUnknownD], a                    ; $790C: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $790C: $EA $D4 $DD
     ld   a, $81                                   ; $790F: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7911: $EA $D1 $DD
     ret                                           ; $7914: $C9
@@ -5985,7 +5985,7 @@ func_020_7C26::
     ld   hl, Data_020_7BFE                        ; $7C39: $21 $FE $7B
     add  hl, bc                                   ; $7C3C: $09
     ld   bc, $08                                  ; $7C3D: $01 $08 $00
-    ld   de, wDC10                                ; $7C40: $11 $10 $DC
+    ld   de, wBGPal1                              ; $7C40: $11 $10 $DC
     call CopyData                                 ; $7C43: $CD $14 $29
 
     pop  bc                                       ; $7C46: $C1
@@ -5997,7 +5997,7 @@ func_020_7C26::
     jr   jr_020_7C5B                              ; $7C4E: $18 $0B
 
 jr_020_7C50:
-    ld   hl, wDC48                                ; $7C50: $21 $48 $DC
+    ld   hl, wBGPal8                              ; $7C50: $21 $48 $DC
     ld   a, $A4                                   ; $7C53: $3E $A4
     ld   [hl+], a                                 ; $7C55: $22
     ld   a, $3C                                   ; $7C56: $3E $3C
@@ -6005,9 +6005,9 @@ jr_020_7C50:
     ld   a, $20                                   ; $7C59: $3E $20
 
 jr_020_7C5B:
-    ld   [wPaletteUnknownD], a                    ; $7C5B: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $7C5B: $EA $D4 $DD
     xor  a                                        ; $7C5E: $AF
-    ld   [wPaletteUnknownC], a                    ; $7C5F: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7C5F: $EA $D3 $DD
     ld   a, $81                                   ; $7C62: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7C64: $EA $D1 $DD
     ret                                           ; $7C67: $C9
@@ -6131,7 +6131,7 @@ func_020_7D7C::
     ldh  [hMultiPurposeE], a                           ; $7D82: $E0 $E5
     ld   a, $0C                                   ; $7D84: $3E $0C
     ldh  [hFreeWarpDataAddress], a                ; $7D86: $E0 $E6
-    ld   hl, wDC10                                ; $7D88: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $7D88: $21 $10 $DC
     ld   d, $24                                   ; $7D8B: $16 $24
     call jr_020_7D97                              ; $7D8D: $CD $97 $7D
     ld   a, $01                                   ; $7D90: $3E $01
@@ -6238,7 +6238,7 @@ func_020_7E0E:
     ldh [hMultiPurposeE], a                            ; $7e14: $e0 $e5
     ld a, $18                                     ; $7e16: $3e $18
     ldh [hMultiPurposeF], a                            ; $7e18: $e0 $e6
-    ld hl, wDC10                                  ; $7e1a: $21 $10 $dc
+    ld hl, wBGPal1                                ; $7e1a: $21 $10 $dc
     ld a, $40                                     ; $7e1d: $3e $40
     ldh [hMultiPurpose3], a                            ; $7e1f: $e0 $da
     call Call_020_7e25                            ; $7e21: $cd $25 $7e
@@ -6371,7 +6371,7 @@ func_020_7EB1::
     ldh [hMultiPurposeE], a                            ; $7eb7: $e0 $e5
     ld a, $18                                     ; $7eb9: $3e $18
     ldh [hMultiPurposeF], a                            ; $7ebb: $e0 $e6
-    ld hl, wDC10                                  ; $7ebd: $21 $10 $dc
+    ld hl, wBGPal1                                ; $7ebd: $21 $10 $dc
     ld d, $40                                     ; $7ec0: $16 $40
     ldh [hMultiPurpose3], a                            ; $7ec2: $e0 $da
     call Call_020_7ec8                            ; $7ec4: $cd $c8 $7e

--- a/src/code/bank27.asm
+++ b/src/code/bank27.asm
@@ -838,9 +838,9 @@ func_027_7BB0::
 
 func_027_7BB6::
     xor  a                                        ; $7BB6: $AF
-    ld   [wPaletteUnknownC], a                    ; $7BB7: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7BB7: $EA $D3 $DD
     ld   a, $20                                   ; $7BBA: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $7BBC: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $7BBC: $EA $D4 $DD
     ld   a, $82                                   ; $7BBF: $3E $82
     ld   [wPaletteDataFlags], a                   ; $7BC1: $EA $D1 $DD
     ret                                           ; $7BC4: $C9
@@ -984,7 +984,7 @@ func_027_7E5A::
 
 jr_027_7E7D:
     ld   bc, $38                                  ; $7E7D: $01 $38 $00
-    ld   de, wDC50                                ; $7E80: $11 $50 $DC
+    ld   de, wObjPal1                             ; $7E80: $11 $50 $DC
     call CopyData                                 ; $7E83: $CD $14 $29
     ret                                           ; $7E86: $C9
 
@@ -1053,7 +1053,7 @@ func_027_7F8C::
 
 jr_027_7FAF:
     ld   bc, $08                                  ; $7FAF: $01 $08 $00
-    ld   de, wDC88                                ; $7FB2: $11 $88 $DC
+    ld   de, wObjPal8                             ; $7FB2: $11 $88 $DC
     call CopyData                                 ; $7FB5: $CD $14 $29
     ret                                           ; $7FB8: $C9
 

--- a/src/code/bank27.asm
+++ b/src/code/bank27.asm
@@ -838,9 +838,9 @@ func_027_7BB0::
 
 func_027_7BB6::
     xor  a                                        ; $7BB6: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7BB7: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7BB7: $EA $D3 $DD
     ld   a, $20                                   ; $7BBA: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $7BBC: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $7BBC: $EA $D4 $DD
     ld   a, $82                                   ; $7BBF: $3E $82
     ld   [wPaletteDataFlags], a                   ; $7BC1: $EA $D1 $DD
     ret                                           ; $7BC4: $C9

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -1433,9 +1433,9 @@ func_017_4E93::
     ld   a, $47                                   ; $4EA6: $3E $47
     ld   [hl], a                                  ; $4EA8: $77
     xor  a                                        ; $4EA9: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $4EAA: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $4EAA: $EA $D3 $DD
     ld   a, $20                                   ; $4EAD: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $4EAF: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $4EAF: $EA $D4 $DD
     ld   a, $81                                   ; $4EB2: $3E $81
     ld   [wPaletteDataFlags], a                   ; $4EB4: $EA $D1 $DD
     ret                                           ; $4EB7: $C9
@@ -1705,9 +1705,9 @@ jr_017_53B8:
     ld   de, wBGPal1                              ; $53CB: $11 $10 $DC
     call CopyData                                 ; $53CE: $CD $14 $29
     xor  a                                        ; $53D1: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $53D2: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $53D2: $EA $D3 $DD
     ld   a, $20                                   ; $53D5: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $53D7: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $53D7: $EA $D4 $DD
     ld   a, $81                                   ; $53DA: $3E $81
     ld   [wPaletteDataFlags], a                   ; $53DC: $EA $D1 $DD
     ret                                           ; $53DF: $C9
@@ -4214,9 +4214,9 @@ label_017_6A80:
     ld   de, wObjPal1                             ; $6A97: $11 $50 $DC
     call CopyData                                 ; $6A9A: $CD $14 $29
     xor  a                                        ; $6A9D: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $6A9E: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $6A9E: $EA $D3 $DD
     ld   a, $18                                   ; $6AA1: $3E $18
-    ld   [wPaletteParticalCopyColorCount], a      ; $6AA3: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $6AA3: $EA $D4 $DD
     ld   a, $82                                   ; $6AA6: $3E $82
     ld   [wPaletteDataFlags], a                   ; $6AA8: $EA $D1 $DD
     ret                                           ; $6AAB: $C9
@@ -4897,9 +4897,9 @@ CreditsTheEnd0Handler::
     ld   a, $7F                                   ; $6FDD: $3E $7F
     ld   [hl], a                                  ; $6FDF: $77
     ld   a, $03                                   ; $6FE0: $3E $03
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $6FE2: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $6FE2: $EA $D3 $DD
     ld   a, $01                                   ; $6FE5: $3E $01
-    ld   [wPaletteParticalCopyColorCount], a      ; $6FE7: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $6FE7: $EA $D4 $DD
     ld   a, $82                                   ; $6FEA: $3E $82
     ld   [wPaletteDataFlags], a                   ; $6FEC: $EA $D1 $DD
     ld   a, $B4                                   ; $6FEF: $3E $B4
@@ -4957,9 +4957,9 @@ CreditsTheEnd4Handler::
     ld   a, $47                                   ; $7041: $3E $47
     ld   [hl], a                                  ; $7043: $77
     ld   a, $04                                   ; $7044: $3E $04
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7046: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7046: $EA $D3 $DD
     ld   a, $01                                   ; $7049: $3E $01
-    ld   [wPaletteParticalCopyColorCount], a      ; $704B: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $704B: $EA $D4 $DD
     ld   a, $81                                   ; $704E: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7050: $EA $D1 $DD
 IF __PATCH_5__

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -1418,7 +1418,7 @@ func_017_4E93::
     and  a                                        ; $4E95: $A7
     ret  z                                        ; $4E96: $C8
 
-    ld   hl, wDC10                                ; $4E97: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $4E97: $21 $10 $DC
     ld   b, $40                                   ; $4E9A: $06 $40
     xor  a                                        ; $4E9C: $AF
 
@@ -1427,15 +1427,15 @@ func_017_4E93::
     dec  b                                        ; $4E9E: $05
     jr   nz, .loop                                ; $4E9F: $20 $FC
 
-    ld   hl, wDC1E                                ; $4EA1: $21 $1E $DC
+    ld   hl, wBGPal2 + 3*2                        ; $4EA1: $21 $1E $DC
     dec  a                                        ; $4EA4: $3D
     ld   [hl+], a                                 ; $4EA5: $22
     ld   a, $47                                   ; $4EA6: $3E $47
     ld   [hl], a                                  ; $4EA8: $77
     xor  a                                        ; $4EA9: $AF
-    ld   [wPaletteUnknownC], a                    ; $4EAA: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $4EAA: $EA $D3 $DD
     ld   a, $20                                   ; $4EAD: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $4EAF: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $4EAF: $EA $D4 $DD
     ld   a, $81                                   ; $4EB2: $3E $81
     ld   [wPaletteDataFlags], a                   ; $4EB4: $EA $D1 $DD
     ret                                           ; $4EB7: $C9
@@ -1702,12 +1702,12 @@ jr_017_53B8:
     ld   hl, Data_017_51A7                        ; $53C4: $21 $A7 $51
     add  hl, bc                                   ; $53C7: $09
     ld   bc, $0040                                ; $53C8: $01 $40 $00
-    ld   de, wDC10                                ; $53CB: $11 $10 $DC
+    ld   de, wBGPal1                              ; $53CB: $11 $10 $DC
     call CopyData                                 ; $53CE: $CD $14 $29
     xor  a                                        ; $53D1: $AF
-    ld   [wPaletteUnknownC], a                    ; $53D2: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $53D2: $EA $D3 $DD
     ld   a, $20                                   ; $53D5: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $53D7: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $53D7: $EA $D4 $DD
     ld   a, $81                                   ; $53DA: $3E $81
     ld   [wPaletteDataFlags], a                   ; $53DC: $EA $D1 $DD
     ret                                           ; $53DF: $C9
@@ -4211,12 +4211,12 @@ label_017_6A80:
     ld   hl, Data_017_6900                        ; $6A90: $21 $00 $69
     add  hl, bc                                   ; $6A93: $09
     ld   bc, $30                                  ; $6A94: $01 $30 $00
-    ld   de, wDC50                                ; $6A97: $11 $50 $DC
+    ld   de, wObjPal1                             ; $6A97: $11 $50 $DC
     call CopyData                                 ; $6A9A: $CD $14 $29
     xor  a                                        ; $6A9D: $AF
-    ld   [wPaletteUnknownC], a                    ; $6A9E: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $6A9E: $EA $D3 $DD
     ld   a, $18                                   ; $6AA1: $3E $18
-    ld   [wPaletteUnknownD], a                    ; $6AA3: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $6AA3: $EA $D4 $DD
     ld   a, $82                                   ; $6AA6: $3E $82
     ld   [wPaletteDataFlags], a                   ; $6AA8: $EA $D1 $DD
     ret                                           ; $6AAB: $C9
@@ -4891,15 +4891,15 @@ CreditsTheEnd0Handler::
     and  a                                        ; $6FD5: $A7
     ret  nz                                       ; $6FD6: $C0
 
-    ld   hl, wDC56                                ; $6FD7: $21 $56 $DC
+    ld   hl, wObjPal1 + 3*2                       ; $6FD7: $21 $56 $DC
     ld   a, $FF                                   ; $6FDA: $3E $FF
     ld   [hl+], a                                 ; $6FDC: $22
     ld   a, $7F                                   ; $6FDD: $3E $7F
     ld   [hl], a                                  ; $6FDF: $77
     ld   a, $03                                   ; $6FE0: $3E $03
-    ld   [wPaletteUnknownC], a                    ; $6FE2: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $6FE2: $EA $D3 $DD
     ld   a, $01                                   ; $6FE5: $3E $01
-    ld   [wPaletteUnknownD], a                    ; $6FE7: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $6FE7: $EA $D4 $DD
     ld   a, $82                                   ; $6FEA: $3E $82
     ld   [wPaletteDataFlags], a                   ; $6FEC: $EA $D1 $DD
     ld   a, $B4                                   ; $6FEF: $3E $B4
@@ -4951,15 +4951,15 @@ CreditsTheEnd3Handler::
 CreditsTheEnd4Handler::
     ld   a, $23                                   ; $7036: $3E $23
     ld   [wTileMapToLoad], a                      ; $7038: $EA $FE $D6
-    ld   hl, wDC18                                ; $703B: $21 $18 $DC
+    ld   hl, wBGPal2                              ; $703B: $21 $18 $DC
     ld   a, $FF                                   ; $703E: $3E $FF
     ld   [hl+], a                                 ; $7040: $22
     ld   a, $47                                   ; $7041: $3E $47
     ld   [hl], a                                  ; $7043: $77
     ld   a, $04                                   ; $7044: $3E $04
-    ld   [wPaletteUnknownC], a                    ; $7046: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7046: $EA $D3 $DD
     ld   a, $01                                   ; $7049: $3E $01
-    ld   [wPaletteUnknownD], a                    ; $704B: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $704B: $EA $D4 $DD
     ld   a, $81                                   ; $704E: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7050: $EA $D1 $DD
 IF __PATCH_5__
@@ -5958,7 +5958,7 @@ func_017_7A01::
     ld   d, $00                                   ; $7A12: $16 $00
     ld   hl, Data_017_79C1                        ; $7A14: $21 $C1 $79
     add  hl, de                                   ; $7A17: $19
-    ld   de, wDC5C                                ; $7A18: $11 $5C $DC
+    ld   de, wObjPal2 + 2*2                       ; $7A18: $11 $5C $DC
 
 jr_017_7A1B:
     ld   a, [hl+]                                 ; $7A1B: $2A
@@ -6713,7 +6713,7 @@ ELSE
     ldh  [hMultiPurposeE], a                           ; $7E8E: $E0 $E5
     ld   a, $18                                   ; $7E90: $3E $18
     ldh  [hFreeWarpDataAddress], a                ; $7E92: $E0 $E6
-    ld   hl, wDC10                                ; $7E94: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $7E94: $21 $10 $DC
     ld   a, $40                                   ; $7E97: $3E $40
     ldh  [hMultiPurpose3], a                           ; $7E99: $E0 $DA
     call func_017_7EA4                            ; $7E9B: $CD $A4 $7E
@@ -6873,7 +6873,7 @@ ELSE
     ldh  [hMultiPurposeE], a                           ; $7F42: $E0 $E5
     ld   a, $18                                   ; $7F44: $3E $18
     ldh  [hFreeWarpDataAddress], a                ; $7F46: $E0 $E6
-    ld   hl, wDC10                                ; $7F48: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $7F48: $21 $10 $DC
     ld   d, $40                                   ; $7F4B: $16 $40
     call func_017_7F57                            ; $7F4D: $CD $57 $7F
 ENDC

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -851,7 +851,7 @@ jr_019_4663:
     add  hl, de                                   ; $4675: $19
     ld   e, l                                     ; $4676: $5D
     ld   d, h                                     ; $4677: $54
-    ld   hl, wDC8A                                ; $4678: $21 $8A $DC
+    ld   hl, wObjPal8 + 1*2                       ; $4678: $21 $8A $DC
 
 jr_019_467B:
     ld   a, [de]                                  ; $467B: $1A
@@ -1469,7 +1469,7 @@ func_019_4A90::
     ld   d, $00                                   ; $4AA4: $16 $00
     ld   hl, Data_019_4A50                        ; $4AA6: $21 $50 $4A
     add  hl, de                                   ; $4AA9: $19
-    ld   de, wDC84                                ; $4AAA: $11 $84 $DC
+    ld   de, wObjPal7 + 2*2                       ; $4AAA: $11 $84 $DC
 
 jr_019_4AAD:
     ld   a, [hl+]                                 ; $4AAD: $2A
@@ -1804,7 +1804,7 @@ jr_019_4C88:
     ldh  [hJingle], a                             ; $4CC8: $E0 $F2
     call func_019_4D45                            ; $4CCA: $CD $45 $4D
     call PlayBombExplosionSfx                     ; $4CCD: $CD $4B $0C
-    ld   de, wDC5C                                ; $4CD0: $11 $5C $DC
+    ld   de, wObjPal2 + 2*2                       ; $4CD0: $11 $5C $DC
     ld   hl, $FF70                                ; $4CD3: $21 $70 $FF
 
 jr_019_4CD6:
@@ -6166,7 +6166,7 @@ BananasSchuleState2Handler::
     and  a                                        ; $6DBD: $A7
     jr   z, jr_019_6DD4                           ; $6DBE: $28 $14
 
-    ld   hl, wDC7A                                ; $6DC0: $21 $7A $DC
+    ld   hl, wObjPal6 + 1*2                       ; $6DC0: $21 $7A $DC
     ld   a, $FF                                   ; $6DC3: $3E $FF
     ld   [hl+], a                                 ; $6DC5: $22
     ld   a, $7F                                   ; $6DC6: $3E $7F

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -673,7 +673,7 @@ EntityInitRacoon::
 
     ld   a, $02                                   ; $4AF7: $3E $02
     ldh  [rSVBK], a                               ; $4AF9: $E0 $70
-    ld   hl, wDC88                                ; $4AFB: $21 $88 $DC
+    ld   hl, wObjPal8                             ; $4AFB: $21 $88 $DC
     ld   de, Data_003_4AC6                        ; $4AFE: $11 $C6 $4A
 
 jr_003_4B01:
@@ -3914,7 +3914,7 @@ SirensInstrumentState0Handler::
     jr   nc, jr_003_5EAE                          ; $5EA7: $30 $05
 
     ld   a, $03                                   ; $5EA9: $3E $03
-    call func_036_70D6_trampoline                 ; $5EAB: $CD $D2 $0A
+    call cycleInstrumentItemColor_trampoline      ; $5EAB: $CD $D2 $0A
 
 jr_003_5EAE:
     ld   a, c                                     ; $5EAE: $79
@@ -4110,7 +4110,7 @@ ENDC
 
 func_003_5FBC::
 IF __PATCH_0__
-    ld   a, [wDC52]
+    ld   a, [wObjPal1 + 1*2]
     inc  a
     jp   nz, HoldEntityAboveLink
     ld   a, $80

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -119,7 +119,7 @@ func_036_409C::
     ld   [hl], a                                  ; $40A8: $77
     di                                            ; $40A9: $F3
     ld   de, Data_036_4094                        ; $40AA: $11 $94 $40
-    ld   hl, wDC80                                ; $40AD: $21 $80 $DC
+    ld   hl, wObjPal7                             ; $40AD: $21 $80 $DC
 
 jr_036_40B0:
     ld   a, [de]                                  ; $40B0: $1A
@@ -308,7 +308,7 @@ func_036_41B2::
     pop  bc                                       ; $41C6: $C1
     di                                            ; $41C7: $F3
     ld   de, Data_036_4094                        ; $41C8: $11 $94 $40
-    ld   hl, wDC80                                ; $41CB: $21 $80 $DC
+    ld   hl, wObjPal7                             ; $41CB: $21 $80 $DC
     ld   a, $02                                   ; $41CE: $3E $02
     ldh  [rSVBK], a                               ; $41D0: $E0 $70
 
@@ -1043,7 +1043,7 @@ func_036_462B::
 func_036_4649::
     di                                            ; $4649: $F3
     ld   hl, $FF70                                ; $464A: $21 $70 $FF
-    ld   de, wDC10                                ; $464D: $11 $10 $DC
+    ld   de, wBGPal1                              ; $464D: $11 $10 $DC
 
 jr_036_4650:
     ld   a, [de]                                  ; $4650: $1A
@@ -1066,7 +1066,7 @@ jr_036_4650:
 func_036_4665::
     di                                            ; $4665: $F3
     ld   hl, $FF70                                ; $4666: $21 $70 $FF
-    ld   de, wDC10                                ; $4669: $11 $10 $DC
+    ld   de, wBGPal1                              ; $4669: $11 $10 $DC
 
 jr_036_466C:
     ld   [hl], $03                                ; $466C: $36 $03
@@ -1787,7 +1787,7 @@ func_036_4A9F::
     ld   a, $02                                   ; $4ABF: $3E $02
     ldh  [rSVBK], a                               ; $4AC1: $E0 $70
     ld   de, Data_036_4A97                        ; $4AC3: $11 $97 $4A
-    ld   hl, wDC80                                ; $4AC6: $21 $80 $DC
+    ld   hl, wObjPal7                             ; $4AC6: $21 $80 $DC
 
 jr_036_4AC9:
     ld   a, [de]                                  ; $4AC9: $1A
@@ -2239,12 +2239,12 @@ jr_036_4D6E:
     ld   d, $00                                   ; $4D76: $16 $00
     ld   hl, Data_036_4D39                        ; $4D78: $21 $39 $4D
     add  hl, de                                   ; $4D7B: $19
-    ld   a, [wDC8C]                               ; $4D7C: $FA $8C $DC
+    ld   a, [wObjPal8 + 2*2]                      ; $4D7C: $FA $8C $DC
     cp   [hl]                                     ; $4D7F: $BE
     jr   nz, jr_036_4D89                          ; $4D80: $20 $07
 
     inc  hl                                       ; $4D82: $23
-    ld   a, [wDC8D]                               ; $4D83: $FA $8D $DC
+    ld   a, [wObjPal8 + 2*2+1]                    ; $4D83: $FA $8D $DC
     cp   [hl]                                     ; $4D86: $BE
     ret  z                                        ; $4D87: $C8
 
@@ -2255,15 +2255,15 @@ jr_036_4D89:
     ld   d, h                                     ; $4D8A: $54
     ld   hl, $FF70                                ; $4D8B: $21 $70 $FF
     ld   a, [de]                                  ; $4D8E: $1A
-    ld   [wDC8C], a                               ; $4D8F: $EA $8C $DC
+    ld   [wObjPal8 + 2*2], a                      ; $4D8F: $EA $8C $DC
     ld   [hl], $02                                ; $4D92: $36 $02
-    ld   [wDC8C], a                               ; $4D94: $EA $8C $DC
+    ld   [wObjPal8 + 2*2], a                      ; $4D94: $EA $8C $DC
     ld   [hl], $00                                ; $4D97: $36 $00
     inc  de                                       ; $4D99: $13
     ld   a, [de]                                  ; $4D9A: $1A
-    ld   [wDC8D], a                               ; $4D9B: $EA $8D $DC
+    ld   [wObjPal8 + 2*2+1], a                    ; $4D9B: $EA $8D $DC
     ld   [hl], $02                                ; $4D9E: $36 $02
-    ld   [wDC8D], a                               ; $4DA0: $EA $8D $DC
+    ld   [wObjPal8 + 2*2+1], a                    ; $4DA0: $EA $8D $DC
     ld   [hl], $00                                ; $4DA3: $36 $00
     ld   a, $02                                   ; $4DA5: $3E $02
     ld   [wPaletteDataFlags], a                   ; $4DA7: $EA $D1 $DD
@@ -2707,7 +2707,7 @@ jr_036_506B:
     pop  af                                       ; $5083: $F1
     ld   [wCurrentBank], a                        ; $5084: $EA $AF $DB
     ld   a, [wGameplayType]                       ; $5087: $FA $95 $DB
-    cp   $0B                                      ; $508A: $FE $0B
+    cp   GAMEPLAY_WORLD                           ; $508A: $FE $0B
     ret  nz                                       ; $508C: $C0
 
     ld   a, [wTransitionSequenceCounter]          ; $508D: $FA $6B $C1
@@ -2747,20 +2747,20 @@ jr_036_50B1:
 func_036_50C9::
     ldh  a, [hActiveEntityState]                  ; $50C9: $F0 $F0
      JP_TABLE                                      ; $50CB
-._00 dw func_036_50E4                             ; $50CC
-._01 dw func_036_5117                             ; $50CE
-._02 dw func_036_5134                             ; $50D0
-._03 dw func_036_5159                             ; $50D2
-._04 dw func_036_5196                             ; $50D4
-._05 dw func_036_51A6                             ; $50D6
-._06 dw func_036_524B                             ; $50D8
-._07 dw func_036_52D8                             ; $50DA
-._08 dw func_036_52FA                             ; $50DC
-._09 dw func_036_53C0                             ; $50DE
-._0A dw func_036_5428                             ; $50E0
-._0B dw func_036_544E                             ; $50E2
+._00 dw TunicFairyState0                             ; $50CC
+._01 dw TunicFairyState1                             ; $50CE
+._02 dw TunicFairyState2                             ; $50D0
+._03 dw TunicFairyState3                             ; $50D2
+._04 dw TunicFairyState4                             ; $50D4
+._05 dw TunicFairyState5                             ; $50D6
+._06 dw TunicFairyState6                             ; $50D8
+._07 dw TunicFairyState7                             ; $50DA
+._08 dw TunicFairyState8                             ; $50DC
+._09 dw TunicFairyState9                             ; $50DE
+._0A dw TunicFairyStateA                             ; $50E0
+._0B dw TunicFairyStateB                             ; $50E2
 
-func_036_50E4::
+TunicFairyState0::
     call func_036_6B8A                            ; $50E4: $CD $8A $6B
     cp   $10                                      ; $50E7: $FE $10
     ret  nc                                       ; $50E9: $D0
@@ -2790,7 +2790,7 @@ func_036_50E4::
     call IncrementEntityState                     ; $5113: $CD $12 $3B
     ret                                           ; $5116: $C9
 
-func_036_5117::
+TunicFairyState1::
     ld   a, [wDialogState]                        ; $5117: $FA $9F $C1
     and  a                                        ; $511A: $A7
     ret  nz                                       ; $511B: $C0
@@ -2815,7 +2815,7 @@ jr_036_512C:
     call IncrementEntityState                     ; $5130: $CD $12 $3B
     ret                                           ; $5133: $C9
 
-func_036_5134::
+TunicFairyState2::
     ld   a, [wDialogState]                        ; $5134: $FA $9F $C1
     and  a                                        ; $5137: $A7
     ret  nz                                       ; $5138: $C0
@@ -2841,7 +2841,7 @@ func_036_5153::
     call func_003_5A2E_trampoline                 ; $5155: $CD $6B $0A
     ret                                           ; $5158: $C9
 
-func_036_5159::
+TunicFairyState3::
     ld   a, $01                                   ; $5159: $3E $01
     ldh  [hLinkInteractiveMotionBlocked], a       ; $515B: $E0 $A1
     ld   a, [wDialogState]                        ; $515D: $FA $9F $C1
@@ -2876,7 +2876,7 @@ func_036_5159::
     call IncrementEntityState                     ; $5192: $CD $12 $3B
     ret                                           ; $5195: $C9
 
-func_036_5196::
+TunicFairyState4::
     call func_036_5153                            ; $5196: $CD $53 $51
     call GetEntityTransitionCountdown             ; $5199: $CD $05 $0C
     ret  nz                                       ; $519C: $C0
@@ -2885,7 +2885,7 @@ func_036_5196::
     call IncrementEntityState                     ; $51A2: $CD $12 $3B
     ret                                           ; $51A5: $C9
 
-func_036_51A6::
+TunicFairyState5::
     ld   a, $02                                   ; $51A6: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $51A8: $E0 $A1
     ld   [wC167], a                               ; $51AA: $EA $67 $C1
@@ -2990,7 +2990,7 @@ jr_036_5248:
     ldh  [hMultiPurpose2], a                           ; $5248: $E0 $D9
     ret                                           ; $524A: $C9
 
-func_036_524B::
+TunicFairyState6::
     ld   a, $02                                   ; $524B: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $524D: $E0 $A1
     ld   [wC167], a                               ; $524F: $EA $67 $C1
@@ -3001,7 +3001,7 @@ func_036_524B::
     ld   hl, wEntitiesUnknownTableD               ; $5257: $21 $D0 $C2
     add  hl, bc                                   ; $525A: $09
     inc  [hl]                                     ; $525B: $34
-    ld   hl, wDC54                                ; $525C: $21 $54 $DC
+    ld   hl, wObjPal1 + 2*2                       ; $525C: $21 $54 $DC
     ld   a, [wTunicType]                          ; $525F: $FA $0F $DC
     and  a                                        ; $5262: $A7
     jr   z, jr_036_526E                           ; $5263: $28 $09
@@ -3082,7 +3082,7 @@ jr_036_5297:
     call IncrementEntityState                     ; $52D4: $CD $12 $3B
     ret                                           ; $52D7: $C9
 
-func_036_52D8::
+TunicFairyState7::
     ld   a, $02                                   ; $52D8: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $52DA: $E0 $A1
     ld   [wC167], a                               ; $52DC: $EA $67 $C1
@@ -3105,7 +3105,7 @@ jr_036_52F2:
     call IncrementEntityState                     ; $52F6: $CD $12 $3B
     ret                                           ; $52F9: $C9
 
-func_036_52FA::
+TunicFairyState8::
     ld   a, $02                                   ; $52FA: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $52FC: $E0 $A1
     ld   [wC167], a                               ; $52FE: $EA $67 $C1
@@ -3153,7 +3153,7 @@ Data_036_5378::
     db   $99, $80, $53, $00, $99, $A0, $53, $00, $99, $C0, $53, $00, $99, $E0, $53, $00
     db   $9A, $00, $53, $00, $9A, $20, $53, $00
 
-func_036_53C0::
+TunicFairyState9::
     call func_036_5153                            ; $53C0: $CD $53 $51
     push bc                                       ; $53C3: $C5
     ld   hl, wEntitiesPrivateState1Table          ; $53C4: $21 $B0 $C2
@@ -3225,8 +3225,9 @@ jr_036_5412:
     call IncrementEntityState                     ; $5424: $CD $12 $3B
     ret                                           ; $5427: $C9
 
+TunicFairyStateA::
 func_036_5428::
-    ld   de, wDC18                                ; $5428: $11 $18 $DC
+    ld   de, wBGPal2                              ; $5428: $11 $18 $DC
     ld   hl, $FF70                                ; $542B: $21 $70 $FF
     di                                            ; $542E: $F3
 
@@ -3249,7 +3250,7 @@ jr_036_542F:
     call IncrementEntityState                     ; $544A: $CD $12 $3B
     ret                                           ; $544D: $C9
 
-func_036_544E::
+TunicFairyStateB::
     call func_036_5153                            ; $544E: $CD $53 $51
     ld   a, [wDialogState]                        ; $5451: $FA $9F $C1
     and  a                                        ; $5454: $A7
@@ -7562,7 +7563,7 @@ func_036_6D4D::
     ld   a, [hl+]                                 ; $6D66: $2A
     ld   h, [hl]                                  ; $6D67: $66
     ld   l, a                                     ; $6D68: $6F
-    ld   de, wDC48                                ; $6D69: $11 $48 $DC
+    ld   de, wBGPal8                              ; $6D69: $11 $48 $DC
     ld   bc, $08                                  ; $6D6C: $01 $08 $00
     call CopyData                                 ; $6D6F: $CD $14 $29
     ld   a, $01                                   ; $6D72: $3E $01
@@ -7580,7 +7581,7 @@ jr_036_6D78:
     jr   z, jr_036_6D8E                           ; $6D81: $28 $0B
 
     ld   hl, Data_036_6D01                        ; $6D83: $21 $01 $6D
-    ld   de, wDC80                                ; $6D86: $11 $80 $DC
+    ld   de, wObjPal7                             ; $6D86: $11 $80 $DC
     ld   bc, $10                                  ; $6D89: $01 $10 $00
     jr   jr_036_6D9E                              ; $6D8C: $18 $10
 
@@ -7592,7 +7593,7 @@ jr_036_6D8E:
     ld   a, [hl+]                                 ; $6D95: $2A
     ld   h, [hl]                                  ; $6D96: $66
     ld   l, a                                     ; $6D97: $6F
-    ld   de, wDC88                                ; $6D98: $11 $88 $DC
+    ld   de, wObjPal8                             ; $6D98: $11 $88 $DC
     ld   bc, $08                                  ; $6D9B: $01 $08 $00
 
 jr_036_6D9E:
@@ -7930,7 +7931,7 @@ Data_036_7036::
     db   $FF, $47, $19, $14, $0A, $10, $00, $00
 
 func_036_703E::
-    ld   hl, wDC88                                ; $703E: $21 $88 $DC
+    ld   hl, wObjPal8                             ; $703E: $21 $88 $DC
     ld   de, Data_036_7036                        ; $7041: $11 $36 $70
 
 jr_036_7044:
@@ -8003,7 +8004,7 @@ Data_036_7096::
     db   $17, $14, $BD, $5E, $D7, $04, $FD, $56, $37, $05, $1D, $57, $97, $09, $3D, $5B
     db   $F5, $09, $5C, $5B, $10, $0A, $5A, $5B, $4B, $06, $79, $57, $A0, $02, $95, $57
 
-func_036_70D6::
+cycleInstrumentItemColor::
     ld   a, [wPaletteUnknownE]                    ; $70D6: $FA $D5 $DD
     ld   a, [wTransitionSequenceCounter]          ; $70D9: $FA $6B $C1
     cp   $04                                      ; $70DC: $FE $04
@@ -8011,7 +8012,7 @@ func_036_70D6::
 
 IF __PATCH_0__
     xor  a
-    ld   [wDC52], a
+    ld   [wObjPal1 + 1*2], a
 ENDC
 
     ldh  a, [hIsGBC]                              ; $70DF: $F0 $FE
@@ -8025,7 +8026,7 @@ ENDC
     ld   d, $00                                   ; $70EA: $16 $00
     ld   hl, Data_036_7096                        ; $70EC: $21 $96 $70
     add  hl, de                                   ; $70EF: $19
-    ld   de, wDC5C                                ; $70F0: $11 $5C $DC
+    ld   de, wObjPal2 + 2*2                       ; $70F0: $11 $5C $DC
 
 jr_036_70F3:
     ld   a, [hl+]                                 ; $70F3: $2A
@@ -8336,7 +8337,7 @@ func_036_72D5:
 ._04 dw func_036_730a
 
 func_036_72e4:
-    ld   a, [wDC52]
+    ld   a, [wObjPal1 + 1*2]
     inc  a
     ret  nz
 
@@ -8354,7 +8355,7 @@ func_036_72f3:
     and  a
     jr   nz, func_036_730a
 
-    ld   hl, wDC64
+    ld   hl, wObjPal3 + 2*2
     ld   a, $ff
     ld   [hl+], a
     ld   a, $7f

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -5395,7 +5395,7 @@ jr_004_6F6C:
     ld   hl, wEntitiesUnknowTableR                ; $6FAD: $21 $90 $C3
     add  hl, bc                                   ; $6FB0: $09
     ld   [hl], a                                  ; $6FB1: $77
-    ld   hl, wDC78                                ; $6FB2: $21 $78 $DC
+    ld   hl, wObjPal6                             ; $6FB2: $21 $78 $DC
     ld   de, Data_004_6F30                        ; $6FB5: $11 $30 $6F
 
 jr_004_6FB8:
@@ -7318,7 +7318,7 @@ func_004_7AED::
     and  a                                        ; $7B29: $A7
     jr   z, jr_004_7B3F                           ; $7B2A: $28 $13
 
-    ld   hl, wDC88                                ; $7B2C: $21 $88 $DC
+    ld   hl, wObjPal8                             ; $7B2C: $21 $88 $DC
     ld   de, Data_004_7AE5                        ; $7B2F: $11 $E5 $7A
 
 jr_004_7B32:

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -5815,15 +5815,15 @@ IF __PATCH_0__
     and  a
     ret  z
 
-    ld   hl, wDC64
+    ld   hl, wObjPal3 + 2*2
     ld   a, $3f
     ld   [hl+], a
     ld   a, $14
     ld   [hl], a
     ld   a, $0a
-    ld   [wPaletteUnknownC], a
+    ld   [wPaletteParticalCopyColorIndexStart], a
     ld   a, $01
-    ld   [wPaletteUnknownD], a
+    ld   [wPaletteParticalCopyColorCount], a
     ld   a, $82
     ld   [wPaletteDataFlags], a
 ENDC
@@ -5842,7 +5842,7 @@ jr_007_659D:
     and  a                                        ; $65AF: $A7
     jr   z, jr_007_65CB                           ; $65B0: $28 $19
 
-    ld   de, wDC18                                ; $65B2: $11 $18 $DC
+    ld   de, wBGPal2                              ; $65B2: $11 $18 $DC
     ld   hl, $FF70                                ; $65B5: $21 $70 $FF
     di                                            ; $65B8: $F3
 

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -5821,9 +5821,9 @@ IF __PATCH_0__
     ld   a, $14
     ld   [hl], a
     ld   a, $0a
-    ld   [wPaletteParticalCopyColorIndexStart], a
+    ld   [wPalettePartialCopyColorIndexStart], a
     ld   a, $01
-    ld   [wPaletteParticalCopyColorCount], a
+    ld   [wPalettePartialCopyColorCount], a
     ld   a, $82
     ld   [wPaletteDataFlags], a
 ENDC

--- a/src/code/entities/racoon.asm
+++ b/src/code/entities/racoon.asm
@@ -574,7 +574,7 @@ jr_005_4C88:
     call_open_dialog $054                         ; $4C8C
     jp   IncrementEntityState                     ; $4C91: $C3 $12 $3B
 
-; This data is pushed into DC88
+; This data is pushed into wObjPal8
 data_005_4C94::
     db   $FF, $47, $31, $52, $C5, $28, $00, $00
 
@@ -591,7 +591,7 @@ TarinShield1Handler::
     and  a                                        ; $4CAD: $A7
     jr   z, jr_005_4CC3                           ; $4CAE: $28 $13
 
-    ld   hl, wDC88                                ; $4CB0: $21 $88 $DC
+    ld   hl, wObjPal8                             ; $4CB0: $21 $88 $DC
     ld   de, data_005_4C94                        ; $4CB3: $11 $94 $4C
 
 jr_005_4CB6:

--- a/src/code/face_shrine_mural.asm
+++ b/src/code/face_shrine_mural.asm
@@ -18,7 +18,7 @@ FaceShrineMuralStage0Handler::
     ldh  a, [hIsGBC]                              ; $6B0D: $F0 $FE
     and  a                                        ; $6B0F: $A7
     jr   z, FaceShrineMuralStage1Handler          ; $6B10: $28 $19
-    ld   hl, wDC10                                ; $6B12: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6B12: $21 $10 $DC
     ld   c, $80                                   ; $6B15: $0E $80
     di                                            ; $6B17: $F3
 

--- a/src/code/file_save_screen.asm
+++ b/src/code/file_save_screen.asm
@@ -24,8 +24,8 @@ FileSaveInitial::
     jr   z, FileSaveMapFadeOut                    ; $4018: $28 $28
 
     ; Running on GBC: copy data from WRAM0 to WRAM3
-    ld   hl, wDC10 ; start address                ; $401A: $21 $10 $DC
-    ld   c, $80    ; bytes count                  ; $401D: $0E $80
+    ld   hl, wBGPal1 ; start address              ; $401A: $21 $10 $DC
+    ld   c, $80      ; bytes count                ; $401D: $0E $80
 
     ; Disable interrupts
     di                                            ; $401F: $F3

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -1831,7 +1831,7 @@ ENDC
 
     ld   hl, Data_001_78A0                        ; $79CD: $21 $A0 $78
     add  hl, bc                                   ; $79D0: $09
-    ld   bc, wDC78                                ; $79D1: $01 $78 $DC
+    ld   bc, wObjPal6                             ; $79D1: $01 $78 $DC
     ld   e, CHUNKSIZE                             ; $79D4: $1E $10
 
 .loop

--- a/src/code/marin_beach.asm
+++ b/src/code/marin_beach.asm
@@ -44,7 +44,7 @@ MarineBeachPrepare0::
     and  a                                        ; $6244: $A7
     jr   z, MarineBeachPrepare1                   ; $6245: $28 $19
 
-    ld   hl, wDC10                                ; $6247: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $6247: $21 $10 $DC
     ld   c, $80                                   ; $624A: $0E $80
     di                                            ; $624C: $F3
 

--- a/src/code/overworld_macros.asm
+++ b/src/code/overworld_macros.asm
@@ -310,20 +310,20 @@ func_024_7815::
     ld   hl, Data_024_7711                        ; $7816: $21 $11 $77
     add  hl, bc                                   ; $7819: $09
     ld   bc, $08                                  ; $781A: $01 $08 $00
-    ld   de, wDC10                                ; $781D: $11 $10 $DC
+    ld   de, wBGPal1                              ; $781D: $11 $10 $DC
     call CopyData                                 ; $7820: $CD $14 $29
     pop  bc                                       ; $7823: $C1
     ld   hl, Data_024_7789                        ; $7824: $21 $89 $77
     add  hl, bc                                   ; $7827: $09
     ld   bc, $08                                  ; $7828: $01 $08 $00
-    ld   de, wDC48                                ; $782B: $11 $48 $DC
+    ld   de, wBGPal8                              ; $782B: $11 $48 $DC
     call CopyData                                 ; $782E: $CD $14 $29
     xor  a                                        ; $7831: $AF
-    ld   [wPaletteUnknownC], a                    ; $7832: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7832: $EA $D3 $DD
     ld   a, $20                                   ; $7835: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $7837: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $7837: $EA $D4 $DD
     ld   a, $81                                   ; $783A: $3E $81
-    ld   [wPaletteDataFlags], a                    ; $783C: $EA $D1 $DD
+    ld   [wPaletteDataFlags], a                   ; $783C: $EA $D1 $DD
     ret                                           ; $783F: $C9
 
 ; Palette data?
@@ -414,15 +414,15 @@ func_024_7A40::
     rl   b                                        ; $7A59: $CB $10
     ld   hl, Data_024_7840                        ; $7A5B: $21 $40 $78
     add  hl, bc                                   ; $7A5E: $09
-    ld   bc, $40                                ; $7A5F: $01 $40 $00
-    ld   de, wDC50                                ; $7A62: $11 $50 $DC
+    ld   bc, $40                                  ; $7A5F: $01 $40 $00
+    ld   de, wObjPal1                             ; $7A62: $11 $50 $DC
     call CopyData                                 ; $7A65: $CD $14 $29
     xor  a                                        ; $7A68: $AF
-    ld   [wPaletteUnknownC], a                    ; $7A69: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7A69: $EA $D3 $DD
     ld   a, $20                                   ; $7A6C: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $7A6E: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $7A6E: $EA $D4 $DD
     ld   a, $82                                   ; $7A71: $3E $82
-    ld   [wPaletteDataFlags], a                    ; $7A73: $EA $D1 $DD
+    ld   [wPaletteDataFlags], a                   ; $7A73: $EA $D1 $DD
     ret                                           ; $7A76: $C9
 
 ; Palette data?
@@ -480,13 +480,13 @@ func_024_7B77::
 .jr_024_7B8E
 
     ld   bc, $40                                ; $7B8E: $01 $40 $00
-    ld   de, wDC10                                ; $7B91: $11 $10 $DC
+    ld   de, wBGPal1                              ; $7B91: $11 $10 $DC
     call CopyData                                 ; $7B94: $CD $14 $29
 
     xor  a                                        ; $7B97: $AF
-    ld   [wPaletteUnknownC], a                    ; $7B98: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $7B98: $EA $D3 $DD
     ld   a, $20                                   ; $7B9B: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $7B9D: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $7B9D: $EA $D4 $DD
     ld   a, $81                                   ; $7BA0: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7BA2: $EA $D1 $DD
     pop  bc                                       ; $7BA5: $C1

--- a/src/code/overworld_macros.asm
+++ b/src/code/overworld_macros.asm
@@ -319,9 +319,9 @@ func_024_7815::
     ld   de, wBGPal8                              ; $782B: $11 $48 $DC
     call CopyData                                 ; $782E: $CD $14 $29
     xor  a                                        ; $7831: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7832: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7832: $EA $D3 $DD
     ld   a, $20                                   ; $7835: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $7837: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $7837: $EA $D4 $DD
     ld   a, $81                                   ; $783A: $3E $81
     ld   [wPaletteDataFlags], a                   ; $783C: $EA $D1 $DD
     ret                                           ; $783F: $C9
@@ -418,9 +418,9 @@ func_024_7A40::
     ld   de, wObjPal1                             ; $7A62: $11 $50 $DC
     call CopyData                                 ; $7A65: $CD $14 $29
     xor  a                                        ; $7A68: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7A69: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7A69: $EA $D3 $DD
     ld   a, $20                                   ; $7A6C: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $7A6E: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $7A6E: $EA $D4 $DD
     ld   a, $82                                   ; $7A71: $3E $82
     ld   [wPaletteDataFlags], a                   ; $7A73: $EA $D1 $DD
     ret                                           ; $7A76: $C9
@@ -484,9 +484,9 @@ func_024_7B77::
     call CopyData                                 ; $7B94: $CD $14 $29
 
     xor  a                                        ; $7B97: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $7B98: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $7B98: $EA $D3 $DD
     ld   a, $20                                   ; $7B9B: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $7B9D: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $7B9D: $EA $D4 $DD
     ld   a, $81                                   ; $7BA0: $3E $81
     ld   [wPaletteDataFlags], a                   ; $7BA2: $EA $D1 $DD
     pop  bc                                       ; $7BA5: $C1

--- a/src/code/palettes.asm
+++ b/src/code/palettes.asm
@@ -34,7 +34,7 @@ jr_021_4026:
 
 jr_021_402B:
     ld   a, $80                                   ; $402B: $3E $80
-    ld   hl, wPaletteParticalCopyColorIndexStart  ; $402D: $21 $D3 $DD
+    ld   hl, wPalettePartialCopyColorIndexStart   ; $402D: $21 $D3 $DD
     ld   e, [hl]                                  ; $4030: $5E
     sla  e                                        ; $4031: $CB $23
     or   e                                        ; $4033: $B3
@@ -59,7 +59,7 @@ jr_021_404F:
     add  hl, de                                   ; $4051: $19
     ld   e, c                                     ; $4052: $59
     ld   d, b                                     ; $4053: $50
-    ld   a, [wPaletteParticalCopyColorCount]      ; $4054: $FA $D4 $DD
+    ld   a, [wPalettePartialCopyColorCount]       ; $4054: $FA $D4 $DD
     sla  a                                        ; $4057: $CB $27
     ld   b, a                                     ; $4059: $47
     call func_021_4068                            ; $405A: $CD $68 $40
@@ -1238,9 +1238,9 @@ func_021_53B6::
 
 jr_021_53C0:
     xor  a                                        ; $53C0: $AF
-    ld   [wPaletteParticalCopyColorIndexStart], a ; $53C1: $EA $D3 $DD
+    ld   [wPalettePartialCopyColorIndexStart], a  ; $53C1: $EA $D3 $DD
     ld   a, $20                                   ; $53C4: $3E $20
-    ld   [wPaletteParticalCopyColorCount], a      ; $53C6: $EA $D4 $DD
+    ld   [wPalettePartialCopyColorCount], a       ; $53C6: $EA $D4 $DD
     ld   a, $81                                   ; $53C9: $3E $81
     ld   [wPaletteDataFlags], a                    ; $53CB: $EA $D1 $DD
     ret                                           ; $53CE: $C9

--- a/src/code/palettes.asm
+++ b/src/code/palettes.asm
@@ -14,7 +14,7 @@ CopyPalettesToHardware::
     and  $01                                      ; $4009: $E6 $01
     jr   z, jr_021_4016                           ; $400B: $28 $09
 
-    ld   hl, wDC10                                ; $400D: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $400D: $21 $10 $DC
     ld   de, $FF68                                ; $4010: $11 $68 $FF
     call func_021_4062                            ; $4013: $CD $62 $40
 
@@ -23,7 +23,7 @@ jr_021_4016:
     and  $02                                      ; $4019: $E6 $02
     jr   z, jr_021_4026                           ; $401B: $28 $09
 
-    ld   hl, wDC50                                ; $401D: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $401D: $21 $50 $DC
     ld   de, $FF6A                                ; $4020: $11 $6A $FF
     call func_021_4062                            ; $4023: $CD $62 $40
 
@@ -34,7 +34,7 @@ jr_021_4026:
 
 jr_021_402B:
     ld   a, $80                                   ; $402B: $3E $80
-    ld   hl, wPaletteUnknownC                     ; $402D: $21 $D3 $DD
+    ld   hl, wPaletteParticalCopyColorIndexStart  ; $402D: $21 $D3 $DD
     ld   e, [hl]                                  ; $4030: $5E
     sla  e                                        ; $4031: $CB $23
     or   e                                        ; $4033: $B3
@@ -46,20 +46,20 @@ jr_021_402B:
 
     ldh  [rBCPS], a                               ; $403D: $E0 $68
     ld   bc, rBGPD                                ; $403F: $01 $69 $FF
-    ld   hl, wDC10                                ; $4042: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $4042: $21 $10 $DC
     jr   jr_021_404F                              ; $4045: $18 $08
 
 jr_021_4047:
     ldh  [rOCPS], a                               ; $4047: $E0 $6A
     ld   bc, rOBPD                                ; $4049: $01 $6B $FF
-    ld   hl, wDC50                                ; $404C: $21 $50 $DC
+    ld   hl, wObjPal1                             ; $404C: $21 $50 $DC
 
 jr_021_404F:
     ld   d, $00                                   ; $404F: $16 $00
     add  hl, de                                   ; $4051: $19
     ld   e, c                                     ; $4052: $59
     ld   d, b                                     ; $4053: $50
-    ld   a, [wPaletteUnknownD]                    ; $4054: $FA $D4 $DD
+    ld   a, [wPaletteParticalCopyColorCount]      ; $4054: $FA $D4 $DD
     sla  a                                        ; $4057: $CB $27
     ld   b, a                                     ; $4059: $47
     call func_021_4068                            ; $405A: $CD $68 $40
@@ -104,7 +104,7 @@ LoadPaletteForTilemap::
 
     ld   h, b                                     ; $4088: $60
     ld   l, c                                     ; $4089: $69
-    ld   de, wDC10                                ; $408A: $11 $10 $DC
+    ld   de, wBGPal1                              ; $408A: $11 $10 $DC
     ld   bc, $80                                  ; $408D: $01 $80 $00
     ld   a, [wPaletteUnknownE]                    ; $4090: $FA $D5 $DD
     and  a                                        ; $4093: $A7
@@ -182,7 +182,7 @@ func_021_40DB::
     cp   $92                                      ; $40FB: $FE $92
     ret  nz                                       ; $40FD: $C0
 
-    ld   hl, wDC8A                                ; $40FE: $21 $8A $DC
+    ld   hl, wObjPal8 + 1*2                       ; $40FE: $21 $8A $DC
     ld   a, [Data_021_56C8 + 6]                   ; $4101: $FA $CE $56
     ld   [hl+], a                                 ; $4104: $22
     ld   a, [Data_021_56C8 + 7]                   ; $4105: $FA $CF $56
@@ -322,7 +322,7 @@ jr_021_41B4:
 
     push hl                                       ; $41BA: $E5
     ld   bc, $40                                ; $41BB: $01 $40 $00
-    ld   de, wDC10                                ; $41BE: $11 $10 $DC
+    ld   de, wBGPal1                              ; $41BE: $11 $10 $DC
     call CopyData                                 ; $41C1: $CD $14 $29
     push hl                                       ; $41C4: $E5
     ld   hl, Data_021_5518                        ; $41C5: $21 $18 $55
@@ -335,7 +335,7 @@ jr_021_41B4:
 
 jr_021_41D6:
     ld   bc, $40                                ; $41D6: $01 $40 $00
-    ld   de, wDC10                                ; $41D9: $11 $10 $DC
+    ld   de, wBGPal1                              ; $41D9: $11 $10 $DC
     ld   a, $02                                   ; $41DC: $3E $02
     ldh  [rSVBK], a                               ; $41DE: $E0 $70
     call CopyData                                 ; $41E0: $CD $14 $29
@@ -357,7 +357,7 @@ jr_021_41D6:
     jr   nz, jr_021_4254                          ; $4201: $20 $51
 
     ld   hl, Data_021_5548                        ; $4203: $21 $48 $55
-    ld   de, wDC78                                ; $4206: $11 $78 $DC
+    ld   de, wObjPal6                             ; $4206: $11 $78 $DC
     ld   c, $08                                   ; $4209: $0E $08
 
 jr_021_420B:
@@ -398,7 +398,7 @@ jr_021_4222:
 
 jr_021_4238:
     ld   c, $02                                   ; $4238: $0E $02
-    ld   de, wDC8C                                ; $423A: $11 $8C $DC
+    ld   de, wObjPal8 + 2*2                       ; $423A: $11 $8C $DC
 
 jr_021_423D:
     ld   a, [wPaletteUnknownE]                    ; $423D: $FA $D5 $DD
@@ -406,7 +406,7 @@ jr_021_423D:
     jr   nz, jr_021_4247                          ; $4241: $20 $04
 
     ld   a, [hl]                                  ; $4243: $7E
-    ld   [wDC8C], a                               ; $4244: $EA $8C $DC
+    ld   [wObjPal8 + 2*2], a                      ; $4244: $EA $8C $DC
 
 jr_021_4247:
     ld   a, $02                                   ; $4247: $3E $02
@@ -440,7 +440,7 @@ label_021_425E:
     ld   b, [hl]                                  ; $4272: $46
     ld   h, b                                     ; $4273: $60
     ld   l, a                                     ; $4274: $6F
-    ld   de, wDC10                                ; $4275: $11 $10 $DC
+    ld   de, wBGPal1                              ; $4275: $11 $10 $DC
     ld   bc, $40                                ; $4278: $01 $40 $00
     ld   a, [wGameplayType]                       ; $427B: $FA $95 $DB
     cp   $01                                      ; $427E: $FE $01
@@ -452,7 +452,7 @@ label_021_425E:
 
     add  hl, bc                                   ; $4289: $09
     ld   bc, $10                                  ; $428A: $01 $10 $00
-    ld   de, wDC80                                ; $428D: $11 $80 $DC
+    ld   de, wObjPal7                             ; $428D: $11 $80 $DC
     ld   a, $02                                   ; $4290: $3E $02
     ld   [wPaletteDataFlags], a                    ; $4292: $EA $D1 $DD
 
@@ -975,7 +975,7 @@ func_021_5185::
     jr   z, jr_021_51D6                           ; $5189: $28 $4B
 
     ld   b, $2D                                   ; $518B: $06 $2D
-    ld   hl, Data_021_523A                        ; $518D: $21 $3A $52
+    ld   hl, IndoorSpritePaletteIndexData                        ; $518D: $21 $3A $52
 
 jr_021_5190:
     ldh  a, [hMapId]                              ; $5190: $F0 $F7
@@ -1036,7 +1036,7 @@ jr_021_51D5:
 
 jr_021_51D6:
     ld   b, $0E                                   ; $51D6: $06 $0E
-    ld   hl, Data_021_52EE                        ; $51D8: $21 $EE $52
+    ld   hl, OverworldSpritePaletteIndexData                        ; $51D8: $21 $EE $52
 
 jr_021_51DB:
     ldh  a, [hMapRoom]                            ; $51DB: $F0 $F6
@@ -1078,7 +1078,9 @@ TilemapPaletteTable::
     db   $60, $67, $70, $67, $80, $67, $A0, $55  ; $522E |`gpg.g.U|
     db   $50, $55, $90, $56                      ; $5236 |PU.V....|
 
-Data_021_523A::
+IndoorSpritePaletteIndexData::
+    ; This is a table with 4 byte records:
+    ; MapId, RoomId, Transition Direction, wPaletteToLoadForTileMap
     db   $00, $17, $04, $81
     db   $00, $13, $01, $80, $00, $13, $00, $80  ; $523E |........|
     db   $00, $13, $03, $81, $00, $10, $00, $CA  ; $5246 |........|
@@ -1103,7 +1105,9 @@ Data_021_523A::
     db   $07, $54, $02, $CF, $16, $6F, $02, $DC  ; $52DE |.T...o..|
     db   $16, $7F, $02, $DD, $16, $8F, $03, $DE  ; $52E6 |........|
 
-Data_021_52EE::
+OverworldSpritePaletteIndexData::
+    ; This is table with 3 byte records:
+    ; RoomId, Transition Direction, wPaletteToLoadForTileMap
     db   $44, $03, $94, $36, $00, $94, $16, $02  ; $52EE |D..6....|
     db   $95, $26, $03, $95, $17, $02, $95, $27  ; $52F6 |.&.....'|
     db   $03, $95, $08, $02, $9B, $17, $01, $9B  ; $52FE |........|
@@ -1210,8 +1214,8 @@ jr_021_537B:
     ld   l, a                                     ; $539B: $6F
 
 jr_021_539C:
-    ld   de, wDC10                                ; $539C: $11 $10 $DC
-    ld   bc, $40                                ; $539F: $01 $40 $00
+    ld   de, wBGPal1                              ; $539C: $11 $10 $DC
+    ld   bc, $40                                  ; $539F: $01 $40 $00
     push bc                                       ; $53A2: $C5
     push de                                       ; $53A3: $D5
     push hl                                       ; $53A4: $E5
@@ -1234,9 +1238,9 @@ func_021_53B6::
 
 jr_021_53C0:
     xor  a                                        ; $53C0: $AF
-    ld   [wPaletteUnknownC], a                    ; $53C1: $EA $D3 $DD
+    ld   [wPaletteParticalCopyColorIndexStart], a ; $53C1: $EA $D3 $DD
     ld   a, $20                                   ; $53C4: $3E $20
-    ld   [wPaletteUnknownD], a                    ; $53C6: $EA $D4 $DD
+    ld   [wPaletteParticalCopyColorCount], a      ; $53C6: $EA $D4 $DD
     ld   a, $81                                   ; $53C9: $3E $81
     ld   [wPaletteDataFlags], a                    ; $53CB: $EA $D1 $DD
     ret                                           ; $53CE: $C9
@@ -1355,7 +1359,7 @@ jr_021_5465:
 func_021_5466::
     push bc                                       ; $5466: $C5
     push hl                                       ; $5467: $E5
-    ld   hl, wDC10                                ; $5468: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $5468: $21 $10 $DC
     ld   a, b                                     ; $546B: $78
     sla  a                                        ; $546C: $CB $27
     sla  a                                        ; $546E: $CB $27
@@ -2488,7 +2492,7 @@ Data_021_67D0::
     db   $FF, $7F, $00, $00, $71, $44, $7F, $7D  ; $73A0 |....qD.}|
     db   $FF, $7F, $00, $00, $31, $52, $FE, $63  ; $73A8 |....1R.c|
 
-; Blocks of $40 bytes of data, copied to wDC10
+; Blocks of $40 bytes of data, copied to wBGPal1
 Data_021_73B0::
     db   $FF, $47, $FD, $2E, $B5, $15, $00, $00  ; $73B0 |.G......|
     db   $FF, $47, $31, $52, $C5, $28, $00, $00  ; $73B8 |.G1R.(..|
@@ -2521,7 +2525,7 @@ Data_021_73B0::
     db   $FF, $47, $00, $00, $31, $52, $FF, $47  ; $7490 |.G..1R.G|
     db   $FF, $47, $00, $00, $03, $7E, $FF, $47  ; $7498 |.G...~.G|
 
-; Blocks of $40 bytes of data, copied to wDC10
+; Blocks of $40 bytes of data, copied to wBGPal1
 Data_021_74A0::
     db   $FF, $47, $FD, $2E, $B5, $15, $00, $00  ; $74A0 |.G......|
     db   $FF, $47, $31, $52, $C5, $28, $00, $00  ; $74A8 |.G1R.(..|
@@ -2534,7 +2538,7 @@ Data_021_74A0::
     db   $FD, $2E, $D9, $11, $CE, $10, $00, $00  ; $74E0 |........|
     db   $FF, $47, $00, $00, $31, $52, $FF, $47  ; $74E8 |.G..1R.G|
 
-; Blocks of $80 bytes of data, copied to wDC10
+; Blocks of $80 bytes of data, copied to wBGPal1
 Data_021_74F0::
     dw 0
     dw 0

--- a/src/code/photo_album.asm
+++ b/src/code/photo_album.asm
@@ -211,7 +211,7 @@ ENDC
 
     ld   bc, $80                                ; $415C: JumpTable_028_40FB $01 $80 $00
     ld   hl, PhotoAlbumPalettes                      ; $415F: JumpTable_028_40FB $21 $B0 $7C
-    ld   de, wDC10                              ; $4162: JumpTable_028_40FB $11 $10 $DC
+    ld   de, wBGPal1                            ; $4162: JumpTable_028_40FB $11 $10 $DC
     call func_028_4176                          ; $4165: JumpTable_028_40FB $CD $76 $41
                                                 ; $4168: JumpTable_028_40FB $3E $C7
     ld   a, $C7
@@ -683,7 +683,7 @@ Data_028_4424::
 func_028_442C::
     ld   hl, Data_028_4424                      ; $442C: $21 $24 $44
     ld   bc, $08                                ; $442F: $01 $08 $00
-    ld   de, wDC10                              ; $4432: $11 $10 $DC
+    ld   de, wBGPal1                            ; $4432: $11 $10 $DC
     call func_028_4176                          ; $4435: $CD $76 $41
     ret                                         ; $4438: $C9
 

--- a/src/code/photos.asm
+++ b/src/code/photos.asm
@@ -187,7 +187,7 @@ JumpTable_037_40EC::
     ld   a, [hl+]                                 ; $4129: $2A
     ld   h, [hl]                                  ; $412A: $66
     ld   l, a                                     ; $412B: $6F
-    ld   de, wDC10                                ; $412C: $11 $10 $DC
+    ld   de, wBGPal1                              ; $412C: $11 $10 $DC
     ld   bc, $80                                  ; $412F: $01 $80 $00
     ld   a, $02                                   ; $4132: $3E $02
     ldh  [rSVBK], a                               ; $4134: $E0 $70
@@ -202,7 +202,7 @@ JumpTable_037_40EC::
     ld   hl, Data_037_40E0                        ; $4146: $21 $E0 $40
     add  hl, de                                   ; $4149: $19
     push hl                                       ; $414A: $E5
-    ld   de, wDC54                                ; $414B: $11 $54 $DC
+    ld   de, wObjPal1 + 2*2                       ; $414B: $11 $54 $DC
     ld   a, $02                                   ; $414E: $3E $02
     ld   [rSVBK], a                               ; $4150: $E0 $70
 .loop_4152_37:
@@ -220,7 +220,7 @@ JumpTable_037_40EC::
     cp   GAMEPLAY_PHOTO_MARIN_CLIFF               ; $4161: $FE $10
     jr   nz, .else_4174_37                        ; $4163: $20 $0F
 
-    ld   de, wDC34                                ; $4165: $11 $34 $DC
+    ld   de, wBGPal5 + 2*2                        ; $4165: $11 $34 $DC
     ld   a, $02                                   ; $4168: $3E $02
     ldh  [rSVBK], a                               ; $416A: $E0 $70
     ld   a, [hl+]                                 ; $416C: $2A
@@ -815,7 +815,7 @@ func_037_4552::
 
 .else_4570_37:
     ld   hl, rSVBK                                ; $4570: $21 $70 $FF
-    ld   de, wDC10                                ; $4573: $11 $10 $DC
+    ld   de, wBGPal1                              ; $4573: $11 $10 $DC
 
 .loop_4576_37:
     ld   a, [de]                                  ; $4576: $1A
@@ -872,7 +872,7 @@ func_037_4552::
     jr   nz, .else_45D3_37                        ; $45B7: $20 $1A
 
     ld   hl, rSVBK                                ; $45B9: $21 $70 $FF
-    ld   de, wDC10                                ; $45BC: $11 $10 $DC
+    ld   de, wBGPal1                              ; $45BC: $11 $10 $DC
 
 .loop_45BF_37:
     ld   [hl], $03                                ; $45BF: $36 $03
@@ -937,7 +937,7 @@ func_037_4552::
     di                                            ; $4617: $F3
     ld   a, $03                                   ; $4618: $3E $03
     ldh  [rSVBK], a                               ; $461A: $E0 $70
-    ld   de, wDC10                                ; $461C: $11 $10 $DC
+    ld   de, wBGPal1                              ; $461C: $11 $10 $DC
     ld   hl, Data_037_454A                        ; $461F: $21 $4A $45
 
 .loop_4622_37:

--- a/src/code/world_map.asm
+++ b/src/code/world_map.asm
@@ -30,7 +30,7 @@ WorldMapState0Handler::
     ldh  a, [hIsGBC]                              ; $564B: $F0 $FE
     and  a                                        ; $564D: $A7
     jr   z, WorldMapState1Handler                 ; $564E: $28 $28
-    ld   hl, wDC10                                ; $5650: $21 $10 $DC
+    ld   hl, wBGPal1                              ; $5650: $21 $10 $DC
     ld   c, $80                                   ; $5653: $0E $80
     di                                            ; $5655: $F3
     ld   a, $03                                   ; $5656: $3E $03

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -3018,103 +3018,41 @@ wDC0E::
 wTunicType::
   ds 1 ; DC0F
 
-; Unlabeled
-; palette data?
-wDC10::
+; The buffer containing the 8 background palettes follow. 8 bytes per palette.
+wBGPal1::
   ds 8 ; DC10 - DC17
+wBGPal2::
+  ds 8 ; DC18 - DC1F
+wBGPal3::
+  ds 8 ; DC20 - DC27
+wBGPal4::
+  ds 8 ; DC28 - DC2F
+wBGPal5::
+  ds 8 ; DC30 - DC37
+wBGPal6::
+  ds 8 ; DC38 - DC3F
+wBGPal7::
+  ds 8 ; DC40 - DC47
+wBGPal8::
+  ds 8 ; DC48 - DC4F
 
-; Unlabeled
-wDC18::
-  ds 6 ; DC18 - DC1D
-
-; Unlabeled
-wDC1E::
-  ds $12 ; DC1E - DC2F
-
-; Unlabeled
-; palette data?
-wDC30::
-  ds 4 ; DC30 - DC33
-
-; Unlabeled
-wDC34::
-  ds 6 ; DC34 - DC39
-
-; Unlabeled
-wDC3A::
-  ds 14 ; DC3A - DC47
-
-; Unlabeled
-wDC48::
-  ds 2 ; DC48  - DC49
-
-; Unlabeled
-wDC4A::
-  ds 6 ; DC4A - DC4F
-
-; Unlabeled
-wDC50::
-  ds 2 ; DC50 - DC51
-
-; Unlabeled
-wDC52::
-  ds 1 ; DC52
-
-; not used
-wDC53::
-  ds 1 ; DC52
-
-; Unlabeled
-wDC54::
-  ds 2 ; DC54 - DC55
-
-; Unlabeled
-wDC56::
-  ds 6 ; DC56 - DC5B
-
-; Unlabeled
-wDC5C::
-  ds 8 ; DC5C - DC63
-
-; Unlabeled
-wDC64::
-  ds 12 ; DC64 - DC6F
-
-; Unlabeled
-wDC70::
+; The buffer containing the 8 object palettes follow. 8 bytes per palette.
+wObjPal1::
+  ds 8 ; DC50 - DC57
+wObjPal2::
+  ds 8 ; DC58 - DC5F
+wObjPal3::
+  ds 8 ; DC60 - DC67
+wObjPal4::
+  ds 8 ; DC68 - DC6F
+wObjPal5::
   ds 8 ; DC70 - DC77
-
-; Unlabeled
-wDC78::
-  ds 2 ; DC78 - DC79
-
-; Unlabeled
-wDC7A::
-  ds 6 ; DC7A - DC7F
-
-; Unlabeled
-wDC80::
-  ds 4 ; DC80 - DC83
-
-; Unlabeled
-wDC84::
-  ds 4 ; DC84 - DC87
-
-; Unlabeled
-wDC88::
-  ds 2 ; DC88 - DC89
-
-; Unlabeled
-wDC8A::
-  ds 2 ; DC8A - DC8B
-
-; Unlabeled
-wDC8C::
-  ds 1 ; DC8C
-
-; Unlabeled
-wDC8D::
-  ds 3 ; DC8D
+wObjPal6::
+  ds 8 ; DC78 - DC7F
+wObjPal7::
+  ds 8 ; DC80 - DC87
+wObjPal8::
+  ds 8 ; DC88 - DC8F
 
 ; Unlabeled
 wDC90::
@@ -3145,8 +3083,9 @@ wDCF0::
   ds $E1 ; DCF0 -DDD0
 
 ; Palette flags for copying palettes to hardware.
-; byte 0 = if enabled, palette data is for BG (otherwise for objects),
-; byte 2 = unknown
+; bit 0: If set, copy background palette to hardware during vblank
+; bit 1: If set, copy object palette to hardware during vblank
+; bit 7: If set, do a partial copy specified by wPaletteParticalCopyColorIndexStart and wPaletteParticalCopyColorCount
 wPaletteDataFlags::
   ds 1 ; DDD1
 
@@ -3155,12 +3094,12 @@ wPaletteDataFlags::
 wPaletteToLoadForTileMap::
   ds 1 ; DDD2
 
-; TODO comment
-wPaletteUnknownC::
+; Palete color index to start copying palette data from if bit 7 is set in wPaletteDataFlags
+wPaletteParticalCopyColorIndexStart::
   ds 1 ; DDD3
 
-; TODO comment
-wPaletteUnknownD::
+; Amount of colors to copy if bit 7 is set in wPaletteDataFlags
+wPaletteParticalCopyColorCount::
   ds 1 ; DDD4
 
 ; TODO comment

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -3085,7 +3085,7 @@ wDCF0::
 ; Palette flags for copying palettes to hardware.
 ; bit 0: If set, copy background palette to hardware during vblank
 ; bit 1: If set, copy object palette to hardware during vblank
-; bit 7: If set, do a partial copy specified by wPaletteParticalCopyColorIndexStart and wPaletteParticalCopyColorCount
+; bit 7: If set, do a partial copy specified by wPalettePartialCopyColorIndexStart and wPalettePartialCopyColorCount
 wPaletteDataFlags::
   ds 1 ; DDD1
 
@@ -3095,11 +3095,11 @@ wPaletteToLoadForTileMap::
   ds 1 ; DDD2
 
 ; Palete color index to start copying palette data from if bit 7 is set in wPaletteDataFlags
-wPaletteParticalCopyColorIndexStart::
+wPalettePartialCopyColorIndexStart::
   ds 1 ; DDD3
 
 ; Amount of colors to copy if bit 7 is set in wPaletteDataFlags
-wPaletteParticalCopyColorCount::
+wPalettePartialCopyColorCount::
   ds 1 ; DDD4
 
 ; TODO comment


### PR DESCRIPTION
This documents the inner workings of the palette data a bit.

Biggest changes are related to the labeling of the palette data. I made a label per palette. But sometimes it's even indexed on a color inside a palette. To prevent a lot of labels I just updated the code to do `+ [color]*2`

There are strange things happening in bank36, where it switching wram banks and accessing seemingly "random" spots. But that might be code that is generating the "fading" palette when opening/closing the inventory.

There are also a few changes related to labeling the tunic fairy, I totally forgot that I had that as open changes on my local disk. But there is nothing special there, just a usual jump table with states.