### PR TITLE
src: fix whitespaces around multi-purpose registers

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -197,7 +197,7 @@ func_91D::
 
 .jp_92F
     callsb GetBGAttributesAddressForObject        ; $092F: $3E $1A $EA $00 $21 $CD $76 $65
-    ldh  a, [hMultiPurpose8]                           ; $0937: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $0937: $F0 $DF
     ld   [MBC3SelectBank], a                      ; $0939: $EA $00 $21
     ld   hl, wDC91                                ; $093C: $21 $91 $DC
     ld   a, [wDC90]                               ; $093F: $FA $90 $DC
@@ -206,7 +206,7 @@ func_91D::
     ld   [wDC90], a                               ; $0945: $EA $90 $DC
     ld   d, $00                                   ; $0948: $16 $00
     add  hl, de                                   ; $094A: $19
-    ldh  a, [hMultiPurpose9]                           ; $094B: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $094B: $F0 $E0
     ld   d, a                                     ; $094D: $57
     ldh  a, [hMultiPurposeA]                           ; $094E: $F0 $E1
     ld   e, a                                     ; $0950: $5F
@@ -261,11 +261,11 @@ func_983::
     callsb func_01A_6710                          ; $0983: $3E $1A $EA $00 $21 $CD $10 $67
 
     ; Switch to the bank containing this room's palettes
-    ldh  a, [hMultiPurpose8]                           ; $098B: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $098B: $F0 $DF
     ld   [MBC3SelectBank], a                      ; $098D: $EA $00 $21
 
     ; Read value from address [hMultiPurposeA hMultiPurpose9]
-    ldh  a, [hMultiPurpose9]                           ; $0990: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $0990: $F0 $E0
     ld   h, a                                     ; $0992: $67
     ldh  a, [hMultiPurposeA]                           ; $0993: $F0 $E1
     ld   l, a                                     ; $0995: $6F
@@ -283,10 +283,10 @@ func_999::
     push bc                                       ; $099A: $C5
     call func_983                                 ; $099B: $CD $83 $09
 
-    ldh  [hMultiPurpose0], a                           ; $099E: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $099E: $E0 $D7
     pop  bc                                       ; $09A0: $C1
     call func_983                                 ; $09A1: $CD $83 $09
-    ldh  [hMultiPurpose1], a                           ; $09A4: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $09A4: $E0 $D8
     ld   a, [wDC90]                               ; $09A6: $FA $90 $DC
     ld   c, a                                     ; $09A9: $4F
     ld   b, $00                                   ; $09AA: $06 $00
@@ -300,9 +300,9 @@ func_999::
     ldi  [hl], a                                  ; $09BA: $22
     ld   a, $01                                   ; $09BB: $3E $01
     ldi  [hl], a                                  ; $09BD: $22
-    ldh  a, [hMultiPurpose0]                           ; $09BE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $09BE: $F0 $D7
     ldi  [hl], a                                  ; $09C0: $22
-    ldh  a, [hMultiPurpose1]                           ; $09C1: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $09C1: $F0 $D8
     ldi  [hl], a                                  ; $09C3: $22
     xor  a                                        ; $09C4: $AF
     ldi  [hl], a                                  ; $09C5: $22
@@ -535,7 +535,7 @@ AdjustBankNumberForGBC::
 ;   de :        destination address
 ;   hl :        source address
 CopyObjectsAttributesToWRAM2::
-    ldh  a, [hMultiPurpose0]                           ; $0B1A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $0B1A: $F0 $D7
     ld   [MBC3SelectBank], a                      ; $0B1C: $EA $00 $21
     ld   a, $02                                   ; $0B1F: $3E $02
     ld   [rSVBK], a                               ; $0B21: $E0 $70
@@ -549,7 +549,7 @@ CopyObjectsAttributesToWRAM2::
 
 ; On GBC, copy some overworld objects to ram bank 2
 func_2BF::
-    ldh  [hMultiPurpose2], a                           ; $0B2F: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $0B2F: $E0 $D9
     ldh  a, [hIsGBC]                              ; $0B31: $F0 $FE
     and  a                                        ; $0B33: $A7
     ret  z                                        ; $0B34: $C8
@@ -559,7 +559,7 @@ func_2BF::
     ret  nz                                       ; $0B39: $C0
 
     push bc                                       ; $0B3A: $C5
-    ldh  a, [hMultiPurpose2]                           ; $0B3B: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $0B3B: $F0 $D9
     and  $80                                      ; $0B3D: $E6 $80
     jr   nz, .else                                ; $0B3F: $20 $0A
     callsb func_020_6E50                          ; $0B41: $3E $20 $EA $00 $21 $CD $50 $6E
@@ -573,7 +573,7 @@ func_2BF::
     ld   [rSVBK], a                               ; $0B52: $E0 $70
 .endIf
 
-    ldh  a, [hMultiPurpose2]                           ; $0B54: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $0B54: $F0 $D9
     and  $7F                                      ; $0B56: $E6 $7F
     ld   [MBC3SelectBank], a                      ; $0B58: $EA $00 $21
     pop  bc                                       ; $0B5B: $C1
@@ -946,11 +946,11 @@ AddTranscientVfx::
     ld   hl, wTranscientVfxTypeTable              ; $0CED: $21 $10 $C5
     add  hl, de                                   ; $0CF0: $19
     ld   [hl], a                                  ; $0CF1: $77
-    ldh  a, [hMultiPurpose1]                           ; $0CF2: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $0CF2: $F0 $D8
     ld   hl, wTranscientVfxPosYTable              ; $0CF4: $21 $40 $C5
     add  hl, de                                   ; $0CF7: $19
     ld   [hl], a                                  ; $0CF8: $77
-    ldh  a, [hMultiPurpose0]                           ; $0CF9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $0CF9: $F0 $D7
     ld   hl, wTranscientVfxPosXTable              ; $0CFB: $21 $30 $C5
     add  hl, de                                   ; $0CFE: $19
     ld   [hl], a                                  ; $0CFF: $77
@@ -962,10 +962,10 @@ AddTranscientVfx::
 label_D07::
     ld   a, [wC140]                               ; $0D07: $FA $40 $C1
     sub  a, $08                                   ; $0D0A: $D6 $08
-    ldh  [hMultiPurpose0], a                           ; $0D0C: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $0D0C: $E0 $D7
     ld   a, [wC142]                               ; $0D0E: $FA $42 $C1
     sub  a, $08                                   ; $0D11: $D6 $08
-    ldh  [hMultiPurpose1], a                           ; $0D13: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $0D13: $E0 $D8
 
 label_D15::
     ld   a, JINGLE_SWORD_POKING                   ; $0D15: $3E $07
@@ -1108,7 +1108,7 @@ LoadRoomTiles::
 
     ; $hMultiPurpose0 = 0
     xor  a                                        ; $0D91: $AF
-    ldh  [hMultiPurpose0], a                           ; $0D92: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $0D92: $E0 $D7
     ; e = $hMapRoom
     ldh  a, [hMapRoom]                            ; $0D94: $F0 $F6
     ld   e, a                                     ; $0D96: $5F
@@ -1207,7 +1207,7 @@ LoadRoomTiles::
     cp   $FF                                      ; $0E09: $FE $FF
     jr   z, .label_E29                            ; $0E0B: $28 $1C
     ld   [bc], a                                  ; $0E0D: $02
-    ldh  a, [hMultiPurpose0]                           ; $0E0E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $0E0E: $F0 $D7
     and  a                                        ; $0E10: $A7
     jr   z, .label_E1E                            ; $0E11: $28 $0B
     ld   a, d                                     ; $0E13: $7A
@@ -2623,7 +2623,7 @@ CheckItemsSwordCollision::
     add  hl, de                                   ; $16D9: $19
     ldh  a, [hLinkPositionY]                      ; $16DA: $F0 $99
     add  a, [hl]                                  ; $16DC: $86
-    ldh  [hMultiPurpose1], a                           ; $16DD: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $16DD: $E0 $D8
     ld   a, $04                                   ; $16DF: $3E $04
     ld   [wC502], a                               ; $16E1: $EA $02 $C5
     call label_D15                                ; $16E4: $CD $15 $0D
@@ -2714,7 +2714,7 @@ func_1756::
     ret  nz                                       ; $1766: $C0
 
     ldh  a, [hLinkPositionX]                      ; $1767: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $1769: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $1769: $E0 $D7
 
     ld   a, [wLinkGroundVfx]                      ; $176B: $FA $81 $C1
     cp   GROUND_VFX_SHALLOW_WATER                 ; $176E: $FE $05
@@ -2724,13 +2724,13 @@ func_1756::
     ldh  [hNoiseSfx], a                           ; $1774: $E0 $F4
     ldh  a, [hLinkPositionY]                      ; $1776: $F0 $99
     add  a, $06                                   ; $1778: $C6 $06
-    ldh  [hMultiPurpose1], a                           ; $177A: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $177A: $E0 $D8
     ld   a, TRANSCIENT_VFX_PEGASUS_DUST           ; $177C: $3E $0B
     jp   AddTranscientVfx                         ; $177E: $C3 $C7 $0C
 
 .shallowWater
     ldh  a, [hLinkPositionY]                      ; $1781: $F0 $99
-    ldh  [hMultiPurpose1], a                           ; $1783: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $1783: $E0 $D8
     ld   a, JINGLE_WATER_DIVE                     ; $1785: $3E $0E
     ldh  [hJingle], a                             ; $1787: $E0 $F2
     ld   a, TRANSCIENT_VFX_PEGASUS_SPLASH         ; $1789: $3E $0C
@@ -2756,9 +2756,9 @@ ApplyLinkMotionState::
     ld   a, [wC145]                               ; $17A6: $FA $45 $C1
     ld   hl, wC13B                                ; $17A9: $21 $3B $C1
     add  a, [hl]                                  ; $17AC: $86
-    ldh  [hMultiPurpose0], a                           ; $17AD: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $17AD: $E0 $D7
     ldh  a, [hLinkPositionX]                      ; $17AF: $F0 $98
-    ldh  [hMultiPurpose1], a                           ; $17B1: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $17B1: $E0 $D8
     ld   hl, hMultiPurpose3                            ; $17B3: $21 $DA $FF
     ld   [hl], $00                                ; $17B6: $36 $00
     ld   a, [wSwordCharge]                        ; $17B8: $FA $22 $C1
@@ -2776,7 +2776,7 @@ ApplyLinkMotionState::
     ld   a, [wC13A]                               ; $17CA: $FA $3A $C1
     ld   l, a                                     ; $17CD: $6F
     ld   a, [wSwordDirection]                     ; $17CE: $FA $36 $C1
-    ldh  [hMultiPurpose2], a                           ; $17D1: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $17D1: $E0 $D9
     ldh  a, [hLinkPositionY]                      ; $17D3: $F0 $99
     cp   $88                                      ; $17D5: $FE $88
     ret  nc                                       ; $17D7: $D0
@@ -3073,7 +3073,7 @@ IF __PATCH_0__
 ELSE
     ld   a, $00                                   ; $19C2: $3E $00
 ENDC
-    ldh  [hMultiPurpose0], a                           ; $19C4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $19C4: $E0 $D7
     ld   de, wSpawnLocationData                   ; $19C6: $11 $5F $DB
 
     ; Copy warp data (5 bytes) from wWarp1 to wSpawnLocationData
@@ -3081,9 +3081,9 @@ ENDC
     ld   a, [hli]                                 ; $19C9: $2A
     ld   [de], a                                  ; $19CA: $12
     inc  de                                       ; $19CB: $13
-    ldh  a, [hMultiPurpose0]                           ; $19CC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $19CC: $F0 $D7
     inc  a                                        ; $19CE: $3C
-    ldh  [hMultiPurpose0], a                           ; $19CF: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $19CF: $E0 $D7
     cp   $05                                      ; $19D1: $FE $05
     jr   nz, .loop                                ; $19D3: $20 $F4
 
@@ -3524,7 +3524,7 @@ ENDC
     ; hl = address of the room object that would intersect with the sword
     or   c                                        ; $1F9D: $B1
     ld   e, a                                     ; $1F9E: $5F
-    ldh  [hMultiPurpose1], a                           ; $1F9F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $1F9F: $E0 $D8
     ld   hl, wRoomObjects                         ; $1FA1: $21 $11 $D7
     add  hl, de                                   ; $1FA4: $19
 
@@ -3535,7 +3535,7 @@ ENDC
 
     ; hMultiPurpose0 = id of room object under the sword
     ld   a, [hl]                                  ; $1FAB: $7E
-    ldh  [hMultiPurpose0], a                           ; $1FAC: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $1FAC: $E0 $D7
 
     ; hMultiPurpose5 = unknown value read from the objects tilesets table
     ; d = map group id
@@ -3544,15 +3544,15 @@ ENDC
     ld   a, [wIsIndoor]                           ; $1FAF: $FA $A5 $DB
     ld   d, a                                     ; $1FB2: $57
     call GetObjectPhysicsFlags_trampoline         ; $1FB3: $CD $26 $2A
-    ldh  [hMultiPurpose5], a                           ; $1FB6: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $1FB6: $E0 $DC
 
     ; If the object is $9A, skip this section
 
-    ldh  a, [hMultiPurpose0]                           ; $1FB8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $1FB8: $F0 $D7
     cp   $9A                                      ; $1FBA: $FE $9A
     jr   z, .notObject9AEnd                       ; $1FBC: $28 $40
 
-    ldh  a, [hMultiPurpose5]                           ; $1FBE: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $1FBE: $F0 $DC
     cp   $00                                      ; $1FC0: $FE $00
     jp   z, .clearC15FAndReturn                   ; $1FC2: $CA $4E $21
     cp   $01                                      ; $1FC5: $FE $01
@@ -3571,7 +3571,7 @@ ENDC
     jp   nc, .clearC15FAndReturn                  ; $1FE3: $D2 $4E $21
 
 .jp_1FE6
-    ldh  a, [hMultiPurpose0]                           ; $1FE6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $1FE6: $F0 $D7
     ld   e, a                                     ; $1FE8: $5F
     cp   $6F                                      ; $1FE9: $FE $6F
     jr   z, .jp_1FF6                              ; $1FEB: $28 $09
@@ -3789,7 +3789,7 @@ ELSE
 ENDC
     xor  a                                        ; $2134: $AF
     ldh  [hMultiPurposeE], a                               ; $2135: $E0 $E5
-    ldh  a, [hMultiPurpose0]                           ; $2137: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $2137: $F0 $D7
     cp   $8E                                      ; $2139: $FE $8E
     jr   z, .jr_2153                              ; $213B: $28 $16
     cp   $20                                      ; $213D: $FE $20
@@ -3801,7 +3801,7 @@ IF __PATCH_0__
 ELSE
     jr   nz, .return                              ; $2145: $20 $06
 ENDC
-    ldh  a, [hMultiPurpose0]                           ; $2147: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $2147: $F0 $D7
     cp   $5C                                      ; $2149: $FE $5C
     jr   z, .jr_2161                              ; $214B: $28 $14
 
@@ -3884,7 +3884,7 @@ UpdateFinalLinkPosition::
 .horizontal
    ; Compute next Link horizontal position
     ld   c, $00                                   ; $21B2: $0E $00
-    ldh  [hMultiPurpose0], a                           ; $21B4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $21B4: $E0 $D7
 
 ; Inputs:
 ;   c : direction (0: horizontal ; 1: vertical)
@@ -4011,7 +4011,7 @@ DoUpdateBGRegion::
     push de                                       ; $2242: $D5
 
     ; hl = wRoomObjects + hMultiPurpose2
-    ldh  a, [hMultiPurpose2]                           ; $2243: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $2243: $F0 $D9
     ld   c, a                                     ; $2245: $4F
     ld   b, $00                                   ; $2246: $06 $00
     ld   hl, wRoomObjects                         ; $2248: $21 $11 $D7
@@ -4110,7 +4110,7 @@ DoUpdateBGRegion::
     callsb func_020_49D9                          ; $22B0: $3E $20 $EA $00 $21 $CD $D9 $49
 
     ; Select BG attributes bank
-    ldh  a, [hMultiPurpose8]                           ; $22B8: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $22B8: $F0 $DF
     ld   [MBC3SelectBank], a                      ; $22BA: $EA $00 $21
     ; Increment again the source and target destination
     call IncrementBGMapSourceAndDestination_Vertical ; $22BD: $CD $14 $22
@@ -4141,7 +4141,7 @@ DoUpdateBGRegion::
     push de                                       ; $22DC: $D5
     callsb func_020_49D9                          ; $22DD: $3E $20 $EA $00 $21 $CD $D9 $49
     ; Select BG attributes bank
-    ldh  a, [hMultiPurpose8]                           ; $22E5: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $22E5: $F0 $DF
     ld   [MBC3SelectBank], a                      ; $22E7: $EA $00 $21
     call IncrementBGMapSourceAndDestination_Horizontal ; $22EA: $CD $24 $22
     ld   a, b                                     ; $22ED: $78
@@ -4167,9 +4167,9 @@ DoUpdateBGRegion::
     ld   b, $00                                   ; $2303: $06 $00
     ld   hl, BGRegionIncrement                    ; $2305: $21 $05 $22
     add  hl, bc                                   ; $2308: $09
-    ldh  a, [hMultiPurpose2]                           ; $2309: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $2309: $F0 $D9
     add  a, [hl]                                  ; $230B: $86
-    ldh  [hMultiPurpose2], a                           ; $230C: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $230C: $E0 $D9
     pop  bc                                       ; $230E: $C1
 
     ; Decrement loop counter
@@ -5138,7 +5138,7 @@ LoadTileset9::
     xor  a                                        ; $2E84: $AF
     ; Copy a row of 16 tiles
 .copyOAMTilesRow
-    ldh  [hMultiPurpose0], a                           ; $2E85: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $2E85: $E0 $D7
     ld   hl, wC193                                ; $2E87: $21 $93 $C1
     ld   e, a                                     ; $2E8A: $5F
     ld   d, $00                                   ; $2E8B: $16 $00
@@ -5210,7 +5210,7 @@ LoadTileset9::
 
     ; Do the actual copy to OAM tiles
     ld   [MBC3SelectBank], a                      ; $2EF2: $EA $00 $21
-    ldh  a, [hMultiPurpose0]                           ; $2EF5: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $2EF5: $F0 $D7
     ld   d, a                                     ; $2EF7: $57
     ld   e, $00                                   ; $2EF8: $1E $00
     ; destination = Lower-half of the OAM tiles section (NPCs tiles)
@@ -5226,7 +5226,7 @@ LoadTileset9::
 .copyskipEntityLoad
 
     ; while hMultiPurpose0 < 4, copy the next row
-    ldh  a, [hMultiPurpose0]                           ; $2F0A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $2F0A: $F0 $D7
     inc  a                                        ; $2F0C: $3C
     cp   $04                                      ; $2F0D: $FE $04
     jp   nz, .copyOAMTilesRow                     ; $2F0F: $C2 $85 $2E
@@ -5527,9 +5527,9 @@ doCopyObjectToBG:
 
     ; Copy tile attributes to BG map for tiles on the upper row
     push hl                                       ; $3055: $E5
-    ldh  a, [hMultiPurpose8]                           ; $3056: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $3056: $F0 $DF
     ld   [MBC3SelectBank], a                      ; $3058: $EA $00 $21
-    ldh  a, [hMultiPurpose9]                           ; $305B: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $305B: $F0 $E0
     ld   h, a                                     ; $305D: $67
     ldh  a, [hMultiPurposeA]                           ; $305E: $F0 $E1
     ld   l, a                                     ; $3060: $6F
@@ -5544,7 +5544,7 @@ doCopyObjectToBG:
 
     ; Update palette offset
     ld   a, h                                     ; $306E: $7C
-    ldh  [hMultiPurpose9], a                           ; $306F: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $306F: $E0 $E0
     ld   a, l                                     ; $3071: $7D
     ldh  [hMultiPurposeA], a                           ; $3072: $E0 $E1
     pop  hl                                       ; $3074: $E1
@@ -5563,9 +5563,9 @@ doCopyObjectToBG:
     pop  de                                       ; $3081: $D1
 
     ; Copy palettes from WRAM1 for tiles on the lower row
-    ldh  a, [hMultiPurpose8]                           ; $3082: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $3082: $F0 $DF
     ld   [MBC3SelectBank], a                      ; $3084: $EA $00 $21
-    ldh  a, [hMultiPurpose9]                           ; $3087: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $3087: $F0 $E0
     ld   h, a                                     ; $3089: $67
     ldh  a, [hMultiPurposeA]                           ; $308A: $F0 $E1
     ld   l, a                                     ; $308C: $6F
@@ -6024,7 +6024,7 @@ LoadRoom::
 LoadRoomObject::
     ; Clear hMultiPurpose0
     xor  a                                        ; $32A9: $AF
-    ldh  [hMultiPurpose0], a                           ; $32AA: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $32AA: $E0 $D7
 
     ; If object type first bit is 1…
     ld   a, [bc]                                  ; $32AC: $0A
@@ -6036,7 +6036,7 @@ LoadRoomObject::
     ; … this is a three-bytes object, that spans more than one block.
     ; The first byte encodes the direction and length of the block:
     ; save it to hMultiPurpose0.
-    ldh  [hMultiPurpose0], a                           ; $32B5: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $32B5: $E0 $D7
     ; Skip the parsed direction-and-length byte
     inc  bc                                       ; $32B7: $03
 .threeBytesObjectEnd
@@ -6216,7 +6216,7 @@ LoadRoomObject::
 
     ; hMultiPurpose9 = object type
     ld   a, d                                     ; $3381: $7A
-    ldh  [hMultiPurpose9], a                           ; $3382: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $3382: $E0 $E0
 
     ; If object is an entrance to somewhere else…
     cp   OBJECT_CLOSED_GATE                       ; $3384: $FE $C2
@@ -6254,7 +6254,7 @@ LoadRoomObject::
 .overworldDoorEnd
 
     ; a = object type
-    ldh  a, [hMultiPurpose9]                           ; $33BC: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $33BC: $F0 $E0
 
     cp   $C5                                      ; $33BE: $FE $C5
     jp   z, .configureStairs                      ; $33C0: $CA $7D $34
@@ -6265,7 +6265,7 @@ LoadRoomObject::
 .loadNonDoorIndoorObject
     ; Re-increment a to be the object type
     add  a, OBJECT_KEY_DOOR_TOP                   ; $33CB: $C6 $EC
-    ldh  [hMultiPurpose9], a                           ; $33CD: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $33CD: $E0 $E0
 
     ; If object type is a conveyor belt…
     push af                                       ; $33CF: $F5
@@ -6293,7 +6293,7 @@ LoadRoomObject::
     ldh  a, [hMapRoom]                            ; $33E4: $F0 $F6
     cp   $C4                                      ; $33E6: $FE $C4
     ; … and the object type is not zero…
-    ldh  a, [hMultiPurpose9]                           ; $33E8: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $33E8: $F0 $E0
     jr   z, .torchEnd                             ; $33EA: $28 $1B
     ; …then increment the number of torches in the room
     ld   hl, wTorchesCount                        ; $33EC: $21 $C9 $DB
@@ -6507,7 +6507,7 @@ LoadRoomObject::
 
     ldh  a, [hMapId]                              ; $34B6: $F0 $F7
     cp   MAP_CAVE_B                               ; $34B8: $FE $0A
-    ldh  a, [hMultiPurpose9]                           ; $34BA: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $34BA: $F0 $E0
     jr   c, .bombableBlockEnd                     ; $34BC: $38 $04
     cp   OBJECT_BOMBABLE_BLOCK                    ; $34BE: $FE $A9
     jr   z, .configureBreakableObject             ; $34C0: $28 $04
@@ -6544,7 +6544,7 @@ LoadRoomObject::
 
     ; a = multiple-blocks object direction and length
     ld   d, $00                                   ; $34DA: $16 $00
-    ldh  a, [hMultiPurpose0]                           ; $34DC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $34DC: $F0 $D7
     ; If there are no coordinates for a multiple-blocks object…
     and  a                                        ; $34DE: $A7
     ; … this is a single-block object:
@@ -6560,7 +6560,7 @@ LoadRoomObject::
     ld   hl, wRoomObjects                         ; $34E4: $21 $11 $D7
     add  hl, de                                   ; $34E7: $19
     ; e = count
-    ldh  a, [hMultiPurpose0]                           ; $34E8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $34E8: $F0 $D7
     and  $0F                                      ; $34EA: $E6 $0F
     ld   e, a                                     ; $34EC: $5F
     ; d = object type
@@ -6580,7 +6580,7 @@ FillRoomWithConsecutiveObjects::
     ldi  [hl], a                                  ; $34F0: $22
 
     ; If the object direction is vertical…
-    ldh  a, [hMultiPurpose0]                           ; $34F1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $34F1: $F0 $D7
     and  $40                                      ; $34F3: $E6 $40
     jr   z, .verticalEnd                          ; $34F5: $28 $04
     ; … increment the target address to move to the next column

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -547,10 +547,10 @@ func_001_5511::
 
     push de                                       ; $551F: $D5
     xor  a                                        ; $5520: $AF
-    ldh  [hMultiPurpose0], a                           ; $5521: $E0 $D7
-    ldh  [hMultiPurpose1], a                           ; $5523: $E0 $D8
-    ldh  [hMultiPurpose2], a                           ; $5525: $E0 $D9
-    ldh  [hMultiPurpose3], a                           ; $5527: $E0 $DA
+    ldh  [hMultiPurpose0], a                      ; $5521: $E0 $D7
+    ldh  [hMultiPurpose1], a                      ; $5523: $E0 $D8
+    ldh  [hMultiPurpose2], a                      ; $5525: $E0 $D9
+    ldh  [hMultiPurpose3], a                      ; $5527: $E0 $DA
     ld   c, a                                     ; $5529: $4F
     ld   b, a                                     ; $552A: $47
     ld   e, a                                     ; $552B: $5F
@@ -580,19 +580,19 @@ jr_001_5544::
     ld   hl, Data_001_53D8                        ; $5545: $21 $D8 $53
     add  hl, bc                                   ; $5548: $09
     ld   a, [hl]                                  ; $5549: $7E
-    ldh  [hMultiPurpose0], a                           ; $554A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $554A: $E0 $D7
     ld   hl, Data_001_53E8                        ; $554C: $21 $E8 $53
     add  hl, bc                                   ; $554F: $09
     ld   a, [hl]                                  ; $5550: $7E
-    ldh  [hMultiPurpose1], a                           ; $5551: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5551: $E0 $D8
     ld   hl, Data_001_53F8                        ; $5553: $21 $F8 $53
     add  hl, bc                                   ; $5556: $09
     ld   a, [hl]                                  ; $5557: $7E
-    ldh  [hMultiPurpose2], a                           ; $5558: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5558: $E0 $D9
     ld   hl, Data_001_5408                        ; $555A: $21 $08 $54
     add  hl, bc                                   ; $555D: $09
     ld   a, [hl]                                  ; $555E: $7E
-    ldh  [hMultiPurpose3], a                           ; $555F: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $555F: $E0 $DA
     pop  hl                                       ; $5561: $E1
     call func_001_5619                            ; $5562: $CD $19 $56
     push hl                                       ; $5565: $E5
@@ -607,10 +607,10 @@ jr_001_5544::
     xor  a                                        ; $5572: $AF
     ld   [hl], a                                  ; $5573: $77
     xor  a                                        ; $5574: $AF
-    ldh  [hMultiPurpose0], a                           ; $5575: $E0 $D7
-    ldh  [hMultiPurpose1], a                           ; $5577: $E0 $D8
-    ldh  [hMultiPurpose2], a                           ; $5579: $E0 $D9
-    ldh  [hMultiPurpose3], a                           ; $557B: $E0 $DA
+    ldh  [hMultiPurpose0], a                      ; $5575: $E0 $D7
+    ldh  [hMultiPurpose1], a                      ; $5577: $E0 $D8
+    ldh  [hMultiPurpose2], a                      ; $5579: $E0 $D9
+    ldh  [hMultiPurpose3], a                      ; $557B: $E0 $DA
     ld   c, a                                     ; $557D: $4F
     ld   b, a                                     ; $557E: $47
     ld   e, a                                     ; $557F: $5F
@@ -664,17 +664,17 @@ jr_001_558C::
     ld   hl, Data_001_5418                        ; $55C1: $21 $18 $54
     add  hl, bc                                   ; $55C4: $09
     ld   a, [hl]                                  ; $55C5: $7E
-    ldh  [hMultiPurpose0], a                           ; $55C6: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $55C6: $E0 $D7
     ld   hl, Data_001_545C                        ; $55C8: $21 $5C $54
     add  hl, bc                                   ; $55CB: $09
     ld   a, [hl]                                  ; $55CC: $7E
-    ldh  [hMultiPurpose1], a                           ; $55CD: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $55CD: $E0 $D8
     xor  a                                        ; $55CF: $AF
-    ldh  [hMultiPurpose2], a                           ; $55D0: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $55D0: $E0 $D9
     ld   hl, Data_001_54A0                        ; $55D2: $21 $A0 $54
     add  hl, bc                                   ; $55D5: $09
     ld   a, [hl]                                  ; $55D6: $7E
-    ldh  [hMultiPurpose3], a                           ; $55D7: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $55D7: $E0 $DA
     pop  hl                                       ; $55D9: $E1
     call func_001_5619 ; ???                      ; $55DA: $CD $19 $56
     push hl                                       ; $55DD: $E5
@@ -701,16 +701,16 @@ jr_001_55F5::
     ld   hl, Data_001_54E4                        ; $55F6: $21 $E4 $54
     add  hl, bc                                   ; $55F9: $09
     ld   a, [hl]                                  ; $55FA: $7E
-    ldh  [hMultiPurpose0], a                           ; $55FB: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $55FB: $E0 $D7
     ld   hl, Data_001_54E6                        ; $55FD: $21 $E6 $54
     add  hl, bc                                   ; $5600: $09
     ld   a, [hl]                                  ; $5601: $7E
-    ldh  [hMultiPurpose1], a                           ; $5602: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5602: $E0 $D8
     ld   a, $01                                   ; $5604: $3E $01
-    ldh  [hMultiPurpose2], a                           ; $5606: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5606: $E0 $D9
     ldh  a, [hMapId]                              ; $5608: $F0 $F7
     add  a, $B1                                   ; $560A: $C6 $B1
-    ldh  [hMultiPurpose3], a                           ; $560C: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $560C: $E0 $DA
     pop  hl                                       ; $560E: $E1
     call func_001_5619 ;show dungeon map no       ; $560F: $CD $19 $56
 IF __PATCH_6__
@@ -725,13 +725,13 @@ ENDC
     ret                                           ; $5618: $C9
 
 func_001_5619::
-    ldh  a, [hMultiPurpose0]                           ; $5619: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5619: $F0 $D7
     ldi  [hl], a                                  ; $561B: $22
-    ldh  a, [hMultiPurpose1]                           ; $561C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $561C: $F0 $D8
     ldi  [hl], a                                  ; $561E: $22
-    ldh  a, [hMultiPurpose2]                           ; $561F: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $561F: $F0 $D9
     ldi  [hl], a                                  ; $5621: $22
-    ldh  a, [hMultiPurpose3]                           ; $5622: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $5622: $F0 $DA
     ld   [hl], a                                  ; $5624: $77
     ret                                           ; $5625: $C9
 
@@ -883,7 +883,7 @@ Data_001_5A6E::
 
 func_001_5A71::
     ld   a, [wDBB4]                               ; $5A71: $FA $B4 $DB
-    ldh  [hMultiPurpose0], a                           ; $5A74: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5A74: $E0 $D7
     ld   a, [wC1B3]                               ; $5A76: $FA $B3 $C1
     ld   hl, wC1B2                                ; $5A79: $21 $B2 $C1
     or   [hl]                                     ; $5A7C: $B6
@@ -957,7 +957,7 @@ jr_001_5AA0::
     jr   nz, jr_001_5AF5                          ; $5AE8: $20 $0B
     ld   a, JINGLE_BUMP                           ; $5AEA: $3E $09
     ldh  [hJingle], a                             ; $5AEC: $E0 $F2
-    ldh  a, [hMultiPurpose0]                           ; $5AEE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5AEE: $F0 $D7
     ld   [wDBB4], a                               ; $5AF0: $EA $B4 $DB
     jr   label_001_5B3F                           ; $5AF3: $18 $4A
 
@@ -1289,15 +1289,15 @@ jr_001_5D77::
     ld   hl, $D604                                ; $5D7E: $21 $04 $D6
     add  hl, de                                   ; $5D81: $19
     ld   c, $00                                   ; $5D82: $0E $00
-    ldh  a, [hMultiPurpose2]                           ; $5D84: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $5D84: $F0 $D9
     and  a                                        ; $5D86: $A7
     jr   z, jr_001_5DAB                           ; $5D87: $28 $22
-    ldh  [hMultiPurpose0], a                           ; $5D89: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5D89: $E0 $D7
 
 jr_001_5D8B::
-    ldh  a, [hMultiPurpose0]                           ; $5D8B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5D8B: $F0 $D7
     sub  a, $08                                   ; $5D8D: $D6 $08
-    ldh  [hMultiPurpose0], a                           ; $5D8F: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5D8F: $E0 $D7
     jr   c, jr_001_5DA2                           ; $5D91: $38 $0F
     ld   a, $AE                                   ; $5D93: $3E $AE
     ldi  [hl], a                                  ; $5D95: $22
@@ -1320,7 +1320,7 @@ jr_001_5DA2::
     jr   jr_001_5DB3                              ; $5DA9: $18 $08
 
 jr_001_5DAB::
-    ldh  a, [hMultiPurpose3]                           ; $5DAB: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $5DAB: $F0 $DA
     cp   c                                        ; $5DAD: $B9
     jr   z, jr_001_5DBF                           ; $5DAE: $28 $0F
     ld   a, $AE                                   ; $5DB0: $3E $AE
@@ -1684,30 +1684,30 @@ PrepareEntityPositionForRoomTransition::
     ld   hl, EntityPosXOffsetTable                ; $5EBC: $21 $97 $5E
     add  hl, bc                                   ; $5EBF: $09
     ld   a, [hl]                                  ; $5EC0: $7E
-    ldh  [hMultiPurpose0], a                           ; $5EC1: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5EC1: $E0 $D7
 
     ; hMultiPurpose1 = EntityPosXSignTable[wRoomTransitionDirection]
     ld   hl, EntityPosXSignTable                  ; $5EC3: $21 $9C $5E
     add  hl, bc                                   ; $5EC6: $09
     ld   a, [hl]                                  ; $5EC7: $7E
-    ldh  [hMultiPurpose1], a                           ; $5EC8: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5EC8: $E0 $D8
 
     ; hMultiPurpose2 = EntityPosYOffsetTable[wRoomTransitionDirection]
     ld   hl, EntityPosYOffsetTable                ; $5ECA: $21 $A1 $5E
     add  hl, bc                                   ; $5ECD: $09
     ld   a, [hl]                                  ; $5ECE: $7E
-    ldh  [hMultiPurpose2], a                           ; $5ECF: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5ECF: $E0 $D9
 
     ; hMultiPurpose3 = EntityPosYSignTable[wRoomTransitionDirection]
     ld   hl, EntityPosYSignTable                  ; $5ED1: $21 $A6 $5E
     add  hl, bc                                   ; $5ED4: $09
     ld   a, [hl]                                  ; $5ED5: $7E
-    ldh  [hMultiPurpose3], a                           ; $5ED6: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $5ED6: $E0 $DA
 
     ; [wEntitiesPosXTable + de] += [hMultiPurpose0]
     ld   hl, wEntitiesPosXTable                   ; $5ED8: $21 $00 $C2
     add  hl, de                                   ; $5EDB: $19
-    ldh  a, [hMultiPurpose0]                           ; $5EDC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5EDC: $F0 $D7
     add  a, [hl]                                  ; $5EDE: $86
     ld   [hl], a                                  ; $5EDF: $77
 
@@ -1715,7 +1715,7 @@ PrepareEntityPositionForRoomTransition::
     rr   c                                        ; $5EE0: $CB $19
     ld   hl, wEntitiesPosXSignTable               ; $5EE2: $21 $20 $C2
     add  hl, de                                   ; $5EE5: $19
-    ldh  a, [hMultiPurpose1]                           ; $5EE6: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5EE6: $F0 $D8
     rl   c                                        ; $5EE8: $CB $11
     adc  a, [hl]                                  ; $5EEA: $8E
     ld   [hl], a                                  ; $5EEB: $77
@@ -1723,7 +1723,7 @@ PrepareEntityPositionForRoomTransition::
     ; [wEntitiesPosYTable + de] += [hMultiPurpose2]
     ld   hl, wEntitiesPosYTable                   ; $5EEC: $21 $10 $C2
     add  hl, de                                   ; $5EEF: $19
-    ldh  a, [hMultiPurpose2]                           ; $5EF0: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $5EF0: $F0 $D9
     add  a, [hl]                                  ; $5EF2: $86
     ld   [hl], a                                  ; $5EF3: $77
 
@@ -1731,7 +1731,7 @@ PrepareEntityPositionForRoomTransition::
     rr   c                                        ; $5EF4: $CB $19
     ld   hl, wEntitiesPosYSignTable               ; $5EF6: $21 $30 $C2
     add  hl, de                                   ; $5EF9: $19
-    ldh  a, [hMultiPurpose3]                           ; $5EFA: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $5EFA: $F0 $DA
     rl   c                                        ; $5EFC: $CB $11
     adc  a, [hl]                                  ; $5EFE: $8E
     ld   [hl], a                                  ; $5EFF: $77
@@ -2762,15 +2762,15 @@ func_001_6BF0::
 
 jr_001_6BF4::
     ld   a, c                                     ; $6BF4: $79
-    ldh  [hMultiPurpose9], a                           ; $6BF5: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $6BF5: $E0 $E0
     ld   d, $00                                   ; $6BF7: $16 $00
 
 label_001_6BF9::
     xor  a                                        ; $6BF9: $AF
-    ldh  [hMultiPurpose0], a                           ; $6BFA: $E0 $D7
-    ldh  [hMultiPurpose1], a                           ; $6BFC: $E0 $D8
-    ldh  [hMultiPurpose2], a                           ; $6BFE: $E0 $D9
-    ldh  [hMultiPurpose3], a                           ; $6C00: $E0 $DA
+    ldh  [hMultiPurpose0], a                      ; $6BFA: $E0 $D7
+    ldh  [hMultiPurpose1], a                      ; $6BFC: $E0 $D8
+    ldh  [hMultiPurpose2], a                      ; $6BFE: $E0 $D9
+    ldh  [hMultiPurpose3], a                      ; $6C00: $E0 $DA
     ld   hl, $DB65                                ; $6C02: $21 $65 $DB
     add  hl, de                                   ; $6C05: $19
     ld   a, [hl]                                  ; $6C06: $7E
@@ -2785,13 +2785,13 @@ label_001_6BF9::
     ld   h, $9D                                   ; $6C15: $26 $9D
     push hl                                       ; $6C17: $E5
     ld   a, $7C                                   ; $6C18: $3E $7C
-    ldh  [hMultiPurpose0], a                           ; $6C1A: $E0 $D7
-    ldh  [hMultiPurpose1], a                           ; $6C1C: $E0 $D8
-    ldh  [hMultiPurpose2], a                           ; $6C1E: $E0 $D9
+    ldh  [hMultiPurpose0], a                      ; $6C1A: $E0 $D7
+    ldh  [hMultiPurpose1], a                      ; $6C1C: $E0 $D8
+    ldh  [hMultiPurpose2], a                      ; $6C1E: $E0 $D9
     ld   hl, Data_001_6BD7                        ; $6C20: $21 $D7 $6B
     add  hl, de                                   ; $6C23: $19
     ld   a, [hl]                                  ; $6C24: $7E
-    ldh  [hMultiPurpose3], a                           ; $6C25: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6C25: $E0 $DA
     pop  hl                                       ; $6C27: $E1
     jr   jr_001_6C48                              ; $6C28: $18 $1E
 
@@ -2807,28 +2807,28 @@ label_001_6C2A::
     ld   hl, Data_001_6BDF                        ; $6C36: $21 $DF $6B
     add  hl, de                                   ; $6C39: $19
     ld   a, [hl]                                  ; $6C3A: $7E
-    ldh  [hMultiPurpose0], a                           ; $6C3B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6C3B: $E0 $D7
     inc  a                                        ; $6C3D: $3C
-    ldh  [hMultiPurpose1], a                           ; $6C3E: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6C3E: $E0 $D8
     add  a, $0F                                   ; $6C40: $C6 $0F
-    ldh  [hMultiPurpose2], a                           ; $6C42: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $6C42: $E0 $D9
     inc  a                                        ; $6C44: $3C
-    ldh  [hMultiPurpose3], a                           ; $6C45: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6C45: $E0 $DA
     pop  hl                                       ; $6C47: $E1
 
 jr_001_6C48::
-    ldh  a, [hMultiPurpose0]                           ; $6C48: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6C48: $F0 $D7
     ld   [hl], a                                  ; $6C4A: $77
     call func_001_6C69                            ; $6C4B: $CD $69 $6C
-    ldh  a, [hMultiPurpose1]                           ; $6C4E: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6C4E: $F0 $D8
     ld   [hl], a                                  ; $6C50: $77
     inc  c                                        ; $6C51: $0C
     call func_001_6C69                            ; $6C52: $CD $69 $6C
-    ldh  a, [hMultiPurpose2]                           ; $6C55: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $6C55: $F0 $D9
     ld   [hl], a                                  ; $6C57: $77
     inc  c                                        ; $6C58: $0C
     call func_001_6C69                            ; $6C59: $CD $69 $6C
-    ldh  a, [hMultiPurpose3]                           ; $6C5C: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $6C5C: $F0 $DA
     ld   [hl], a                                  ; $6C5E: $77
     inc  e                                        ; $6C5F: $1C
     ld   a, e                                     ; $6C60: $7B

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -473,7 +473,7 @@ UpdatePaletteEffectForInteractiveObjects::
 
     ; If Link's motion state doesn't allow for palette effects, return
     xor  a                                        ; $4C5D: $AF
-    ldh  [hMultiPurpose0], a                           ; $4C5E: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4C5E: $E0 $D7
     ld   d, a                                     ; $4C60: $57
     ld   a, [wLinkMotionState]                    ; $4C61: $FA $1C $C1
     ld   e, a                                     ; $4C64: $5F
@@ -494,7 +494,7 @@ UpdatePaletteEffectForInteractiveObjects::
     jr   nz, .jr_014_4C82                         ; $4C7B: $20 $05
 
     ld   a, [wC3CD]                               ; $4C7D: $FA $CD $C3
-    ldh  [hMultiPurpose0], a                           ; $4C80: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4C80: $E0 $D7
 
 .jr_014_4C82
     ld   a, [wBGPaletteEffectAddress]             ; $4C82: $FA $CC $C3
@@ -517,7 +517,7 @@ UpdatePaletteEffectForInteractiveObjects::
     and  $01                                      ; $4C9E: $E6 $01
     jr   nz, .return                              ; $4CA0: $20 $0F
 
-    ldh  a, [hMultiPurpose0]                           ; $4CA2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4CA2: $F0 $D7
     ld   hl, wBGPaletteEffectAddress              ; $4CA4: $21 $CC $C3
     sub  [hl]                                     ; $4CA7: $96
     jr   z, .return                               ; $4CA8: $28 $07
@@ -540,7 +540,7 @@ jr_014_4CB2:
     or   [hl]                                     ; $4CB8: $B6
     ret  nz                                       ; $4CB9: $C0
 
-    ldh  a, [hMultiPurpose0]                           ; $4CBA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4CBA: $F0 $D7
     ld   hl, wBGPaletteEffectAddress              ; $4CBC: $21 $CC $C3
     sub  [hl]                                     ; $4CBF: $96
     jr   nz, jr_014_4CC7                          ; $4CC0: $20 $05
@@ -946,7 +946,7 @@ jr_014_5036:
 RenderTransitionEffect::
     srl  a                                        ; $5038: $CB $3F
     srl  a                                        ; $503A: $CB $3F
-    ldh  [hMultiPurpose0], a                           ; $503C: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $503C: $E0 $D7
     ld   a, [wTransitionGfxFrameCount]            ; $503E: $FA $80 $C1
     nop                                           ; $5041: $00
     and  $E0                                      ; $5042: $E6 $E0
@@ -961,20 +961,20 @@ RenderTransitionEffect::
 
 jr_014_5050:
     ld   a, e                                     ; $5050: $7B
-    ldh  [hMultiPurpose1], a                           ; $5051: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5051: $E0 $D8
     ld   hl, wC17C                                ; $5053: $21 $7C $C1
     xor  a                                        ; $5056: $AF
     ld   [hl+], a                                 ; $5057: $22
     ld   [hl+], a                                 ; $5058: $22
     ld   [hl+], a                                 ; $5059: $22
     ld   a, $58                                   ; $505A: $3E $58
-    ldh  [hMultiPurpose2], a                           ; $505C: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $505C: $E0 $D9
     ldh  a, [hIsGBC]                              ; $505E: $F0 $FE
     and  a                                        ; $5060: $A7
     jr   z, label_014_5067                        ; $5061: $28 $04
 
     ld   a, $88                                   ; $5063: $3E $88
-    ldh  [hMultiPurpose2], a                           ; $5065: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5065: $E0 $D9
 
 label_014_5067:
     ldh  a, [rSTAT]                               ; $5067: $F0 $41
@@ -996,7 +996,7 @@ jr_014_506F:
     ld   a, [wC17D]                               ; $5082: $FA $7D $C1
     adc  $00                                      ; $5085: $CE $00
     ld   [wC17D], a                               ; $5087: $EA $7D $C1
-    ldh  a, [hMultiPurpose2]                           ; $508A: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $508A: $F0 $D9
     ld   hl, wC17C                                ; $508C: $21 $7C $C1
     cp   [hl]                                     ; $508F: $BE
     ret  z                                        ; $5090: $C8
@@ -1009,7 +1009,7 @@ jr_014_506F:
     inc  c                                        ; $509A: $0C
 
 jr_014_509B:
-    ldh  a, [hMultiPurpose0]                           ; $509B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $509B: $F0 $D7
     add  [hl]                                     ; $509D: $86
     and  $1F                                      ; $509E: $E6 $1F
     ld   hl, hMultiPurpose1                            ; $50A0: $21 $D8 $FF
@@ -2195,5 +2195,5 @@ jr_014_5920:
     ld   a, $1C                                   ; $592F: $3E $1C
 
 jr_014_5931:
-    ldh  [hMultiPurpose8], a                           ; $5931: $E0 $DF
+    ldh  [hMultiPurpose8], a                      ; $5931: $E0 $DF
     ret                                           ; $5933: $C9

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -28,7 +28,7 @@ SpawnChestWithItem::
     ld   [hl], a                                  ; $41F2: $77
     ld   hl, wEntitiesSpriteVariantTable          ; $41F3: $21 $B0 $C3
     add  hl, de                                   ; $41F6: $19
-    ldh  a, [hMultiPurpose8]                           ; $41F7: $F0 $DF
+    ldh  a, [hMultiPurpose8]                      ; $41F7: $F0 $DF
     ld   [hl], a                                  ; $41F9: $77
 
 .return
@@ -739,9 +739,9 @@ groundVfxEnd:
 
 shallowWaterVfx:
     ldh  a, [hLinkPositionY]                      ; $45AD: $F0 $99
-    ldh  [hMultiPurpose1], a                           ; $45AF: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $45AF: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $45B1: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $45B3: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $45B3: $E0 $D7
     ld   a, JINGLE_WATER_DIVE                     ; $45B5: $3E $0E
     ldh  [hJingle], a                             ; $45B7: $E0 $F2
     ld   a, TRANSCIENT_VFX_PEGASUS_SPLASH         ; $45B9: $3E $0C
@@ -1795,7 +1795,7 @@ jr_002_4C8B:
     ret                                           ; $4C91: $C9
 
 label_002_4C92:
-    ldh  a, [hMultiPurpose1]                           ; $4C92: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4C92: $F0 $D8
     ld   e, a                                     ; $4C94: $5F
     ld   d, $00                                   ; $4C95: $16 $00
     ld   hl, wRoomObjects                         ; $4C97: $21 $11 $D7
@@ -1868,13 +1868,13 @@ jr_002_4CD3:
     ld   b, d                                     ; $4D07: $42
     ld   a, $0C                                   ; $4D08: $3E $0C
     call ApplyVectorTowardsLink_trampoline        ; $4D0A: $CD $AA $3B
-    ldh  a, [hMultiPurpose0]                           ; $4D0D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D0D: $F0 $D7
     cpl                                           ; $4D0F: $2F
     inc  a                                        ; $4D10: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $4D11: $21 $50 $C2
     add  hl, bc                                   ; $4D14: $09
     ld   [hl], a                                  ; $4D15: $77
-    ldh  a, [hMultiPurpose1]                           ; $4D16: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4D16: $F0 $D8
     cpl                                           ; $4D18: $2F
     inc  a                                        ; $4D19: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $4D1A: $21 $40 $C2
@@ -1920,7 +1920,7 @@ func_002_4D20::
     ldh  [hSwordIntersectedAreaY], a              ; $4D52: $E0 $CD
     or   c                                        ; $4D54: $B1
     ld   e, a                                     ; $4D55: $5F
-    ldh  [hMultiPurpose1], a                           ; $4D56: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4D56: $E0 $D8
     ld   hl, wRoomObjects                         ; $4D58: $21 $11 $D7
     add  hl, de                                   ; $4D5B: $19
     ld   a, h                                     ; $4D5C: $7C
@@ -1928,7 +1928,7 @@ func_002_4D20::
     jp   nz, label_002_4D95                       ; $4D5F: $C2 $95 $4D
 
     ld   a, [hl]                                  ; $4D62: $7E
-    ldh  [hMultiPurpose0], a                           ; $4D63: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4D63: $E0 $D7
     ld   e, a                                     ; $4D65: $5F
     ld   a, [wIsIndoor]                           ; $4D66: $FA $A5 $DB
     ld   d, a                                     ; $4D69: $57
@@ -1940,7 +1940,7 @@ func_002_4D20::
     and  a                                        ; $4D72: $A7
     jr   nz, jr_002_4D8D                          ; $4D73: $20 $18
 
-    ldh  a, [hMultiPurpose0]                           ; $4D75: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D75: $F0 $D7
     cp   $0C                                      ; $4D77: $FE $0C
     jr   z, label_002_4D95                        ; $4D79: $28 $1A
 
@@ -1959,7 +1959,7 @@ func_002_4D20::
     jr   jr_002_4D93                              ; $4D8B: $18 $06
 
 jr_002_4D8D:
-    ldh  a, [hMultiPurpose0]                           ; $4D8D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D8D: $F0 $D7
     cp   $05                                      ; $4D8F: $FE $05
     jr   nz, label_002_4D95                       ; $4D91: $20 $02
 
@@ -1972,12 +1972,12 @@ label_002_4D95:
     ret                                           ; $4D96: $C9
 
 label_002_4D97:
-    ldh  a, [hMultiPurpose0]                           ; $4D97: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D97: $F0 $D7
     ldh  [hSwordIntersectedAreaX], a              ; $4D99: $E0 $CE
     swap a                                        ; $4D9B: $CB $37
     and  $0F                                      ; $4D9D: $E6 $0F
     ld   e, a                                     ; $4D9F: $5F
-    ldh  a, [hMultiPurpose1]                           ; $4DA0: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4DA0: $F0 $D8
     ldh  [hSwordIntersectedAreaY], a              ; $4DA2: $E0 $CD
     and  $F0                                      ; $4DA4: $E6 $F0
     or   e                                        ; $4DA6: $B3
@@ -2786,17 +2786,17 @@ func_002_524A::
 jr_002_524F:
     ldh  a, [hLinkPositionX]                      ; $524F: $F0 $98
     sub  $08                                      ; $5251: $D6 $08
-    ldh  [hMultiPurpose1], a                           ; $5253: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5253: $E0 $D8
     ldh  a, [hFrameCounter]                       ; $5255: $F0 $E7
     rla                                           ; $5257: $17
     rla                                           ; $5258: $17
     and  $10                                      ; $5259: $E6 $10
-    ldh  [hMultiPurpose3], a                           ; $525B: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $525B: $E0 $DA
     xor  a                                        ; $525D: $AF
     ld   h, a                                     ; $525E: $67
     ld   l, a                                     ; $525F: $6F
     ld   a, $06                                   ; $5260: $3E $06
-    ldh  [hMultiPurpose2], a                           ; $5262: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5262: $E0 $D9
     jp   func_1819                                ; $5264: $C3 $19 $18
 
 LinkMotionRecoverHandler::
@@ -2948,7 +2948,7 @@ label_002_5310::
     ld   hl, hMultiPurpose0                            ; $5351: $21 $D7 $FF
     add  [hl]                                     ; $5354: $86
     ld   [hl], a                                  ; $5355: $77
-    ldh  a, [hMultiPurpose2]                           ; $5356: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $5356: $F0 $D9
     cp   $FF                                      ; $5358: $FE $FF
     jr   z, jr_002_535E                           ; $535A: $28 $02
 
@@ -2956,7 +2956,7 @@ label_002_5310::
     ld   [de], a                                  ; $535D: $12
 
 jr_002_535E::
-    ldh  a, [hMultiPurpose3]                           ; $535E: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $535E: $F0 $DA
     cp   $FF                                      ; $5360: $FE $FF
     jr   z, jr_002_5366                           ; $5362: $28 $02
 
@@ -2966,7 +2966,7 @@ jr_002_535E::
 jr_002_5366::
     inc  de                                       ; $5366: $13
     inc  bc                                       ; $5367: $03
-    ldh  a, [hMultiPurpose1]                           ; $5368: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5368: $F0 $D8
     ld   hl, hLinkPositionX                       ; $536A: $21 $98 $FF
     add  [hl]                                     ; $536D: $86
     ld   [de], a                                  ; $536E: $12
@@ -2974,15 +2974,15 @@ jr_002_5366::
     ld   [bc], a                                  ; $5371: $02
     inc  de                                       ; $5372: $13
     inc  bc                                       ; $5373: $03
-    ldh  a, [hMultiPurpose2]                           ; $5374: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $5374: $F0 $D9
     ld   [de], a                                  ; $5376: $12
-    ldh  a, [hMultiPurpose3]                           ; $5377: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $5377: $F0 $DA
     ld   [bc], a                                  ; $5379: $02
     inc  de                                       ; $537A: $13
     inc  bc                                       ; $537B: $03
-    ldh  a, [hMultiPurpose4]                           ; $537C: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $537C: $F0 $DB
     ld   [de], a                                  ; $537E: $12
-    ldh  a, [hMultiPurpose5]                           ; $537F: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $537F: $F0 $DC
     ld   [bc], a                                  ; $5381: $02
     ret                                           ; $5382: $C9
 
@@ -3051,12 +3051,12 @@ TryOpenLockedDoor::
     or   $40                                      ; $53CC: $F6 $40
     ld   [hl], a                                  ; $53CE: $77
     ldh  [hRoomStatus], a                         ; $53CF: $E0 $F8
-    ldh  a, [hMultiPurpose4]                           ; $53D1: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $53D1: $F0 $DB
     and  $F0                                      ; $53D3: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $53D5: $E0 $CE
     swap a                                        ; $53D7: $CB $37
     ld   e, a                                     ; $53D9: $5F
-    ldh  a, [hMultiPurpose5]                           ; $53DA: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $53DA: $F0 $DC
     and  $F0                                      ; $53DC: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $53DE: $E0 $CD
     or   e                                        ; $53E0: $B3
@@ -3066,10 +3066,10 @@ TryOpenLockedDoor::
     call func_014_5526_trampoline                 ; $53E4: $CD $78 $21
     ldh  a, [hSwordIntersectedAreaX]              ; $53E7: $F0 $CE
     add  $08                                      ; $53E9: $C6 $08
-    ldh  [hMultiPurpose0], a                           ; $53EB: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $53EB: $E0 $D7
     ldh  a, [hSwordIntersectedAreaY]              ; $53ED: $F0 $CD
     add  $10                                      ; $53EF: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $53F1: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $53F1: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $53F3: $3E $02
     call AddTranscientVfx                         ; $53F5: $CD $C7 $0C
     jp   .return                                  ; $53F8: $C3 $1D $54
@@ -3082,13 +3082,13 @@ TryOpenLockedDoor::
     ld   hl, wEntitiesStatusTable                 ; $5402: $21 $80 $C2
     add  hl, de                                   ; $5405: $19
     dec  [hl]                                     ; $5406: $35
-    ldh  a, [hMultiPurpose4]                           ; $5407: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $5407: $F0 $DB
     and  $F0                                      ; $5409: $E6 $F0
     add  $08                                      ; $540B: $C6 $08
     ld   hl, wEntitiesPosXTable                   ; $540D: $21 $00 $C2
     add  hl, de                                   ; $5410: $19
     ld   [hl], a                                  ; $5411: $77
-    ldh  a, [hMultiPurpose5]                           ; $5412: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $5412: $F0 $DC
     and  $F0                                      ; $5414: $E6 $F0
     add  $10                                      ; $5416: $C6 $10
     ld   hl, wEntitiesPosYTable                   ; $5418: $21 $10 $C2
@@ -3387,7 +3387,7 @@ RenderTranscientVfx::
     ; Decrement the vfx countdown
     dec  a                                        ; $5576: $3D
     ld   [hl], a                                  ; $5577: $77
-    ldh  [hMultiPurpose0], a                           ; $5578: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5578: $E0 $D7
     ; if the VFX countdown reached zero, remove the effect
     jr   nz, .render                              ; $557A: $20 $03
 
@@ -3471,10 +3471,10 @@ RenderTranscientLavaSplash::
     ld   c, $04                                   ; $561C: $0E $04
 
 jr_002_561E:
-    ldh  a, [hMultiPurpose1]                           ; $561E: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $561E: $F0 $D8
     ld   [de], a                                  ; $5620: $12
     inc  de                                       ; $5621: $13
-    ldh  a, [hMultiPurpose2]                           ; $5622: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $5622: $F0 $D9
     ld   hl, Data_002_5600 - 1                    ; $5624: $21 $FF $55
     add  hl, bc                                   ; $5627: $09
     add  [hl]                                     ; $5628: $86
@@ -3506,7 +3506,7 @@ RenderTranscientRumble::
     ld   [wC167], a                               ; $564A: $EA $67 $C1
     xor  a                                        ; $564D: $AF
     ld   [wScreenShakeHorizontal], a              ; $564E: $EA $55 $C1
-    ldh  a, [hMultiPurpose0]                           ; $5651: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5651: $F0 $D7
     cp   $02                                      ; $5653: $FE $02
     jr   nc, jr_002_565B                          ; $5655: $30 $04
 
@@ -3558,7 +3558,7 @@ jr_002_568C:
     cp   $08                                      ; $568E: $FE $08
     jp   nz, label_002_5707                       ; $5690: $C2 $07 $57
 
-    ldh  a, [hMultiPurpose0]                           ; $5693: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5693: $F0 $D7
     rra                                           ; $5695: $1F
     rra                                           ; $5696: $1F
     rra                                           ; $5697: $1F
@@ -3568,9 +3568,9 @@ jr_002_568C:
     ld   hl, Data_002_5642                        ; $569C: $21 $42 $56
     add  hl, de                                   ; $569F: $19
     ld   a, [hl+]                                 ; $56A0: $2A
-    ldh  [hMultiPurpose0], a                           ; $56A1: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $56A1: $E0 $D7
     ld   a, [hl]                                  ; $56A3: $7E
-    ldh  [hMultiPurpose1], a                           ; $56A4: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $56A4: $E0 $D8
     ld   a, $60                                   ; $56A6: $3E $60
     ldh  [hSwordIntersectedAreaX], a              ; $56A8: $E0 $CE
     ldh  a, [hMapRoom]                            ; $56AA: $F0 $F6
@@ -3596,7 +3596,7 @@ jr_002_56B8:
     ld   [hl+], a                                 ; $56CB: $22
     ld   a, $41                                   ; $56CC: $3E $41
     ld   [hl+], a                                 ; $56CE: $22
-    ldh  a, [hMultiPurpose0]                           ; $56CF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $56CF: $F0 $D7
     ld   [hl+], a                                 ; $56D1: $22
     ldh  a, [hFFCF]                               ; $56D2: $F0 $CF
     ld   [hl+], a                                 ; $56D4: $22
@@ -3605,7 +3605,7 @@ jr_002_56B8:
     ld   [hl+], a                                 ; $56D9: $22
     ld   a, $41                                   ; $56DA: $3E $41
     ld   [hl+], a                                 ; $56DC: $22
-    ldh  a, [hMultiPurpose1]                           ; $56DD: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $56DD: $F0 $D8
     ld   [hl+], a                                 ; $56DF: $22
     ld   [hl], b                                  ; $56E0: $70
     ld   a, e                                     ; $56E1: $7B
@@ -3639,7 +3639,7 @@ Data_002_5708::
 
 RenderTranscientPegasusDust::
     call func_002_58D0                            ; $5718: $CD $D0 $58
-    ldh  a, [hMultiPurpose0]                           ; $571B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $571B: $F0 $D7
     and  $08                                      ; $571D: $E6 $08
     ld   d, $00                                   ; $571F: $16 $00
     ld   e, a                                     ; $5721: $5F
@@ -3658,7 +3658,7 @@ Data_002_5736::
 
 RenderTranscientSmoke::
     call func_002_58D0                            ; $5746: $CD $D0 $58
-    ldh  a, [hMultiPurpose0]                           ; $5749: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5749: $F0 $D7
     and  $08                                      ; $574B: $E6 $08
     ld   d, $00                                   ; $574D: $16 $00
     ld   e, a                                     ; $574F: $5F
@@ -3672,7 +3672,7 @@ Data_002_575A::
     db   $01, $01, $FF, $FF
 
 RenderTranscientMovingSparkle::
-    ldh  a, [hMultiPurpose0]                           ; $575E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $575E: $F0 $D7
     cp   $0A                                      ; $5760: $FE $0A
     jr   c, jr_002_5780                           ; $5762: $38 $1C
 
@@ -3699,7 +3699,7 @@ jr_002_5780:
     call func_002_58D0                            ; $5780: $CD $D0 $58
     push bc                                       ; $5783: $C5
     ld   c, $3A                                   ; $5784: $0E $3A
-    ldh  a, [hMultiPurpose0]                           ; $5786: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5786: $F0 $D7
     cp   $07                                      ; $5788: $FE $07
     jr   nc, jr_002_578E                          ; $578A: $30 $02
 
@@ -3711,17 +3711,17 @@ jr_002_578E:
     ld   d, $00                                   ; $5792: $16 $00
     ld   hl, wDynamicOAMBuffer                    ; $5794: $21 $30 $C0
     add  hl, de                                   ; $5797: $19
-    ldh  a, [hMultiPurpose1]                           ; $5798: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5798: $F0 $D8
     ld   [hl+], a                                 ; $579A: $22
-    ldh  a, [hMultiPurpose2]                           ; $579B: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $579B: $F0 $D9
     ld   [hl+], a                                 ; $579D: $22
     ld   a, c                                     ; $579E: $79
     ld   [hl+], a                                 ; $579F: $22
     xor  a                                        ; $57A0: $AF
     ld   [hl+], a                                 ; $57A1: $22
-    ldh  a, [hMultiPurpose1]                           ; $57A2: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $57A2: $F0 $D8
     ld   [hl+], a                                 ; $57A4: $22
-    ldh  a, [hMultiPurpose2]                           ; $57A5: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $57A5: $F0 $D9
     add  $08                                      ; $57A7: $C6 $08
     ld   [hl+], a                                 ; $57A9: $22
     ld   a, c                                     ; $57AA: $79
@@ -3740,9 +3740,9 @@ jr_002_57BB:
     ld   d, $00                                   ; $57BB: $16 $00
     ld   hl, wDynamicOAMBuffer                    ; $57BD: $21 $30 $C0
     add  hl, de                                   ; $57C0: $19
-    ldh  a, [hMultiPurpose1]                           ; $57C1: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $57C1: $F0 $D8
     ld   [hl+], a                                 ; $57C3: $22
-    ldh  a, [hMultiPurpose2]                           ; $57C4: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $57C4: $F0 $D9
     ld   [hl+], a                                 ; $57C6: $22
     ld   a, $24                                   ; $57C7: $3E $24
     ld   [hl+], a                                 ; $57C9: $22
@@ -3762,7 +3762,7 @@ Data_002_57DD::
 
 RenderTranscientSwordPoke::
     call func_002_58D0                            ; $57ED: $CD $D0 $58
-    ldh  a, [hMultiPurpose0]                           ; $57F0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $57F0: $F0 $D7
     and  $08                                      ; $57F2: $E6 $08
     ld   d, $00                                   ; $57F4: $16 $00
     ld   e, a                                     ; $57F6: $5F
@@ -3791,7 +3791,7 @@ jr_002_582D:
     ld   hl, Data_002_57FD                        ; $5830: $21 $FD $57
 
 jr_002_5833:
-    ldh  a, [hMultiPurpose0]                           ; $5833: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5833: $F0 $D7
     and  $08                                      ; $5835: $E6 $08
     ld   e, a                                     ; $5837: $5F
     ld   d, $00                                   ; $5838: $16 $00
@@ -3813,12 +3813,12 @@ label_002_583A:
     jp   label_002_58F5                           ; $5851: $C3 $F5 $58
 
 label_002_5854:
-    ldh  a, [hMultiPurpose1]                           ; $5854: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5854: $F0 $D8
     add  [hl]                                     ; $5856: $86
     ld   [de], a                                  ; $5857: $12
     inc  hl                                       ; $5858: $23
     inc  de                                       ; $5859: $13
-    ldh  a, [hMultiPurpose2]                           ; $585A: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $585A: $F0 $D9
     add  [hl]                                     ; $585C: $86
     ld   [de], a                                  ; $585D: $12
     inc  hl                                       ; $585E: $23
@@ -3835,7 +3835,7 @@ Data_002_5867::
     db   $00, $00, $7A, $00, $00, $08, $7A, $20, $00, $00, $78, $00, $00, $08, $78, $20
 
 label_002_5877:
-    ldh  a, [hMultiPurpose0]                           ; $5877: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5877: $F0 $D7
     and  $08                                      ; $5879: $E6 $08
     ld   d, $00                                   ; $587B: $16 $00
     ld   e, a                                     ; $587D: $5F
@@ -3848,7 +3848,7 @@ Data_002_5884::
 
 RenderTranscientPoof::
     call func_002_58D0                            ; $58A4: $CD $D0 $58
-    ldh  a, [hMultiPurpose0]                           ; $58A7: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $58A7: $F0 $D7
     cp   $04                                      ; $58A9: $FE $04
     jr   nz, jr_002_58BB                          ; $58AB: $20 $0E
 
@@ -3868,7 +3868,7 @@ jr_002_58BB:
     call func_002_5F5C                            ; $58BF: $CD $5C $5F
 
 jr_002_58C2:
-    ldh  a, [hMultiPurpose0]                           ; $58C2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $58C2: $F0 $D7
     rla                                           ; $58C4: $17
     and  $18                                      ; $58C5: $E6 $18
     ld   d, $00                                   ; $58C7: $16 $00
@@ -3880,14 +3880,14 @@ func_002_58D0::
     ld   hl, wTranscientVfxPosYTable              ; $58D0: $21 $40 $C5
     add  hl, bc                                   ; $58D3: $09
     ld   a, [hl]                                  ; $58D4: $7E
-    ldh  [hMultiPurpose1], a                           ; $58D5: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $58D5: $E0 $D8
     cp   $88                                      ; $58D7: $FE $88
     jr   nc, ClearTranscientVfx                   ; $58D9: $30 $0B
 
     ld   hl, wTranscientVfxPosXTable              ; $58DB: $21 $30 $C5
     add  hl, bc                                   ; $58DE: $09
     ld   a, [hl]                                  ; $58DF: $7E
-    ldh  [hMultiPurpose2], a                           ; $58E0: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $58E0: $E0 $D9
     cp   $A8                                      ; $58E2: $FE $A8
     jr   c, jr_002_58EC                           ; $58E4: $38 $06
 
@@ -3943,9 +3943,9 @@ func_002_5926::
     ldh  a, [hLinkPositionY]                      ; $5926: $F0 $99
 
 func_002_5928::
-    ldh  [hMultiPurpose1], a                           ; $5928: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5928: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $592A: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $592C: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $592C: $E0 $D7
     ld   a, JINGLE_WATER_DIVE                     ; $592E: $3E $0E
     ldh  [hJingle], a                             ; $5930: $E0 $F2
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $5932: $3E $01
@@ -4241,7 +4241,7 @@ jr_002_5B31:
     ld   hl, wC1F0                                ; $5B41: $21 $F0 $C1
     add  hl, bc                                   ; $5B44: $09
     ld   a, [hl]                                  ; $5B45: $7E
-    ldh  [hMultiPurpose0], a                           ; $5B46: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5B46: $E0 $D7
     ld   a, c                                     ; $5B48: $79
     and  $07                                      ; $5B49: $E6 $07
     ld   c, a                                     ; $5B4B: $4F
@@ -4522,7 +4522,7 @@ jr_002_5CE5:
     ld   hl, wC1F4                                ; $5CF7: $21 $F4 $C1
     add  hl, bc                                   ; $5CFA: $09
     ld   a, [hl]                                  ; $5CFB: $7E
-    ldh  [hMultiPurpose0], a                           ; $5CFC: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5CFC: $E0 $D7
 
 jr_002_5CFE:
     ld   hl, Data_002_5BF4                        ; $5CFE: $21 $F4 $5B
@@ -5179,12 +5179,12 @@ LoadHeartsCount::
     and  a                                        ; $643D: $A7
     jr   z, jr_002_6462                           ; $643E: $28 $22
 
-    ldh  [hMultiPurpose0], a                           ; $6440: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6440: $E0 $D7
 
 jr_002_6442:
-    ldh  a, [hMultiPurpose0]                           ; $6442: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6442: $F0 $D7
     sub  $08                                      ; $6444: $D6 $08
-    ldh  [hMultiPurpose0], a                           ; $6446: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6446: $E0 $D7
     jr   c, jr_002_6459                           ; $6448: $38 $0F
 
     ld   a, $A9                                   ; $644A: $3E $A9
@@ -5381,7 +5381,7 @@ jr_002_6982:
     and  a                                        ; $698B: $A7
     ret  nz                                       ; $698C: $C0
 
-    ldh  a, [hMultiPurpose0]                           ; $698D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $698D: $F0 $D7
     cp   $B0                                      ; $698F: $FE $B0
     jr   z, jr_002_699E                           ; $6991: $28 $0B
 
@@ -5438,7 +5438,7 @@ jr_002_69D7:
     and  a                                        ; $69E0: $A7
     ret  nz                                       ; $69E1: $C0
 
-    ldh  a, [hMultiPurpose0]                           ; $69E2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $69E2: $F0 $D7
     cp   $B1                                      ; $69E4: $FE $B1
     jr   z, jr_002_69F3                           ; $69E6: $28 $0B
 
@@ -5645,7 +5645,7 @@ jr_002_6AFC:
     and  a                                        ; $6B02: $A7
     ret  nz                                       ; $6B03: $C0
 
-    ldh  a, [hMultiPurpose0]                           ; $6B04: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6B04: $F0 $D7
     cp   $B1                                      ; $6B06: $FE $B1
     jr   z, jr_002_6B2A                           ; $6B08: $28 $20
 
@@ -5730,8 +5730,8 @@ label_002_6B66:
     ld   c, $04                                   ; $6B66: $0E $04
     ld   b, $00                                   ; $6B68: $06 $00
     call func_002_6C2F                            ; $6B6A: $CD $2F $6C
-    ldh  a, [hMultiPurpose1]                           ; $6B6D: $F0 $D8
-    ldh  [hMultiPurpose0], a                           ; $6B6F: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $6B6D: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $6B6F: $E0 $D7
     xor  a                                        ; $6B71: $AF
     ld   [wCollisionType], a                      ; $6B72: $EA $33 $C1
     ld   c, $00                                   ; $6B75: $0E $00
@@ -5885,7 +5885,7 @@ func_002_6C2F::
     ld   a, [wIsIndoor]                           ; $6C58: $FA $A5 $DB
     ld   d, a                                     ; $6C5B: $57
     call GetObjectPhysicsFlags_trampoline         ; $6C5C: $CD $26 $2A
-    ldh  [hMultiPurpose1], a                           ; $6C5F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6C5F: $E0 $D8
     cp   $60                                      ; $6C61: $FE $60
     jr   z, func_002_6C69                         ; $6C63: $28 $04
 
@@ -6458,7 +6458,7 @@ func_002_6F2C::
     ldh  a, [hLinkPositionX]                      ; $6F30: $F0 $98
     sub  $08                                      ; $6F32: $D6 $08
     add  [hl]                                     ; $6F34: $86
-    ldh  [hMultiPurpose4], a                           ; $6F35: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $6F35: $E0 $DB
     swap a                                        ; $6F37: $CB $37
     and  $0F                                      ; $6F39: $E6 $0F
     ld   e, a                                     ; $6F3B: $5F
@@ -6467,7 +6467,7 @@ func_002_6F2C::
     ldh  a, [hLinkPositionY]                      ; $6F40: $F0 $99
     add  [hl]                                     ; $6F42: $86
     sub  $10                                      ; $6F43: $D6 $10
-    ldh  [hMultiPurpose5], a                           ; $6F45: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $6F45: $E0 $DC
     and  $F0                                      ; $6F47: $E6 $F0
     or   e                                        ; $6F49: $B3
     ld   e, a                                     ; $6F4A: $5F
@@ -6608,9 +6608,9 @@ jr_002_700D:
 jr_002_7015:
     ; Schedule deep rumble animation
     ldh  a, [hLinkPositionY]                      ; $7015: $F0 $99
-    ldh  [hMultiPurpose1], a                           ; $7017: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7017: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $7019: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $701B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $701B: $E0 $D7
     ld   a, TRANSCIENT_VFX_RUMBLE                 ; $701D: $3E $09
     call AddTranscientVfx                         ; $701F: $CD $C7 $0C
     ld   [hl], $DF                                ; $7022: $36 $DF
@@ -6664,7 +6664,7 @@ jr_002_7053:
     cp   $00                                      ; $7069: $FE $00
     jr   nz, jr_002_7078                          ; $706B: $20 $0B
 
-    ldh  a, [hMultiPurpose4]                           ; $706D: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $706D: $F0 $DB
     and  $0F                                      ; $706F: $E6 $0F
     cp   $08                                      ; $7071: $FE $08
     jp   c, label_002_7461                        ; $7073: $DA $61 $74
@@ -6675,7 +6675,7 @@ jr_002_7078:
     cp   $01                                      ; $7078: $FE $01
     jr   nz, jr_002_7085                          ; $707A: $20 $09
 
-    ldh  a, [hMultiPurpose4]                           ; $707C: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $707C: $F0 $DB
     and  $0F                                      ; $707E: $E6 $0F
     cp   $08                                      ; $7080: $FE $08
     jp   nc, label_002_7461                       ; $7082: $D2 $61 $74
@@ -6846,13 +6846,13 @@ jr_002_716E:
     ld   d, $00                                   ; $717B: $16 $00
     ld   hl, Data_002_49CA                        ; $717D: $21 $CA $49
     add  hl, de                                   ; $7180: $19
-    ldh  a, [hMultiPurpose4]                           ; $7181: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $7181: $F0 $DB
     rra                                           ; $7183: $1F
     rra                                           ; $7184: $1F
     rra                                           ; $7185: $1F
     and  $01                                      ; $7186: $E6 $01
     ld   e, a                                     ; $7188: $5F
-    ldh  a, [hMultiPurpose5]                           ; $7189: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $7189: $F0 $DC
     rra                                           ; $718B: $1F
     rra                                           ; $718C: $1F
     and  $02                                      ; $718D: $E6 $02
@@ -6875,7 +6875,7 @@ label_002_719C:
     cp   ENTITY_ROOSTER                           ; $71A7: $FE $D5
     jp   z, collisionEnd                          ; $71A9: $CA $54 $74
 
-    ldh  a, [hMultiPurpose5]                           ; $71AC: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $71AC: $F0 $DC
     and  $0F                                      ; $71AE: $E6 $0F
     cp   $08                                      ; $71B0: $FE $08
     jp   c, label_002_7461                        ; $71B2: $DA $61 $74
@@ -6888,7 +6888,7 @@ label_002_71BB:
     and  a                                        ; $71BE: $A7
     jp   nz, collisionEnd                         ; $71BF: $C2 $54 $74
 
-    ldh  a, [hMultiPurpose5]                           ; $71C2: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $71C2: $F0 $DC
     and  $0F                                      ; $71C4: $E6 $0F
     cp   $06                                      ; $71C6: $FE $06
     jp   nc, label_002_726A                       ; $71C8: $D2 $6A $72
@@ -6996,7 +6996,7 @@ label_002_7260:
     jp   z, label_002_7461                        ; $7267: $CA $61 $74
 
 label_002_726A:
-    ldh  a, [hMultiPurpose4]                           ; $726A: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $726A: $F0 $DB
     and  $0F                                      ; $726C: $E6 $0F
     cp   $06                                      ; $726E: $FE $06
     jr   c, label_002_7277                        ; $7270: $38 $05
@@ -7156,10 +7156,10 @@ jr_002_734F:
     and  a                                        ; $7352: $A7
     jp   z, collisionEnd                          ; $7353: $CA $54 $74
 
-    ldh  a, [hMultiPurpose4]                           ; $7356: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $7356: $F0 $DB
     and  $F0                                      ; $7358: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $735A: $E0 $CE
-    ldh  a, [hMultiPurpose5]                           ; $735C: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $735C: $F0 $DC
     and  $F0                                      ; $735E: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $7360: $E0 $CD
     ldh  a, [hDungeonFloorTile]                   ; $7362: $F0 $E9
@@ -7239,14 +7239,14 @@ IF __PATCH_0__
 ENDC
     and  $F0                                      ; $73CC: $E6 $F0
     or   e                                        ; $73CE: $B3
-    ldh  [hMultiPurpose0], a                           ; $73CF: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $73CF: $E0 $D7
     ld   e, $00                                   ; $73D1: $1E $00
     ld   d, e                                     ; $73D3: $53
 
 jr_002_73D4:
     ld   hl, Data_002_73A3                        ; $73D4: $21 $A3 $73
     add  hl, de                                   ; $73D7: $19
-    ldh  a, [hMultiPurpose0]                           ; $73D8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $73D8: $F0 $D7
     cp   [hl]                                     ; $73DA: $BE
     jr   nz, jr_002_73E6                          ; $73DB: $20 $09
 
@@ -7387,7 +7387,7 @@ func_002_7468::
     jr   nz, jr_002_7493                          ; $7470: $20 $21
 
 jr_002_7472:
-    ldh  a, [hMultiPurpose5]                           ; $7472: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $7472: $F0 $DC
     and  $0F                                      ; $7474: $E6 $0F
     cp   $06                                      ; $7476: $FE $06
     jr   nc, jr_002_74AC                          ; $7478: $30 $32
@@ -7417,7 +7417,7 @@ jr_002_7493:
     jr   nz, jr_002_74AC                          ; $74A1: $20 $09
 
 jr_002_74A3:
-    ldh  a, [hMultiPurpose5]                           ; $74A3: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $74A3: $F0 $DC
     and  $0F                                      ; $74A5: $E6 $0F
     cp   $0C                                      ; $74A7: $FE $0C
     jp   nc, ApplyMapFadeOutTransitionWithNoise   ; $74A9: $D2 $7D $0C
@@ -7489,13 +7489,13 @@ Data_002_750E::
 func_002_7512::
     ldh  a, [hLinkPositionX]                      ; $7512: $F0 $98
     and  $F0                                      ; $7514: $E6 $F0
-    ldh  [hMultiPurpose0], a                           ; $7516: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7516: $E0 $D7
     swap a                                        ; $7518: $CB $37
     ld   e, a                                     ; $751A: $5F
     ldh  a, [hLinkPositionY]                      ; $751B: $F0 $99
     sub  $04                                      ; $751D: $D6 $04
     and  $F0                                      ; $751F: $E6 $F0
-    ldh  [hMultiPurpose1], a                           ; $7521: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7521: $E0 $D8
     or   e                                        ; $7523: $B3
     ld   e, a                                     ; $7524: $5F
     ldh  [hLinkRoomPosition], a                   ; $7525: $E0 $FA
@@ -7727,7 +7727,7 @@ jr_002_7672:
     ld   hl, hLinkPositionX                       ; $7672: $21 $98 $FF
     add  [hl]                                     ; $7675: $86
     ld   [hl], a                                  ; $7676: $77
-    ldh  a, [hMultiPurpose1]                           ; $7677: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7677: $F0 $D8
     add  $10                                      ; $7679: $C6 $10
     ld   hl, hLinkPositionY                       ; $767B: $21 $99 $FF
     sub  [hl]                                     ; $767E: $96

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -550,22 +550,22 @@ Data_020_4870::
 func_020_4874::
     ld   hl, Data_020_486C                        ; $4874: $21 $6C $48
     add  hl, de                                   ; $4877: $19
-    ldh  a, [hMultiPurpose0]                           ; $4878: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4878: $F0 $D7
     add  [hl]                                     ; $487A: $86
     sub  $08                                      ; $487B: $D6 $08
     and  $F0                                      ; $487D: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $487F: $E0 $CE
     swap a                                        ; $4881: $CB $37
-    ldh  [hMultiPurpose0], a                           ; $4883: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4883: $E0 $D7
     ld   hl, Data_020_4870                        ; $4885: $21 $70 $48
     add  hl, de                                   ; $4888: $19
-    ldh  a, [hMultiPurpose1]                           ; $4889: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4889: $F0 $D8
     add  [hl]                                     ; $488B: $86
     sub  $10                                      ; $488C: $D6 $10
     and  $F0                                      ; $488E: $E6 $F0
     ld   e, a                                     ; $4890: $5F
     ldh  [hSwordIntersectedAreaY], a              ; $4891: $E0 $CD
-    ldh  a, [hMultiPurpose0]                           ; $4893: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4893: $F0 $D7
     or   e                                        ; $4895: $B3
     ld   e, a                                     ; $4896: $5F
     ret                                           ; $4897: $C9
@@ -628,9 +628,9 @@ func_020_48CA::
     ldh  a, [hLinkDirection]                      ; $48DD: $F0 $9E
     ld   e, a                                     ; $48DF: $5F
     ldh  a, [hLinkPositionX]                      ; $48E0: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $48E2: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $48E2: $E0 $D7
     ldh  a, [hLinkPositionY]                      ; $48E4: $F0 $99
-    ldh  [hMultiPurpose1], a                           ; $48E6: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $48E6: $E0 $D8
     call func_020_4874                            ; $48E8: $CD $74 $48
     ld   hl, wRoomObjects                         ; $48EB: $21 $11 $D7
     add  hl, de                                   ; $48EE: $19
@@ -706,25 +706,25 @@ Data_020_4950::
 func_020_4954::
     ld   a, [hl]                                  ; $4954: $7E
     inc  a                                        ; $4955: $3C
-    ldh  [hMultiPurpose0], a                           ; $4956: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4956: $E0 $D7
     dec  a                                        ; $4958: $3D
     cp   $55                                      ; $4959: $FE $55
     jr   nz, jr_020_4961                          ; $495B: $20 $04
 
     ld   a, $AE                                   ; $495D: $3E $AE
-    ldh  [hMultiPurpose0], a                           ; $495F: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $495F: $E0 $D7
 
 jr_020_4961:
-    ldh  a, [hMultiPurpose0]                           ; $4961: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4961: $F0 $D7
     ld   [hl], a                                  ; $4963: $77
     call label_2887                               ; $4964: $CD $87 $28
     push bc                                       ; $4967: $C5
-    ldh  a, [hMultiPurpose0]                           ; $4968: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4968: $F0 $D7
     ld   [wDDD8], a                               ; $496A: $EA $D8 $DD
     ld   a, $20                                   ; $496D: $3E $20
     call func_91D                                 ; $496F: $CD $1D $09
     pop  bc                                       ; $4972: $C1
-    ldh  a, [hMultiPurpose0]                           ; $4973: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4973: $F0 $D7
     cp   $AE                                      ; $4975: $FE $AE
     jr   nz, jr_020_497F                          ; $4977: $20 $06
 
@@ -897,7 +897,7 @@ func_020_4A76::
     ld   c, a                                     ; $4A79: $4F
     ld   b, $00                                   ; $4A7A: $06 $00
     ld   a, [wTransitionOffset]                               ; $4A7C: $FA $2A $C1
-    ldh  [hMultiPurpose2], a                           ; $4A7F: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $4A7F: $E0 $D9
     ld   hl, Data_020_49EC                        ; $4A81: $21 $EC $49
     add  hl, bc                                   ; $4A84: $09
     ldh  a, [hIsGBC]                              ; $4A85: $F0 $FE
@@ -927,16 +927,16 @@ Data_020_4AA4::
 
 func_020_4AB3::
     push hl                                       ; $4AB3: $E5
-    ldh  a, [hMultiPurpose0]                           ; $4AB4: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4AB4: $F0 $D7
     add  h                                        ; $4AB6: $84
     ld   [bc], a                                  ; $4AB7: $02
     inc  bc                                       ; $4AB8: $03
-    ldh  a, [hMultiPurpose1]                           ; $4AB9: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4AB9: $F0 $D8
     add  l                                        ; $4ABB: $85
     ld   [bc], a                                  ; $4ABC: $02
     inc  bc                                       ; $4ABD: $03
     ld   hl, Data_020_4A93                        ; $4ABE: $21 $93 $4A
-    ldh  a, [hMultiPurpose2]                           ; $4AC1: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $4AC1: $F0 $D9
     sla  a                                        ; $4AC3: $CB $27
     ld   e, a                                     ; $4AC5: $5F
     ld   d, $00                                   ; $4AC6: $16 $00
@@ -963,7 +963,7 @@ jr_020_4AD4:
     and  a                                        ; $4AE1: $A7
     jr   z, jr_020_4AEF                           ; $4AE2: $28 $0B
 
-    ldh  a, [hMultiPurpose3]                           ; $4AE4: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $4AE4: $F0 $DA
     and  a                                        ; $4AE6: $A7
     jr   z, jr_020_4AEF                           ; $4AE7: $28 $06
 
@@ -975,11 +975,11 @@ jr_020_4AD4:
 jr_020_4AEF:
     inc  bc                                       ; $4AEF: $03
     pop  hl                                       ; $4AF0: $E1
-    ldh  a, [hMultiPurpose0]                           ; $4AF1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4AF1: $F0 $D7
     add  h                                        ; $4AF3: $84
     ld   [bc], a                                  ; $4AF4: $02
     inc  bc                                       ; $4AF5: $03
-    ldh  a, [hMultiPurpose1]                           ; $4AF6: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4AF6: $F0 $D8
     add  l                                        ; $4AF8: $85
     add  $08                                      ; $4AF9: $C6 $08
     ld   [bc], a                                  ; $4AFB: $02
@@ -999,7 +999,7 @@ jr_020_4AEF:
     and  a                                        ; $4B10: $A7
     jr   z, jr_020_4B1E                           ; $4B11: $28 $0B
 
-    ldh  a, [hMultiPurpose3]                           ; $4B13: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $4B13: $F0 $DA
     and  a                                        ; $4B15: $A7
     jr   z, jr_020_4B1E                           ; $4B16: $28 $06
 
@@ -1590,7 +1590,7 @@ jr_020_527C:
     ld   hl, data_020_5246                        ; $5280: $21 $46 $52
     add  hl, de                                   ; $5283: $19
     ld   a, [hl]                                  ; $5284: $7E
-    ldh  [hMultiPurpose0], a                           ; $5285: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5285: $E0 $D7
     sla  e                                        ; $5287: $CB $23
     ld   hl, data_020_5224                        ; $5289: $21 $24 $52
     add  hl, de                                   ; $528C: $19
@@ -1623,7 +1623,7 @@ jr_020_52A8:
     and  [hl]                                     ; $52AF: $A6
     jr   nz, jr_020_52A8                          ; $52B0: $20 $F6
 
-    ldh  a, [hMultiPurpose0]                           ; $52B2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $52B2: $F0 $D7
     ld   l, a                                     ; $52B4: $6F
     ld   a, [wC17C]                               ; $52B5: $FA $7C $C1
     ld   e, a                                     ; $52B8: $5F
@@ -2032,10 +2032,10 @@ jr_020_55F0:
 
     inc  [hl]                                     ; $5601: $34
     xor  a                                        ; $5602: $AF
-    ldh  [hMultiPurpose0], a                           ; $5603: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5603: $E0 $D7
 
 jr_020_5605:
-    ldh  a, [hMultiPurpose0]                           ; $5605: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5605: $F0 $D7
     cp   $03                                      ; $5607: $FE $03
     jr   z, jr_020_562E                           ; $5609: $28 $23
 
@@ -2092,10 +2092,10 @@ func_020_564B::
     jr   z, jr_020_568A                           ; $564D: $28 $3B
 
     xor  a                                        ; $564F: $AF
-    ldh  [hMultiPurpose0], a                           ; $5650: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5650: $E0 $D7
 
 jr_020_5652:
-    ldh  a, [hMultiPurpose0]                           ; $5652: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5652: $F0 $D7
     cp   $03                                      ; $5654: $FE $03
     jr   z, jr_020_568A                           ; $5656: $28 $32
 
@@ -2109,7 +2109,7 @@ jr_020_5652:
     ld   b, $00                                   ; $5662: $06 $00
 
 jr_020_5664:
-    ldh  a, [hMultiPurpose0]                           ; $5664: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5664: $F0 $D7
     sla  a                                        ; $5666: $CB $27
     sla  a                                        ; $5668: $CB $27
     or   b                                        ; $566A: $B0
@@ -2677,7 +2677,7 @@ InventoryLoad2Handler::
     ld   hl, tradingItemPaletteIndexes           ; $5B08: $21 $EE $5A
     add  hl, bc                                   ; $5B0B: $09
     ld   a, [hl]                                  ; $5B0C: $7E
-    ldh  [hMultiPurpose0], a                           ; $5B0D: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5B0D: $E0 $D7
     ld   a, $9C                                   ; $5B0F: $3E $9C
     ld   [wDC91], a                               ; $5B11: $EA $91 $DC
     ld   [wDC91+4], a                               ; $5B14: $EA $95 $DC
@@ -2688,7 +2688,7 @@ InventoryLoad2Handler::
     ld   a, $41                                   ; $5B21: $3E $41
     ld   [wDC91+2], a                               ; $5B23: $EA $93 $DC
     ld   [wDC91+6], a                               ; $5B26: $EA $97 $DC
-    ldh  a, [hMultiPurpose0]                           ; $5B29: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5B29: $F0 $D7
     ld   [wDC91+3], a                               ; $5B2B: $EA $94 $DC
     ld   [wDC91+7], a                               ; $5B2E: $EA $98 $DC
     xor  a                                        ; $5B31: $AF
@@ -2706,7 +2706,7 @@ jr_020_5B3D:
     ret                                           ; $5B48: $C9
 
 AdjustInventoryTilesForLevelsAndCounts::
-    ldh  a, [hMultiPurpose1]                           ; $5B49: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5B49: $F0 $D8
     cp   INVENTORY_OCARINA                        ; $5B4B: $FE $09
     jr   z, jr_020_5B8B                           ; $5B4D: $28 $3C
 
@@ -2827,7 +2827,7 @@ func_020_5BB9::
     ld   a, $81                                   ; $5BD8: $3E $81
     ld   [hl+], a                                 ; $5BDA: $22
     push hl                                       ; $5BDB: $E5
-    ldh  a, [hMultiPurpose1]                           ; $5BDC: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5BDC: $F0 $D8
     sla  a                                        ; $5BDE: $CB $27
     ld   c, a                                     ; $5BE0: $4F
     ld   hl, InventoryItemPaletteIndexes          ; $5BE1: $21 $14 $5C
@@ -2942,12 +2942,12 @@ func_020_5C9C::
     ld   hl, wBButtonSlot                         ; $5C9E: $21 $00 $DB
     add  hl, bc                                   ; $5CA1: $09
     ld   a, [hl]                                  ; $5CA2: $7E
-    ldh  [hMultiPurpose1], a                           ; $5CA3: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5CA3: $E0 $D8
     sla  a                                        ; $5CA5: $CB $27
     ld   e, a                                     ; $5CA7: $5F
     sla  a                                        ; $5CA8: $CB $27
     add  e                                        ; $5CAA: $83
-    ldh  [hMultiPurpose0], a                           ; $5CAB: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5CAB: $E0 $D7
     ldh  a, [hIsGBC]                              ; $5CAD: $F0 $FE
     and  a                                        ; $5CAF: $A7
     jr   z, jr_020_5CB5                           ; $5CB0: $28 $03
@@ -2990,7 +2990,7 @@ jr_020_5CB5:
     ld   [hl+], a                                 ; $5CD6: $22
 
     push hl                                       ; $5CD7: $E5
-    ldh  a, [hMultiPurpose0]                           ; $5CD8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5CD8: $F0 $D7
     ld   c, a                                     ; $5CDA: $4F
 
     ; de = InventoryItemTiles + [hMultiPurpose0]
@@ -3038,7 +3038,7 @@ jr_020_5CB5:
     ld   a, $02                                   ; $5D06: $3E $02
     ld   [hl+], a                                 ; $5D08: $22
     push hl                                       ; $5D09: $E5
-    ldh  a, [hMultiPurpose0]                           ; $5D0A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5D0A: $F0 $D7
     ld   c, a                                     ; $5D0C: $4F
     ld   hl, InventoryItemTiles + 3               ; $5D0D: $21 $33 $5C
     add  hl, bc                                   ; $5D10: $09
@@ -4019,7 +4019,7 @@ jr_020_63AB:
     add  [hl]                                     ; $63B2: $86
     pop  hl                                       ; $63B3: $E1
     ld   [hl+], a                                 ; $63B4: $22
-    ldh  a, [hMultiPurpose0]                           ; $63B5: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $63B5: $F0 $D7
     ld   [hl+], a                                 ; $63B7: $22
     ld   a, $04                                   ; $63B8: $3E $04
     ld   [hl+], a                                 ; $63BA: $22
@@ -4643,7 +4643,7 @@ func_020_6A68::
     ld   a, $1F                                   ; $6A74: $3E $1F
 
 jr_020_6A76:
-    ldh  [hMultiPurpose0], a                           ; $6A76: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6A76: $E0 $D7
     ldh  a, [hMultiPurposeE]                           ; $6A78: $F0 $E5
     ld   c, a                                     ; $6A7A: $4F
     ld   a, [hl+]                                 ; $6A7B: $2A
@@ -4662,7 +4662,7 @@ jr_020_6A76:
     ld   a, $3E                                   ; $6A8E: $3E $3E
 
 jr_020_6A90:
-    ldh  [hMultiPurpose1], a                           ; $6A90: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6A90: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $6A92: $F0 $E6
     ld   c, a                                     ; $6A94: $4F
     ld   a, [hl]                                  ; $6A95: $7E
@@ -4674,17 +4674,17 @@ jr_020_6A90:
     ld   a, $7C                                   ; $6A9D: $3E $7C
 
 jr_020_6A9F:
-    ldh  [hMultiPurpose2], a                           ; $6A9F: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $6A9F: $E0 $D9
     pop  hl                                       ; $6AA1: $E1
-    ldh  a, [hMultiPurpose0]                           ; $6AA2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6AA2: $F0 $D7
     ld   b, a                                     ; $6AA4: $47
-    ldh  a, [hMultiPurpose1]                           ; $6AA5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6AA5: $F0 $D8
     swap a                                        ; $6AA7: $CB $37
     ld   c, a                                     ; $6AA9: $4F
     and  $E0                                      ; $6AAA: $E6 $E0
     or   b                                        ; $6AAC: $B0
     ld   [hl+], a                                 ; $6AAD: $22
-    ldh  a, [hMultiPurpose2]                           ; $6AAE: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $6AAE: $F0 $D9
     ld   b, a                                     ; $6AB0: $47
     ld   a, c                                     ; $6AB1: $79
     and  $03                                      ; $6AB2: $E6 $03
@@ -4716,7 +4716,7 @@ func_020_6AC1::
     ldh  [hFreeWarpDataAddress], a                ; $6AD5: $E0 $E6
     ld   hl, wBGPal1                              ; $6AD7: $21 $10 $DC
     ld   a, $40                                   ; $6ADA: $3E $40
-    ldh  [hMultiPurpose3], a                           ; $6ADC: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6ADC: $E0 $DA
     ld   a, e                                     ; $6ADE: $7B
     and  $10                                      ; $6ADF: $E6 $10
     jr   z, func_020_6AF5                         ; $6AE1: $28 $12
@@ -4764,7 +4764,7 @@ jr_020_6B17:
     ld   a, b                                     ; $6B17: $78
 
 jr_020_6B18:
-    ldh  [hMultiPurpose0], a                           ; $6B18: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6B18: $E0 $D7
     ld   a, e                                     ; $6B1A: $7B
     and  $E0                                      ; $6B1B: $E6 $E0
     swap a                                        ; $6B1D: $CB $37
@@ -4801,7 +4801,7 @@ jr_020_6B43:
     ld   a, b                                     ; $6B43: $78
 
 jr_020_6B44:
-    ldh  [hMultiPurpose1], a                           ; $6B44: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6B44: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $6B46: $F0 $E6
     ld   c, a                                     ; $6B48: $4F
     ld   a, d                                     ; $6B49: $7A
@@ -4824,25 +4824,25 @@ jr_020_6B5B:
     ld   a, b                                     ; $6B5B: $78
 
 jr_020_6B5C:
-    ldh  [hMultiPurpose2], a                           ; $6B5C: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $6B5C: $E0 $D9
     pop  hl                                       ; $6B5E: $E1
-    ldh  a, [hMultiPurpose0]                           ; $6B5F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6B5F: $F0 $D7
     ld   b, a                                     ; $6B61: $47
-    ldh  a, [hMultiPurpose1]                           ; $6B62: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6B62: $F0 $D8
     swap a                                        ; $6B64: $CB $37
     ld   c, a                                     ; $6B66: $4F
     and  $E0                                      ; $6B67: $E6 $E0
     or   b                                        ; $6B69: $B0
     ld   [hl+], a                                 ; $6B6A: $22
-    ldh  a, [hMultiPurpose2]                           ; $6B6B: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $6B6B: $F0 $D9
     ld   b, a                                     ; $6B6D: $47
     ld   a, c                                     ; $6B6E: $79
     and  $03                                      ; $6B6F: $E6 $03
     or   b                                        ; $6B71: $B0
     ld   [hl+], a                                 ; $6B72: $22
-    ldh  a, [hMultiPurpose3]                           ; $6B73: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $6B73: $F0 $DA
     dec  a                                        ; $6B75: $3D
-    ldh  [hMultiPurpose3], a                           ; $6B76: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6B76: $E0 $DA
     and  a                                        ; $6B78: $A7
     jp   nz, func_020_6AF5                        ; $6B79: $C2 $F5 $6A
 
@@ -4898,7 +4898,7 @@ jr_020_6BB4:
     pop  bc                                       ; $6BBB: $C1
     ld   hl, wBGPal1                              ; $6BBC: $21 $10 $DC
     ld   a, $08                                   ; $6BBF: $3E $08
-    ldh  [hMultiPurpose0], a                           ; $6BC1: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6BC1: $E0 $D7
 
 jr_020_6BC3:
     call func_020_6B86                            ; $6BC3: $CD $86 $6B
@@ -4906,10 +4906,10 @@ jr_020_6BC3:
     call func_020_6B86                            ; $6BC9: $CD $86 $6B
     inc  hl                                       ; $6BCC: $23
     inc  hl                                       ; $6BCD: $23
-    ldh  a, [hMultiPurpose0]                           ; $6BCE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6BCE: $F0 $D7
     dec  a                                        ; $6BD0: $3D
     and  a                                        ; $6BD1: $A7
-    ldh  [hMultiPurpose0], a                           ; $6BD2: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6BD2: $E0 $D7
     jr   nz, jr_020_6BC3                          ; $6BD4: $20 $ED
 
     ld   a, $01                                   ; $6BD6: $3E $01
@@ -5063,7 +5063,7 @@ jr_020_6C8B:
     ldh  [hFreeWarpDataAddress], a                ; $6C95: $E0 $E6
     ld   hl, wBGPal1                              ; $6C97: $21 $10 $DC
     ld   a, $40                                   ; $6C9A: $3E $40
-    ldh  [hMultiPurpose3], a                           ; $6C9C: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6C9C: $E0 $DA
     call func_020_6AF5                            ; $6C9E: $CD $F5 $6A
     ld   a, $01                                   ; $6CA1: $3E $01
 
@@ -5102,7 +5102,7 @@ jr_020_6CB5:
     ldh  [hFreeWarpDataAddress], a                ; $6CD8: $E0 $E6
     ld   hl, wBGPal1                              ; $6CDA: $21 $10 $DC
     ld   a, $40                                   ; $6CDD: $3E $40
-    ldh  [hMultiPurpose3], a                           ; $6CDF: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6CDF: $E0 $DA
     ld   a, [wTransitionGfx]                      ; $6CE1: $FA $7F $C1
     cp   $03                                      ; $6CE4: $FE $03
     jr   z, jr_020_6CFA                           ; $6CE6: $28 $12
@@ -5209,7 +5209,7 @@ jr_020_6D68:
     ld   a, $1F                                   ; $6D6F: $3E $1F
 
 jr_020_6D71:
-    ldh  [hMultiPurpose0], a                           ; $6D71: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6D71: $E0 $D7
     ld   a, [hl+]                                 ; $6D73: $2A
     and  $E0                                      ; $6D74: $E6 $E0
     swap a                                        ; $6D76: $CB $37
@@ -5225,7 +5225,7 @@ jr_020_6D71:
     ld   a, $3E                                   ; $6D85: $3E $3E
 
 jr_020_6D87:
-    ldh  [hMultiPurpose1], a                           ; $6D87: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6D87: $E0 $D8
     ld   a, [hl]                                  ; $6D89: $7E
     add  $04                                      ; $6D8A: $C6 $04
     and  $7C                                      ; $6D8C: $E6 $7C
@@ -5234,18 +5234,18 @@ jr_020_6D87:
     ld   a, $7C                                   ; $6D90: $3E $7C
 
 jr_020_6D92:
-    ldh  [hMultiPurpose2], a                           ; $6D92: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $6D92: $E0 $D9
     pop  hl                                       ; $6D94: $E1
-    ldh  a, [hMultiPurpose0]                           ; $6D95: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6D95: $F0 $D7
     ld   d, a                                     ; $6D97: $57
-    ldh  a, [hMultiPurpose1]                           ; $6D98: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6D98: $F0 $D8
     swap a                                        ; $6D9A: $CB $37
     and  $E0                                      ; $6D9C: $E6 $E0
     or   d                                        ; $6D9E: $B2
     ld   [hl+], a                                 ; $6D9F: $22
-    ldh  a, [hMultiPurpose2]                           ; $6DA0: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $6DA0: $F0 $D9
     ld   d, a                                     ; $6DA2: $57
-    ldh  a, [hMultiPurpose1]                           ; $6DA3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6DA3: $F0 $D8
     swap a                                        ; $6DA5: $CB $37
     and  $03                                      ; $6DA7: $E6 $03
     or   d                                        ; $6DA9: $B2
@@ -5327,13 +5327,13 @@ LoadRoomObjectsAttributes::
 
 .jr_020_6E14
     ld   a, BANK(RoomGBCOverlay2BAlt)             ; $6E14: $3E $27
-    ldh  [hMultiPurpose0], a                           ; $6E16: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6E16: $E0 $D7
     jr   .copyAttributes                          ; $6E18: $18 $22
 
 .jr_020_6E1A
     ; Set attributes bank for rooms < $CC
     ld   a, BANK(RoomGBCOverlaysA) ; $6E1A: $3E $26
-    ldh  [hMultiPurpose0], a                           ; $6E1C: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6E1C: $E0 $D7
     ; If the room id >= $CC…
     ldh  a, [hMapRoom]                            ; $6E1E: $F0 $F6
     cp   $CC                                      ; $6E20: $FE $CC
@@ -6153,7 +6153,7 @@ jr_020_7D97:
     xor  a                                        ; $7DA3: $AF
 
 jr_020_7DA4:
-    ldh  [hMultiPurpose0], a                           ; $7DA4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7DA4: $E0 $D7
     ldh  a, [hMultiPurposeE]                           ; $7DA6: $F0 $E5
     ld   c, a                                     ; $7DA8: $4F
     ld   a, [hl+]                                 ; $7DA9: $2A
@@ -6173,7 +6173,7 @@ jr_020_7DA4:
     xor  a                                        ; $7DBC: $AF
 
 jr_020_7DBD:
-    ldh  [hMultiPurpose1], a                           ; $7DBD: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7DBD: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $7DBF: $F0 $E6
     ld   c, a                                     ; $7DC1: $4F
     ld   a, [hl]                                  ; $7DC2: $7E
@@ -6186,17 +6186,17 @@ jr_020_7DBD:
     xor  a                                        ; $7DCA: $AF
 
 jr_020_7DCB:
-    ldh  [hMultiPurpose2], a                           ; $7DCB: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $7DCB: $E0 $D9
     pop  hl                                       ; $7DCD: $E1
-    ldh  a, [hMultiPurpose0]                           ; $7DCE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7DCE: $F0 $D7
     ld   b, a                                     ; $7DD0: $47
-    ldh  a, [hMultiPurpose1]                           ; $7DD1: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7DD1: $F0 $D8
     swap a                                        ; $7DD3: $CB $37
     ld   c, a                                     ; $7DD5: $4F
     and  $E0                                      ; $7DD6: $E6 $E0
     or   b                                        ; $7DD8: $B0
     ld   [hl+], a                                 ; $7DD9: $22
-    ldh  a, [hMultiPurpose2]                           ; $7DDA: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7DDA: $F0 $D9
     ld   b, a                                     ; $7DDC: $47
     ld   a, c                                     ; $7DDD: $79
     and  $03                                      ; $7DDE: $E6 $03

--- a/src/code/credits.asm
+++ b/src/code/credits.asm
@@ -79,7 +79,7 @@ ENDC
     ld   d, a                                     ; $407C: $57
 
 jr_017_407D:
-    ldh  [hMultiPurpose2], a                           ; $407D: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $407D: $E0 $D9
     sla  a                                        ; $407F: $CB $27
     ld   e, a                                     ; $4081: $5F
     ld   hl, Data_017_4048                        ; $4082: $21 $48 $40
@@ -94,7 +94,7 @@ jr_017_407D:
     ld   a, [hl]                                  ; $408D: $7E
     and  c                                        ; $408E: $A1
     ld   [hl], a                                  ; $408F: $77
-    ldh  a, [hMultiPurpose2]                           ; $4090: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $4090: $F0 $D9
     inc  a                                        ; $4092: $3C
     cp   $0D                                      ; $4093: $FE $0D
     jr   nz, jr_017_407D                          ; $4095: $20 $E6
@@ -436,18 +436,18 @@ jr_017_46C9:
     ld   a, $18                                   ; $46D2: $3E $18
 
 jr_017_46D4:
-    ldh  [hMultiPurpose0], a                           ; $46D4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $46D4: $E0 $D7
     ld   c, $09                                   ; $46D6: $0E $09
 
 jr_017_46D8:
     ld   a, $40                                   ; $46D8: $3E $40
     ld   [de], a                                  ; $46DA: $12
     inc  de                                       ; $46DB: $13
-    ldh  a, [hMultiPurpose0]                           ; $46DC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $46DC: $F0 $D7
     ld   [de], a                                  ; $46DE: $12
     inc  de                                       ; $46DF: $13
     add  $10                                      ; $46E0: $C6 $10
-    ldh  [hMultiPurpose0], a                           ; $46E2: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $46E2: $E0 $D7
     ld   a, [hl+]                                 ; $46E4: $2A
     inc  hl                                       ; $46E5: $23
     push hl                                       ; $46E6: $E5
@@ -528,7 +528,7 @@ func_017_4784::
     add  hl, de                                   ; $47A1: $19
     push hl                                       ; $47A2: $E5
     xor  a                                        ; $47A3: $AF
-    ldh  [hMultiPurpose1], a                           ; $47A4: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $47A4: $E0 $D8
     ld   de, wDynamicOAMBuffer+$24                                ; $47A6: $11 $54 $C0
     ldh  a, [hIsGBC]                              ; $47A9: $F0 $FE
     and  a                                        ; $47AB: $A7
@@ -572,17 +572,17 @@ func_017_47C8::
     ld   a, $18                                   ; $47E4: $3E $18
 
 jr_017_47E6:
-    ldh  [hMultiPurpose0], a                           ; $47E6: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $47E6: $E0 $D7
 
 jr_017_47E8:
     ldh  a, [hMultiPurposeH]                               ; $47E8: $F0 $E9
     ld   [de], a                                  ; $47EA: $12
     inc  de                                       ; $47EB: $13
-    ldh  a, [hMultiPurpose0]                           ; $47EC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $47EC: $F0 $D7
     ld   [de], a                                  ; $47EE: $12
     inc  de                                       ; $47EF: $13
     add  b                                        ; $47F0: $80
-    ldh  [hMultiPurpose0], a                           ; $47F1: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $47F1: $E0 $D7
     ld   a, [wD011]                               ; $47F3: $FA $11 $D0
     cp   $25                                      ; $47F6: $FE $25
     ld   a, [hl+]                                 ; $47F8: $2A
@@ -766,7 +766,7 @@ ApplyWindFishVfx::
     inc  a                                        ; $48FC: $3C
     ld   [wTransitionGfxFrameCount], a            ; $48FD: $EA $80 $C1
     ld   a, [wD005]                               ; $4900: $FA $05 $D0
-    ldh  [hMultiPurpose1], a                           ; $4903: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4903: $E0 $D8
     ld   hl, wC17C                                ; $4905: $21 $7C $C1
     xor  a                                        ; $4908: $AF
     ld   [hl+], a                                 ; $4909: $22
@@ -5491,7 +5491,7 @@ func_017_76DE::
     ld   d, a                                     ; $76E5: $57
     sra  a                                        ; $76E6: $CB $2F
     add  d                                        ; $76E8: $82
-    ldh  [hMultiPurpose0], a                           ; $76E9: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $76E9: $E0 $D7
     ldh  a, [hFrameCounter]                       ; $76EB: $F0 $E7
     and  $03                                      ; $76ED: $E6 $03
     jr   nz, jr_017_76FD                          ; $76EF: $20 $0C
@@ -5926,7 +5926,7 @@ func_017_79A7::
     add  hl, bc                                   ; $79AA: $09
     ld   a, [hl]                                  ; $79AB: $7E
     add  $50                                      ; $79AC: $C6 $50
-    ldh  [hMultiPurpose0], a                           ; $79AE: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $79AE: $E0 $D7
     call func_017_7A01                            ; $79B0: $CD $01 $7A
     ld   de, Data_017_7987                        ; $79B3: $11 $87 $79
     call func_017_7A29                            ; $79B6: $CD $29 $7A
@@ -5975,7 +5975,7 @@ jr_017_7A1B:
 func_017_7A29::
     push bc                                       ; $7A29: $C5
     push de                                       ; $7A2A: $D5
-    ldh  a, [hMultiPurpose0]                           ; $7A2B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7A2B: $F0 $D7
     ld   e, a                                     ; $7A2D: $5F
     ld   d, b                                     ; $7A2E: $50
     ld   hl, wOAMBuffer                                ; $7A2F: $21 $00 $C0
@@ -6715,7 +6715,7 @@ ELSE
     ldh  [hFreeWarpDataAddress], a                ; $7E92: $E0 $E6
     ld   hl, wBGPal1                              ; $7E94: $21 $10 $DC
     ld   a, $40                                   ; $7E97: $3E $40
-    ldh  [hMultiPurpose3], a                           ; $7E99: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7E99: $E0 $DA
     call func_017_7EA4                            ; $7E9B: $CD $A4 $7E
 ENDC
     ld   a, $01                                   ; $7E9E: $3E $01
@@ -6758,7 +6758,7 @@ jr_017_7EC6:
     ld   a, b                                     ; $7EC6: $78
 
 jr_017_7EC7:
-    ldh  [hMultiPurpose0], a                           ; $7EC7: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7EC7: $E0 $D7
     ld   a, e                                     ; $7EC9: $7B
     and  $E0                                      ; $7ECA: $E6 $E0
     swap a                                        ; $7ECC: $CB $37
@@ -6795,7 +6795,7 @@ jr_017_7EF2:
     ld   a, b                                     ; $7EF2: $78
 
 jr_017_7EF3:
-    ldh  [hMultiPurpose1], a                           ; $7EF3: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7EF3: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $7EF5: $F0 $E6
     ld   c, a                                     ; $7EF7: $4F
     ld   a, d                                     ; $7EF8: $7A
@@ -6818,25 +6818,25 @@ jr_017_7F0A:
     ld   a, b                                     ; $7F0A: $78
 
 jr_017_7F0B:
-    ldh  [hMultiPurpose2], a                           ; $7F0B: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $7F0B: $E0 $D9
     pop  hl                                       ; $7F0D: $E1
-    ldh  a, [hMultiPurpose0]                           ; $7F0E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7F0E: $F0 $D7
     ld   b, a                                     ; $7F10: $47
-    ldh  a, [hMultiPurpose1]                           ; $7F11: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7F11: $F0 $D8
     swap a                                        ; $7F13: $CB $37
     ld   c, a                                     ; $7F15: $4F
     and  $E0                                      ; $7F16: $E6 $E0
     or   b                                        ; $7F18: $B0
     ld   [hl+], a                                 ; $7F19: $22
-    ldh  a, [hMultiPurpose2]                           ; $7F1A: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7F1A: $F0 $D9
     ld   b, a                                     ; $7F1C: $47
     ld   a, c                                     ; $7F1D: $79
     and  $03                                      ; $7F1E: $E6 $03
     or   b                                        ; $7F20: $B0
     ld   [hl+], a                                 ; $7F21: $22
-    ldh  a, [hMultiPurpose3]                           ; $7F22: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7F22: $F0 $DA
     dec  a                                        ; $7F24: $3D
-    ldh  [hMultiPurpose3], a                           ; $7F25: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7F25: $E0 $DA
     and  a                                        ; $7F27: $A7
     jp   nz, func_017_7EA4                        ; $7F28: $C2 $A4 $7E
 
@@ -6898,7 +6898,7 @@ func_017_7F57::
     ld   a, $1F                                   ; $7F63: $3E $1F
 
 jr_017_7F65:
-    ldh  [hMultiPurpose0], a                           ; $7F65: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7F65: $E0 $D7
     ldh  a, [hMultiPurposeE]                           ; $7F67: $F0 $E5
     ld   c, a                                     ; $7F69: $4F
     ld   a, [hl+]                                 ; $7F6A: $2A
@@ -6917,7 +6917,7 @@ jr_017_7F65:
     ld   a, $3E                                   ; $7F7D: $3E $3E
 
 jr_017_7F7F:
-    ldh  [hMultiPurpose1], a                           ; $7F7F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7F7F: $E0 $D8
     ldh  a, [hFreeWarpDataAddress]                ; $7F81: $F0 $E6
     ld   c, a                                     ; $7F83: $4F
     ld   a, [hl]                                  ; $7F84: $7E
@@ -6929,17 +6929,17 @@ jr_017_7F7F:
     ld   a, $7C                                   ; $7F8C: $3E $7C
 
 jr_017_7F8E:
-    ldh  [hMultiPurpose2], a                           ; $7F8E: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $7F8E: $E0 $D9
     pop  hl                                       ; $7F90: $E1
-    ldh  a, [hMultiPurpose0]                           ; $7F91: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7F91: $F0 $D7
     ld   b, a                                     ; $7F93: $47
-    ldh  a, [hMultiPurpose1]                           ; $7F94: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7F94: $F0 $D8
     swap a                                        ; $7F96: $CB $37
     ld   c, a                                     ; $7F98: $4F
     and  $E0                                      ; $7F99: $E6 $E0
     or   b                                        ; $7F9B: $B0
     ld   [hl+], a                                 ; $7F9C: $22
-    ldh  a, [hMultiPurpose2]                           ; $7F9D: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7F9D: $F0 $D9
     ld   b, a                                     ; $7F9F: $47
     ld   a, c                                     ; $7FA0: $79
     and  $03                                      ; $7FA1: $E6 $03

--- a/src/code/entities/angler_fish.asm
+++ b/src/code/entities/angler_fish.asm
@@ -123,12 +123,12 @@ jr_005_561E:
     ld   hl, wEntitiesUnknownTableD               ; $5638: $21 $D0 $C2
     add  hl, de                                   ; $563B: $19
     ld   [hl], $02                                ; $563C: $36 $02
-    ldh  a, [hMultiPurpose0]                           ; $563E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $563E: $F0 $D7
     sub  $14                                      ; $5640: $D6 $14
     ld   hl, wEntitiesPosXTable                         ; $5642: $21 $00 $C2
     add  hl, de                                   ; $5645: $19
     ld   [hl], a                                  ; $5646: $77
-    ldh  a, [hMultiPurpose1]                           ; $5647: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5647: $F0 $D8
     sub  $04                                      ; $5649: $D6 $04
     ld   hl, wEntitiesPosYTable                         ; $564B: $21 $10 $C2
     add  hl, de                                   ; $564E: $19

--- a/src/code/entities/anti_kirby.asm
+++ b/src/code/entities/anti_kirby.asm
@@ -215,11 +215,11 @@ jr_006_434B:
 
     ld   a, $08                                   ; $437F: $3E $08
     call GetVectorTowardsLink_trampoline          ; $4381: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4384: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4384: $F0 $D7
     cpl                                           ; $4386: $2F
     inc  a                                        ; $4387: $3C
     ldh  [hLinkPositionYIncrement], a             ; $4388: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $438A: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $438A: $F0 $D8
     cpl                                           ; $438C: $2F
     inc  a                                        ; $438D: $3C
     ldh  [hLinkPositionXIncrement], a             ; $438E: $E0 $9A

--- a/src/code/entities/armos_knight.asm
+++ b/src/code/entities/armos_knight.asm
@@ -149,13 +149,13 @@ jr_006_5394:
     call SpawnNewEntity_trampoline                ; $53B6: $CD $86 $3B
     jr   c, label_006_5411                        ; $53B9: $38 $56
 
-    ldh  a, [hMultiPurpose0]                           ; $53BB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $53BB: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $53BD: $21 $00 $C2
     add  hl, de                                   ; $53C0: $19
     dec  a                                        ; $53C1: $3D
     ld   [hl], a                                  ; $53C2: $77
-    ldh  [hMultiPurpose0], a                           ; $53C3: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $53C5: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $53C3: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $53C5: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $53C7: $21 $DA $FF
     sub  [hl]                                     ; $53CA: $96
     ld   hl, wEntitiesPosYTable                   ; $53CB: $21 $10 $C2
@@ -175,13 +175,13 @@ jr_006_53D3:
     call SpawnNewEntity_trampoline                ; $53DF: $CD $86 $3B
     jr   c, label_006_5411                        ; $53E2: $38 $2D
 
-    ldh  a, [hMultiPurpose0]                           ; $53E4: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $53E4: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $53E6: $21 $00 $C2
     add  hl, de                                   ; $53E9: $19
     add  $07                                      ; $53EA: $C6 $07
     ld   [hl], a                                  ; $53EC: $77
-    ldh  [hMultiPurpose0], a                           ; $53ED: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $53EF: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $53ED: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $53EF: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $53F1: $21 $DA $FF
     sub  [hl]                                     ; $53F4: $96
     ld   hl, wEntitiesPosYTable                   ; $53F5: $21 $10 $C2
@@ -189,7 +189,7 @@ jr_006_53D3:
 
 jr_006_53F9:
     ld   [hl], a                                  ; $53F9: $77
-    ldh  [hMultiPurpose1], a                           ; $53FA: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $53FA: $E0 $D8
     ld   hl, wEntitiesPrivateCountdown1Table      ; $53FC: $21 $F0 $C2
     add  hl, de                                   ; $53FF: $19
     ld   [hl], $0F                                ; $5400: $36 $0F

--- a/src/code/entities/bank15.asm
+++ b/src/code/entities/bank15.asm
@@ -414,10 +414,10 @@ func_015_451D::
     ld   a, JINGLE_WATER_DIVE                     ; $451D: $3E $0E
     ldh  [hJingle], a                             ; $451F: $E0 $F2
     ldh  a, [hActiveEntityPosX]                   ; $4521: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4523: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4523: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4525: $F0 $EC
     add  $00                                      ; $4527: $C6 $00
-    ldh  [hMultiPurpose1], a                           ; $4529: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4529: $E0 $D8
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $452B: $3E $01
     jp   AddTranscientVfx                         ; $452D: $C3 $C7 $0C
 
@@ -551,9 +551,9 @@ jr_015_460B:
 
     ld   a, $50                                   ; $460D: $3E $50
     dec  a                                        ; $460F: $3D
-    ldh  [hMultiPurpose0], a                           ; $4610: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4610: $E0 $D7
     ld   a, $30                                   ; $4612: $3E $30
-    ldh  [hMultiPurpose1], a                           ; $4614: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4614: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $4616: $3E $02
     call AddTranscientVfx                         ; $4618: $CD $C7 $0C
     ld   a, JINGLE_POOF                           ; $461B: $3E $2F
@@ -802,18 +802,18 @@ func_015_4780::
     ld   a, $0A                                   ; $4790: $3E $0A
     ldh  [hNoiseSfx], a                           ; $4792: $E0 $F4
     push bc                                       ; $4794: $C5
-    ldh  a, [hMultiPurpose2]                           ; $4795: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $4795: $F0 $D9
     ld   c, a                                     ; $4797: $4F
     ld   hl, Data_015_4776                        ; $4798: $21 $76 $47
     add  hl, bc                                   ; $479B: $09
-    ldh  a, [hMultiPurpose0]                           ; $479C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $479C: $F0 $D7
     add  [hl]                                     ; $479E: $86
     ld   hl, wEntitiesPosXTable                   ; $479F: $21 $00 $C2
     add  hl, de                                   ; $47A2: $19
     ld   [hl], a                                  ; $47A3: $77
     ld   hl, Data_015_4778                        ; $47A4: $21 $78 $47
     add  hl, bc                                   ; $47A7: $09
-    ldh  a, [hMultiPurpose1]                           ; $47A8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $47A8: $F0 $D8
     add  [hl]                                     ; $47AA: $86
     ld   hl, wEntitiesPosYTable                   ; $47AB: $21 $10 $C2
     add  hl, de                                   ; $47AE: $19
@@ -830,7 +830,7 @@ func_015_4780::
     ld   hl, wEntitiesSpeedYTable                 ; $47BF: $21 $50 $C2
     add  hl, de                                   ; $47C2: $19
     ld   [hl], a                                  ; $47C3: $77
-    ldh  a, [hMultiPurpose2]                           ; $47C4: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $47C4: $F0 $D9
     ld   hl, wEntitiesSpriteVariantTable          ; $47C6: $21 $B0 $C3
     add  hl, de                                   ; $47C9: $19
     ld   [hl], a                                  ; $47CA: $77
@@ -1314,11 +1314,11 @@ PokeyEntityHandler::
     call SpawnNewEntity_trampoline                ; $4C10: $CD $86 $3B
     jr   c, jr_015_4C49                           ; $4C13: $38 $34
 
-    ldh  a, [hMultiPurpose0]                           ; $4C15: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4C15: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4C17: $21 $00 $C2
     add  hl, de                                   ; $4C1A: $19
     ld   [hl], a                                  ; $4C1B: $77
-    ldh  a, [hMultiPurpose1]                           ; $4C1C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4C1C: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4C1E: $21 $10 $C2
     add  hl, de                                   ; $4C21: $19
     ld   [hl], a                                  ; $4C22: $77
@@ -1330,13 +1330,13 @@ PokeyEntityHandler::
     ld   b, d                                     ; $4C2A: $42
     ld   a, $20                                   ; $4C2B: $3E $20
     call GetVectorTowardsLink_trampoline          ; $4C2D: $CD $B5 $3B
-    ldh  a, [hMultiPurpose1]                           ; $4C30: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4C30: $F0 $D8
     cpl                                           ; $4C32: $2F
     inc  a                                        ; $4C33: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $4C34: $21 $40 $C2
     add  hl, bc                                   ; $4C37: $09
     ld   [hl], a                                  ; $4C38: $77
-    ldh  a, [hMultiPurpose0]                           ; $4C39: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4C39: $F0 $D7
     cpl                                           ; $4C3B: $2F
     inc  a                                        ; $4C3C: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $4C3D: $21 $50 $C2
@@ -1491,9 +1491,9 @@ func_015_4D0F::
     jr   c, jr_015_4D39                           ; $4D21: $38 $16
 
     ldh  a, [hActiveEntityPosX]                   ; $4D23: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4D25: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4D25: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4D27: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $4D29: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4D29: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $4D2B: $3E $02
     call AddTranscientVfx                         ; $4D2D: $CD $C7 $0C
     ld   a, JINGLE_POOF                           ; $4D30: $3E $2F
@@ -1545,11 +1545,11 @@ jr_015_4D5B:
 
     ld   a, $12                                   ; $4D77: $3E $12
     ldh  [hNoiseSfx], a                           ; $4D79: $E0 $F4
-    ldh  a, [hMultiPurpose0]                           ; $4D7B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D7B: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4D7D: $21 $00 $C2
     add  hl, de                                   ; $4D80: $19
     ld   [hl], a                                  ; $4D81: $77
-    ldh  a, [hMultiPurpose1]                           ; $4D82: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4D82: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4D84: $21 $10 $C2
     add  hl, de                                   ; $4D87: $19
     add  $04                                      ; $4D88: $C6 $04
@@ -1609,7 +1609,7 @@ label_015_4DB5:
     ld   [wInvincibilityCounter], a               ; $4DE6: $EA $C7 $DB
     ld   a, $30                                   ; $4DE9: $3E $30
     call GetVectorTowardsLink_trampoline          ; $4DEB: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4DEE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4DEE: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $4DF0: $E0 $9B
 
 jr_015_4DF2:
@@ -1637,7 +1637,7 @@ jr_015_4DFB:
     ld   [hl], a                                  ; $4E12: $77
     ld   hl, Data_015_4DB1                        ; $4E13: $21 $B1 $4D
     add  hl, bc                                   ; $4E16: $09
-    ldh  a, [hMultiPurpose0]                           ; $4E17: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4E17: $F0 $D7
     add  [hl]                                     ; $4E19: $86
     ld   hl, wEntitiesPosXTable                   ; $4E1A: $21 $00 $C2
     add  hl, de                                   ; $4E1D: $19
@@ -1648,7 +1648,7 @@ jr_015_4DFB:
     ld   hl, wEntitiesSpeedXTable                 ; $4E24: $21 $40 $C2
     add  hl, de                                   ; $4E27: $19
     ld   [hl], a                                  ; $4E28: $77
-    ldh  a, [hMultiPurpose1]                           ; $4E29: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4E29: $F0 $D8
     add  $00                                      ; $4E2B: $C6 $00
     ld   hl, wEntitiesPosYTable                   ; $4E2D: $21 $10 $C2
     add  hl, de                                   ; $4E30: $19
@@ -1747,9 +1747,9 @@ StalfosEvasiveEntityHandler::
 
 label_015_4ECB:
     ldh  a, [hActiveEntityPosX]                   ; $4ECB: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4ECD: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4ECD: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4ECF: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $4ED1: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4ED1: $E0 $D8
     ld   a, JINGLE_SWORD_POKING                   ; $4ED3: $3E $07
     ldh  [hJingle], a                             ; $4ED5: $E0 $F2
     ld   a, TRANSCIENT_VFX_SWORD_POKE             ; $4ED7: $3E $05
@@ -1803,15 +1803,15 @@ jr_015_4F02:
     add  hl, de                                   ; $4F28: $19
     set  1, [hl]                                  ; $4F29: $CB $CE
     set  4, [hl]                                  ; $4F2B: $CB $E6
-    ldh  a, [hMultiPurpose0]                           ; $4F2D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4F2D: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4F2F: $21 $00 $C2
     add  hl, de                                   ; $4F32: $19
     ld   [hl], a                                  ; $4F33: $77
-    ldh  a, [hMultiPurpose1]                           ; $4F34: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4F34: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4F36: $21 $10 $C2
     add  hl, de                                   ; $4F39: $19
     ld   [hl], a                                  ; $4F3A: $77
-    ldh  a, [hMultiPurpose3]                           ; $4F3B: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $4F3B: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $4F3D: $21 $10 $C3
     add  hl, de                                   ; $4F40: $19
     ld   [hl], a                                  ; $4F41: $77
@@ -1864,13 +1864,13 @@ func_015_4F5A::
     ldh  [hJingle], a                             ; $4F8E: $E0 $F2
     ld   a, $12                                   ; $4F90: $3E $12
     call GetVectorTowardsLink_trampoline          ; $4F92: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4F95: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4F95: $F0 $D7
     cpl                                           ; $4F97: $2F
     inc  a                                        ; $4F98: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $4F99: $21 $50 $C2
     add  hl, bc                                   ; $4F9C: $09
     ld   [hl], a                                  ; $4F9D: $77
-    ldh  a, [hMultiPurpose1]                           ; $4F9E: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4F9E: $F0 $D8
     cpl                                           ; $4FA0: $2F
     inc  a                                        ; $4FA1: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $4FA2: $21 $40 $C2
@@ -2527,21 +2527,21 @@ jr_015_5384:
     push bc                                       ; $538C: $C5
     ldh  a, [hMultiPurposeG]                               ; $538D: $F0 $E8
     ld   c, a                                     ; $538F: $4F
-    ldh  a, [hMultiPurpose0]                           ; $5390: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5390: $F0 $D7
     ld   hl, Data_015_5356                        ; $5392: $21 $56 $53
     add  hl, bc                                   ; $5395: $09
     add  [hl]                                     ; $5396: $86
     ld   hl, wEntitiesPosXTable                   ; $5397: $21 $00 $C2
     add  hl, de                                   ; $539A: $19
     ld   [hl], a                                  ; $539B: $77
-    ldh  a, [hMultiPurpose1]                           ; $539C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $539C: $F0 $D8
     ld   hl, Data_015_535E                        ; $539E: $21 $5E $53
     add  hl, bc                                   ; $53A1: $09
     add  [hl]                                     ; $53A2: $86
     ld   hl, wEntitiesPosYTable                   ; $53A3: $21 $10 $C2
     add  hl, de                                   ; $53A6: $19
     ld   [hl], a                                  ; $53A7: $77
-    ldh  a, [hMultiPurpose3]                           ; $53A8: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $53A8: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $53AA: $21 $10 $C3
     add  hl, de                                   ; $53AD: $19
     ld   [hl], a                                  ; $53AE: $77
@@ -3089,14 +3089,14 @@ func_015_5854::
     ld   c, a                                     ; $586C: $4F
     ld   hl, Data_015_584C                        ; $586D: $21 $4C $58
     add  hl, bc                                   ; $5870: $09
-    ldh  a, [hMultiPurpose0]                           ; $5871: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5871: $F0 $D7
     add  [hl]                                     ; $5873: $86
     ld   hl, wEntitiesPosXTable                   ; $5874: $21 $00 $C2
     add  hl, de                                   ; $5877: $19
     ld   [hl], a                                  ; $5878: $77
     ld   hl, Data_015_5850                        ; $5879: $21 $50 $58
     add  hl, bc                                   ; $587C: $09
-    ldh  a, [hMultiPurpose1]                           ; $587D: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $587D: $F0 $D8
     add  [hl]                                     ; $587F: $86
     ld   hl, wEntitiesPosYTable                   ; $5880: $21 $10 $C2
     add  hl, de                                   ; $5883: $19
@@ -3693,11 +3693,11 @@ func_015_5E38::
     ld   hl, wEntitiesUnknowTableP                ; $5E54: $21 $40 $C4
     add  hl, de                                   ; $5E57: $19
     inc  [hl]                                     ; $5E58: $34
-    ldh  a, [hMultiPurpose0]                           ; $5E59: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5E59: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $5E5B: $21 $00 $C2
     add  hl, de                                   ; $5E5E: $19
     ld   [hl], a                                  ; $5E5F: $77
-    ldh  a, [hMultiPurpose1]                           ; $5E60: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5E60: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5E62: $21 $10 $C2
     add  hl, de                                   ; $5E65: $19
     ld   [hl], a                                  ; $5E66: $77
@@ -3728,14 +3728,14 @@ func_015_5E85::
     ldh  [hNoiseSfx], a                           ; $5E87: $E0 $F4
     ld   a, $18                                   ; $5E89: $3E $18
     call GetVectorTowardsLink_trampoline          ; $5E8B: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $5E8E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5E8E: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $5E90: $E0 $9B
     cpl                                           ; $5E92: $2F
     inc  a                                        ; $5E93: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $5E94: $21 $50 $C2
     add  hl, bc                                   ; $5E97: $09
     ld   [hl], a                                  ; $5E98: $77
-    ldh  a, [hMultiPurpose1]                           ; $5E99: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5E99: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $5E9B: $E0 $9A
     cpl                                           ; $5E9D: $2F
     inc  a                                        ; $5E9E: $3C
@@ -3859,11 +3859,11 @@ jr_015_5F4C:
     call SpawnNewEntity_trampoline                ; $5F50: $CD $86 $3B
     jr   c, jr_015_5F96                           ; $5F53: $38 $41
 
-    ldh  a, [hMultiPurpose0]                           ; $5F55: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5F55: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $5F57: $21 $00 $C2
     add  hl, de                                   ; $5F5A: $19
     ld   [hl], a                                  ; $5F5B: $77
-    ldh  a, [hMultiPurpose1]                           ; $5F5C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5F5C: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5F5E: $21 $10 $C2
     add  hl, de                                   ; $5F61: $19
     ld   [hl], a                                  ; $5F62: $77
@@ -3871,11 +3871,11 @@ jr_015_5F4C:
     add  hl, de                                   ; $5F66: $19
     inc  [hl]                                     ; $5F67: $34
     push bc                                       ; $5F68: $C5
-    ldh  a, [hMultiPurpose0]                           ; $5F69: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5F69: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $5F6B: $21 $00 $C2
     add  hl, de                                   ; $5F6E: $19
     ld   [hl], a                                  ; $5F6F: $77
-    ldh  a, [hMultiPurpose1]                           ; $5F70: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5F70: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5F72: $21 $10 $C2
     add  hl, de                                   ; $5F75: $19
     ld   [hl], a                                  ; $5F76: $77
@@ -4149,8 +4149,8 @@ func_015_6245::
     ld   hl, wEntitiesUnknowTableY                ; $6268: $21 $D0 $C3
     add  hl, bc                                   ; $626B: $09
     ld   a, [hl]                                  ; $626C: $7E
-    ldh  [hMultiPurpose0], a                           ; $626D: $E0 $D7
-    ldh  a, [hMultiPurpose0]                           ; $626F: $F0 $D7
+    ldh  [hMultiPurpose0], a                      ; $626D: $E0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $626F: $F0 $D7
     sub  $0C                                      ; $6271: $D6 $0C
     and  $7F                                      ; $6273: $E6 $7F
     ld   e, a                                     ; $6275: $5F
@@ -4167,7 +4167,7 @@ func_015_6245::
     ldh  [hActiveEntitySpriteVariant], a          ; $6287: $E0 $F1
     ld   de, Data_015_6235                        ; $6289: $11 $35 $62
     call RenderActiveEntitySpritesPair            ; $628C: $CD $C0 $3B
-    ldh  a, [hMultiPurpose0]                           ; $628F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $628F: $F0 $D7
     sub  $18                                      ; $6291: $D6 $18
     and  $7F                                      ; $6293: $E6 $7F
     ld   e, a                                     ; $6295: $5F
@@ -4186,7 +4186,7 @@ func_015_6245::
 
 jr_015_62AC:
     call RenderActiveEntitySpritesPair            ; $62AC: $CD $C0 $3B
-    ldh  a, [hMultiPurpose0]                           ; $62AF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $62AF: $F0 $D7
     sub  $24                                      ; $62B1: $D6 $24
     and  $7F                                      ; $62B3: $E6 $7F
     ld   e, a                                     ; $62B5: $5F
@@ -4203,7 +4203,7 @@ jr_015_62AC:
     ldh  [hActiveEntitySpriteVariant], a          ; $62C7: $E0 $F1
     ld   de, Data_015_6235                        ; $62C9: $11 $35 $62
     call RenderActiveEntitySpritesPair            ; $62CC: $CD $C0 $3B
-    ldh  a, [hMultiPurpose0]                           ; $62CF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $62CF: $F0 $D7
     sub  $2E                                      ; $62D1: $D6 $2E
     and  $7F                                      ; $62D3: $E6 $7F
     ld   e, a                                     ; $62D5: $5F
@@ -4799,7 +4799,7 @@ jr_015_66D6:
     ld   hl, wEntitiesPrivateState1Table          ; $6707: $21 $B0 $C2
     add  hl, de                                   ; $670A: $19
     inc  [hl]                                     ; $670B: $34
-    ldh  a, [hMultiPurpose1]                           ; $670C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $670C: $F0 $D8
     sub  $10                                      ; $670E: $D6 $10
     ld   hl, wEntitiesPosYTable                   ; $6710: $21 $10 $C2
     add  hl, de                                   ; $6713: $19
@@ -4970,7 +4970,7 @@ func_015_6811::
 
     ld   a, $18                                   ; $6820: $3E $18
     call GetVectorTowardsLink_trampoline          ; $6822: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6825: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6825: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $6827: $21 $50 $C2
     sub  [hl]                                     ; $682A: $96
     bit  7, a                                     ; $682B: $CB $7F
@@ -4981,7 +4981,7 @@ func_015_6811::
 
 jr_015_6831:
     inc  [hl]                                     ; $6831: $34
-    ldh  a, [hMultiPurpose1]                           ; $6832: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6832: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $6834: $21 $40 $C2
     sub  [hl]                                     ; $6837: $96
     bit  7, a                                     ; $6838: $CB $7F
@@ -5024,11 +5024,11 @@ jr_015_685F:
     call SpawnNewEntity_trampoline                ; $686B: $CD $86 $3B
     ret  c                                        ; $686E: $D8
 
-    ldh  a, [hMultiPurpose0]                           ; $686F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $686F: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6871: $21 $00 $C2
     add  hl, de                                   ; $6874: $19
     ld   [hl], a                                  ; $6875: $77
-    ldh  a, [hMultiPurpose1]                           ; $6876: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6876: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6878: $21 $10 $C2
     add  hl, de                                   ; $687B: $19
     ld   [hl], a                                  ; $687C: $77
@@ -5379,7 +5379,7 @@ jr_015_6CBC:
     call GetVectorTowardsLink_trampoline          ; $6CD9: $CD $B5 $3B
     ld   hl, wEntitiesSpeedYTable                 ; $6CDC: $21 $50 $C2
     add  hl, bc                                   ; $6CDF: $09
-    ldh  a, [hMultiPurpose0]                           ; $6CE0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6CE0: $F0 $D7
     sub  [hl]                                     ; $6CE2: $96
     and  $80                                      ; $6CE3: $E6 $80
     jr   nz, jr_015_6CE9                          ; $6CE5: $20 $02
@@ -5391,7 +5391,7 @@ jr_015_6CE9:
     dec  [hl]                                     ; $6CE9: $35
     ld   hl, wEntitiesSpeedXTable                 ; $6CEA: $21 $40 $C2
     add  hl, bc                                   ; $6CED: $09
-    ldh  a, [hMultiPurpose1]                           ; $6CEE: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6CEE: $F0 $D8
     sub  [hl]                                     ; $6CF0: $96
     and  $80                                      ; $6CF1: $E6 $80
     jr   nz, jr_015_6CF7                          ; $6CF3: $20 $02
@@ -5756,7 +5756,7 @@ jr_015_6F40:
     ldh  [hLinkPositionY], a                      ; $6F4A: $E0 $99
     ld   a, $08                                   ; $6F4C: $3E $08
     call GetVectorTowardsLink_trampoline          ; $6F4E: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6F51: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6F51: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $6F53: $21 $50 $C2
     add  hl, bc                                   ; $6F56: $09
     sub  [hl]                                     ; $6F57: $96
@@ -5768,7 +5768,7 @@ jr_015_6F40:
 
 jr_015_6F5E:
     dec  [hl]                                     ; $6F5E: $35
-    ldh  a, [hMultiPurpose1]                           ; $6F5F: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6F5F: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $6F61: $21 $40 $C2
     add  hl, bc                                   ; $6F64: $09
     sub  [hl]                                     ; $6F65: $96
@@ -6217,9 +6217,9 @@ ENDC
     ld   [wSubtractHealthBuffer], a               ; $72FF: $EA $94 $DB
     ld   a, $20                                   ; $7302: $3E $20
     call GetVectorTowardsLink_trampoline          ; $7304: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7307: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7307: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $7309: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $730B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $730B: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $730D: $E0 $9A
     ld   a, $10                                   ; $730F: $3E $10
     ld   [wC13E], a                               ; $7311: $EA $3E $C1
@@ -6571,11 +6571,11 @@ BeetleSpawnerEntityHandler::
     call SpawnNewEntityInRange_trampoline         ; $753A: $CD $98 $3B
     jr   c, jr_015_756E                           ; $753D: $38 $2F
 
-    ldh  a, [hMultiPurpose0]                           ; $753F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $753F: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7541: $21 $00 $C2
     add  hl, de                                   ; $7544: $19
     ld   [hl], a                                  ; $7545: $77
-    ldh  a, [hMultiPurpose1]                           ; $7546: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7546: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7548: $21 $10 $C2
     add  hl, de                                   ; $754B: $19
     ld   [hl], a                                  ; $754C: $77
@@ -6683,9 +6683,9 @@ jr_015_75E1:
 
     push hl                                       ; $75EF: $E5
     ldh  a, [hActiveEntityPosX]                   ; $75F0: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $75F2: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $75F2: $E0 $D7
     ldh  a, [hActiveEntityPosY]                   ; $75F4: $F0 $EF
-    ldh  [hMultiPurpose1], a                           ; $75F6: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $75F6: $E0 $D8
     ld   a, TRANSCIENT_VFX_SWORD_POKE             ; $75F8: $3E $05
     call AddTranscientVfx                         ; $75FA: $CD $C7 $0C
     pop  hl                                       ; $75FD: $E1
@@ -6732,9 +6732,9 @@ jr_015_7619:
 jr_015_7639:
     ldh  a, [hActiveEntityPosX]                   ; $7639: $F0 $EE
     add  $04                                      ; $763B: $C6 $04
-    ldh  [hMultiPurpose0], a                           ; $763D: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $763D: $E0 $D7
     ldh  a, [hActiveEntityPosY]                   ; $763F: $F0 $EF
-    ldh  [hMultiPurpose1], a                           ; $7641: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7641: $E0 $D8
     ld   a, TRANSCIENT_VFX_LASER_BEAM             ; $7643: $3E $06
     call AddTranscientVfx                         ; $7645: $CD $C7 $0C
     ld   [hl], $10                                ; $7648: $36 $10
@@ -6873,11 +6873,11 @@ jr_015_773A:
     call SpawnNewEntity_trampoline                ; $773A: $CD $86 $3B
     ret  c                                        ; $773D: $D8
 
-    ldh  a, [hMultiPurpose0]                           ; $773E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $773E: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7740: $21 $00 $C2
     add  hl, de                                   ; $7743: $19
     ld   [hl], a                                  ; $7744: $77
-    ldh  a, [hMultiPurpose1]                           ; $7745: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7745: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7747: $21 $10 $C2
     add  hl, de                                   ; $774A: $19
     sub  $0C                                      ; $774B: $D6 $0C
@@ -6977,13 +6977,13 @@ func_015_77BF::
     ld   [hl], a                                  ; $77E6: $77
     ld   a, $10                                   ; $77E7: $3E $10
     call GetVectorTowardsLink_trampoline          ; $77E9: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $77EC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $77EC: $F0 $D7
     cpl                                           ; $77EE: $2F
     inc  a                                        ; $77EF: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $77F0: $21 $50 $C2
     add  hl, bc                                   ; $77F3: $09
     ld   [hl], a                                  ; $77F4: $77
-    ldh  a, [hMultiPurpose1]                           ; $77F5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $77F5: $F0 $D8
     cpl                                           ; $77F7: $2F
     inc  a                                        ; $77F8: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $77F9: $21 $40 $C2
@@ -7742,7 +7742,7 @@ jr_015_7C08:
 func_015_7C0A::
     call func_015_7BDB                            ; $7C0A: $CD $DB $7B
     ld   a, e                                     ; $7C0D: $7B
-    ldh  [hMultiPurpose0], a                           ; $7C0E: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7C0E: $E0 $D7
     ld   a, d                                     ; $7C10: $7A
     bit  7, a                                     ; $7C11: $CB $7F
     jr   z, jr_015_7C17                           ; $7C13: $28 $02
@@ -7754,7 +7754,7 @@ jr_015_7C17:
     push af                                       ; $7C17: $F5
     call func_015_7BEB                            ; $7C18: $CD $EB $7B
     ld   a, e                                     ; $7C1B: $7B
-    ldh  [hMultiPurpose1], a                           ; $7C1C: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7C1C: $E0 $D8
     ld   a, d                                     ; $7C1E: $7A
     bit  7, a                                     ; $7C1F: $CB $7F
     jr   z, jr_015_7C25                           ; $7C21: $28 $02
@@ -7767,11 +7767,11 @@ jr_015_7C25:
     cp   d                                        ; $7C26: $BA
     jr   nc, jr_015_7C2D                          ; $7C27: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $7C29: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7C29: $F0 $D7
     jr   jr_015_7C2F                              ; $7C2B: $18 $02
 
 jr_015_7C2D:
-    ldh  a, [hMultiPurpose1]                           ; $7C2D: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7C2D: $F0 $D8
 
 jr_015_7C2F:
     ld   e, a                                     ; $7C2F: $5F
@@ -7848,9 +7848,9 @@ label_015_7C71:
 label_015_7C91:
     call func_015_7B13                            ; $7C91: $CD $13 $7B
     ldh  a, [hActiveEntityPosX]                   ; $7C94: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $7C96: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7C96: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7C98: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7C9A: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7C9A: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $7C9C: $3E $02
     call AddTranscientVfx                         ; $7C9E: $CD $C7 $0C
     ld   a, $13                                   ; $7CA1: $3E $13
@@ -7859,11 +7859,11 @@ label_015_7C91:
 
     ld   a, $36                                   ; $7CA6: $3E $36
     call SpawnNewEntity_trampoline                ; $7CA8: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7CAB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7CAB: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7CAD: $21 $00 $C2
     add  hl, de                                   ; $7CB0: $19
     ld   [hl], a                                  ; $7CB1: $77
-    ldh  a, [hMultiPurpose1]                           ; $7CB2: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7CB2: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7CB4: $21 $10 $C2
     add  hl, de                                   ; $7CB7: $19
     ld   [hl], a                                  ; $7CB8: $77

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -1234,7 +1234,7 @@ ZoraState0Handler::
     add  hl, bc                                   ; $4A5A: $09
     ld   [hl], a                                  ; $4A5B: $77
     call func_018_6493                            ; $4A5C: $CD $93 $64
-    ldh  a, [hMultiPurpose3]                           ; $4A5F: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $4A5F: $F0 $DA
     cp   $07                                      ; $4A61: $FE $07
     ret  nz                                       ; $4A63: $C0
 
@@ -1306,10 +1306,10 @@ ZoraState3Handler::
     ld   a, JINGLE_WATER_DIVE                     ; $4AC9: $3E $0E
     ldh  [hJingle], a                             ; $4ACB: $E0 $F2
     ldh  a, [hActiveEntityPosX]                   ; $4ACD: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4ACF: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4ACF: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4AD1: $F0 $EC
     add  $00                                      ; $4AD3: $C6 $00
-    ldh  [hMultiPurpose1], a                           ; $4AD5: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4AD5: $E0 $D8
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $4AD7: $3E $01
     jp   AddTranscientVfx                         ; $4AD9: $C3 $C7 $0C
 
@@ -1321,11 +1321,11 @@ jr_018_4ADC:
     call SpawnNewEntity_trampoline                ; $4AE2: $CD $86 $3B
     jr   c, jr_018_4B03                           ; $4AE5: $38 $1C
 
-    ldh  a, [hMultiPurpose0]                           ; $4AE7: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4AE7: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4AE9: $21 $00 $C2
     add  hl, de                                   ; $4AEC: $19
     ld   [hl], a                                  ; $4AED: $77
-    ldh  a, [hMultiPurpose1]                           ; $4AEE: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4AEE: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4AF0: $21 $10 $C2
     add  hl, de                                   ; $4AF3: $19
     ld   [hl], a                                  ; $4AF4: $77
@@ -1926,9 +1926,9 @@ MadBatterState1Handler::
     call GetEntityTransitionCountdown             ; $4F1E: $CD $05 $0C
     ld   [hl], $90                                ; $4F21: $36 $90
     ldh  a, [hActiveEntityPosX]                   ; $4F23: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4F25: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4F25: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4F27: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $4F29: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4F29: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $4F2B: $3E $02
     call AddTranscientVfx                         ; $4F2D: $CD $C7 $0C
     ld   a, JINGLE_ENEMY_MORPH_IN                 ; $4F30: $3E $06
@@ -1968,11 +1968,11 @@ MadBatterState3Handler::
     ld   [hl], $48                                ; $4F63: $36 $48
     ld   a, $02                                   ; $4F65: $3E $02
     call SpawnNewEntity_trampoline                ; $4F67: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4F6A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4F6A: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4F6C: $21 $00 $C2
     add  hl, de                                   ; $4F6F: $19
     ld   [hl], a                                  ; $4F70: $77
-    ldh  a, [hMultiPurpose1]                           ; $4F71: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4F71: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4F73: $21 $10 $C2
     add  hl, de                                   ; $4F76: $19
     ld   [hl], a                                  ; $4F77: $77
@@ -2046,11 +2046,11 @@ MadBatterState6Handler::
     call SpawnNewEntity_trampoline                ; $4FDA: $CD $86 $3B
     ld   a, $26                                   ; $4FDD: $3E $26
     ldh  [hNoiseSfx], a                           ; $4FDF: $E0 $F4
-    ldh  a, [hMultiPurpose0]                           ; $4FE1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4FE1: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4FE3: $21 $00 $C2
     add  hl, de                                   ; $4FE6: $19
     ld   [hl], a                                  ; $4FE7: $77
-    ldh  a, [hMultiPurpose1]                           ; $4FE8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4FE8: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4FEA: $21 $10 $C2
     add  hl, de                                   ; $4FED: $19
     ld   [hl], a                                  ; $4FEE: $77
@@ -2884,12 +2884,12 @@ WalrusState0Handler::
     call SpawnNewEntity_trampoline                ; $5553: $CD $86 $3B
     jr   c, jr_018_557B                           ; $5556: $38 $23
 
-    ldh  a, [hMultiPurpose0]                           ; $5558: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5558: $F0 $D7
     sub  $08                                      ; $555A: $D6 $08
     ld   hl, wEntitiesPosXTable                   ; $555C: $21 $00 $C2
     add  hl, de                                   ; $555F: $19
     ld   [hl], a                                  ; $5560: $77
-    ldh  a, [hMultiPurpose1]                           ; $5561: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5561: $F0 $D8
     add  $02                                      ; $5563: $C6 $02
     ld   hl, wEntitiesPosYTable                   ; $5565: $21 $10 $C2
     add  hl, de                                   ; $5568: $19
@@ -3142,18 +3142,18 @@ func_018_572E::
     ld   a, $24                                   ; $572E: $3E $24
     ldh  [hNoiseSfx], a                           ; $5730: $E0 $F4
     ldh  a, [hActiveEntityPosX]                   ; $5732: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $5734: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5734: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $5736: $F0 $EC
     add  $10                                      ; $5738: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $573A: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $573A: $E0 $D8
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $573C: $3E $01
     call AddTranscientVfx                         ; $573E: $CD $C7 $0C
     ldh  a, [hActiveEntityPosX]                   ; $5741: $F0 $EE
     add  $10                                      ; $5743: $C6 $10
-    ldh  [hMultiPurpose0], a                           ; $5745: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5745: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $5747: $F0 $EC
     add  $10                                      ; $5749: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $574B: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $574B: $E0 $D8
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $574D: $3E $01
     jp   AddTranscientVfx                         ; $574F: $C3 $C7 $0C
 
@@ -3572,7 +3572,7 @@ func_018_5A91::
     call SpawnNewEntity_trampoline                ; $5AAB: $CD $86 $3B
     jr   c, jr_018_5AE7                           ; $5AAE: $38 $37
 
-    ldh  a, [hMultiPurpose1]                           ; $5AB0: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5AB0: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5AB2: $21 $10 $C2
     add  hl, de                                   ; $5AB5: $19
     sub  $08                                      ; $5AB6: $D6 $08
@@ -3588,7 +3588,7 @@ func_018_5A91::
     ld   c, a                                     ; $5AC3: $4F
     ld   hl, Data_018_5A88                        ; $5AC4: $21 $88 $5A
     add  hl, bc                                   ; $5AC7: $09
-    ldh  a, [hMultiPurpose0]                           ; $5AC8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5AC8: $F0 $D7
     add  [hl]                                     ; $5ACA: $86
     ld   hl, wEntitiesPosXTable                   ; $5ACB: $21 $00 $C2
     add  hl, de                                   ; $5ACE: $19
@@ -4024,9 +4024,9 @@ jr_018_5CEF:
 
 jr_018_5D5E:
     ldh  a, [hActiveEntityVisualPosY]             ; $5D5E: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $5D60: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5D60: $E0 $D8
     ldh  a, [hActiveEntityPosX]                   ; $5D62: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $5D64: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5D64: $E0 $D7
     ld   a, JINGLE_WATER_DIVE                     ; $5D66: $3E $0E
     ldh  [hJingle], a                             ; $5D68: $E0 $F2
     ld   a, TRANSCIENT_VFX_PEGASUS_SPLASH         ; $5D6A: $3E $0C
@@ -4244,7 +4244,7 @@ jr_018_5EA2:
 jr_018_5EAD:
     ld   a, $18                                   ; $5EAD: $3E $18
     call func_036_4A4C_trampoline                 ; $5EAF: $CD $EA $0A
-    ldh  a, [hMultiPurpose0]                           ; $5EB2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5EB2: $F0 $D7
     jp   OpenDialogInTable2                       ; $5EB4: $C3 $7C $23
 
 Data_018_5EB7::
@@ -4873,11 +4873,11 @@ RevealMamuCave::
     ld   a, $20                                   ; $6304: $3E $20
     ldh  [hSwordIntersectedAreaY], a              ; $6306: $E0 $CD
     add  $10                                      ; $6308: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $630A: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $630A: $E0 $D8
     ld   a, $80                                   ; $630C: $3E $80
     ldh  [hSwordIntersectedAreaX], a              ; $630E: $E0 $CE
     add  $08                                      ; $6310: $C6 $08
-    ldh  [hMultiPurpose0], a                           ; $6312: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6312: $E0 $D7
     ld   a, TRANSCIENT_VFX_POOF                   ; $6314: $3E $02
     call AddTranscientVfx                         ; $6316: $CD $C7 $0C
     call label_2887                               ; $6319: $CD $87 $28
@@ -4976,7 +4976,7 @@ jr_018_63AF:
     add  hl, bc                                   ; $63B7: $09
     ld   [hl], a                                  ; $63B8: $77
     call func_018_6493                            ; $63B9: $CD $93 $64
-    ldh  a, [hMultiPurpose3]                           ; $63BC: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $63BC: $F0 $DA
     cp   $00                                      ; $63BE: $FE $00
     jr   z, jr_018_63C9                           ; $63C0: $28 $07
 
@@ -4999,11 +4999,11 @@ jr_018_63D1:
     call SpawnNewEntityInRange_trampoline         ; $63D8: $CD $98 $3B
     jr   c, jr_018_63F7                           ; $63DB: $38 $1A
 
-    ldh  a, [hMultiPurpose0]                           ; $63DD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $63DD: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $63DF: $21 $00 $C2
     add  hl, de                                   ; $63E2: $19
     ld   [hl], a                                  ; $63E3: $77
-    ldh  a, [hMultiPurpose1]                           ; $63E4: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $63E4: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $63E6: $21 $10 $C2
     add  hl, de                                   ; $63E9: $19
     ld   [hl], a                                  ; $63EA: $77
@@ -5114,7 +5114,7 @@ func_018_6493::
     add  hl, bc                                   ; $6497: $09
     ld   a, [hl]                                  ; $6498: $7E
     sub  $01                                      ; $6499: $D6 $01
-    ldh  [hMultiPurpose4], a                           ; $649B: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $649B: $E0 $DB
     and  $F0                                      ; $649D: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $649F: $E0 $CE
     swap a                                        ; $64A1: $CB $37
@@ -5123,7 +5123,7 @@ func_018_6493::
     ld   c, a                                     ; $64A7: $4F
     ld   a, [hl]                                  ; $64A8: $7E
     sub  $07                                      ; $64A9: $D6 $07
-    ldh  [hMultiPurpose5], a                           ; $64AB: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $64AB: $E0 $DC
     and  $F0                                      ; $64AD: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $64AF: $E0 $CD
     or   c                                        ; $64B1: $B1
@@ -5256,7 +5256,7 @@ jr_018_655B:
 
     ld   a, $08                                   ; $657B: $3E $08
     call GetVectorTowardsLink_trampoline          ; $657D: $CD $B5 $3B
-    ldh  a, [hMultiPurpose1]                           ; $6580: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6580: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $6582: $21 $40 $C2
     add  hl, bc                                   ; $6585: $09
     add  [hl]                                     ; $6586: $86
@@ -5766,9 +5766,9 @@ VireEntityHandler::
     jr   nz, jr_018_6A71                          ; $6A0E: $20 $61
 
     ldh  a, [hActiveEntityPosX]                   ; $6A10: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6A12: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6A12: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $6A14: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $6A16: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6A16: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $6A18: $3E $02
     call AddTranscientVfx                         ; $6A1A: $CD $C7 $0C
     ld   a, $0C                                   ; $6A1D: $3E $0C
@@ -5791,15 +5791,15 @@ func_018_6A31::
     ld   hl, wEntitiesLoadOrderTable              ; $6A3D: $21 $60 $C4
     add  hl, de                                   ; $6A40: $19
     ld   [hl], a                                  ; $6A41: $77
-    ldh  a, [hMultiPurpose0]                           ; $6A42: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A42: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6A44: $21 $00 $C2
     add  hl, de                                   ; $6A47: $19
     ld   [hl], a                                  ; $6A48: $77
-    ldh  a, [hMultiPurpose1]                           ; $6A49: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6A49: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6A4B: $21 $10 $C2
     add  hl, de                                   ; $6A4E: $19
     ld   [hl], a                                  ; $6A4F: $77
-    ldh  a, [hMultiPurpose3]                           ; $6A50: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $6A50: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $6A52: $21 $10 $C3
     add  hl, de                                   ; $6A55: $19
     ld   [hl], a                                  ; $6A56: $77
@@ -5887,13 +5887,13 @@ VireState1Handler::
 
     ld   a, $10                                   ; $6AE0: $3E $10
     call GetVectorTowardsLink_trampoline          ; $6AE2: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6AE5: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6AE5: $F0 $D7
     cpl                                           ; $6AE7: $2F
     inc  a                                        ; $6AE8: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $6AE9: $21 $50 $C2
     add  hl, bc                                   ; $6AEC: $09
     ld   [hl], a                                  ; $6AED: $77
-    ldh  a, [hMultiPurpose1]                           ; $6AEE: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6AEE: $F0 $D8
     cpl                                           ; $6AF0: $2F
     inc  a                                        ; $6AF1: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $6AF2: $21 $40 $C2
@@ -6086,13 +6086,13 @@ VireState3Handler::
 
     ld   a, $20                                   ; $6C05: $3E $20
     call GetVectorTowardsLink_trampoline          ; $6C07: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6C0A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6C0A: $F0 $D7
     cpl                                           ; $6C0C: $2F
     inc  a                                        ; $6C0D: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $6C0E: $21 $50 $C2
     add  hl, bc                                   ; $6C11: $09
     ld   [hl], a                                  ; $6C12: $77
-    ldh  a, [hMultiPurpose1]                           ; $6C13: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6C13: $F0 $D8
     cpl                                           ; $6C15: $2F
     inc  a                                        ; $6C16: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $6C17: $21 $40 $C2
@@ -6120,7 +6120,7 @@ jr_018_6C27:
 jr_018_6C38:
     ld   a, $20                                   ; $6C38: $3E $20
     call GetVectorTowardsLink_trampoline          ; $6C3A: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6C3D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6C3D: $F0 $D7
     cpl                                           ; $6C3F: $2F
     inc  a                                        ; $6C40: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $6C41: $21 $50 $C2
@@ -6137,7 +6137,7 @@ jr_018_6C38:
 jr_018_6C4E:
     dec  [hl]                                     ; $6C4E: $35
     dec  [hl]                                     ; $6C4F: $35
-    ldh  a, [hMultiPurpose1]                           ; $6C50: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6C50: $F0 $D8
     cpl                                           ; $6C52: $2F
     inc  a                                        ; $6C53: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $6C54: $21 $40 $C2
@@ -6419,11 +6419,11 @@ jr_018_6DDE:
     call SpawnNewEntity_trampoline                ; $6DED: $CD $86 $3B
     jr   c, jr_018_6E35                           ; $6DF0: $38 $43
 
-    ldh  a, [hMultiPurpose0]                           ; $6DF2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6DF2: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6DF4: $21 $00 $C2
     add  hl, de                                   ; $6DF7: $19
     ld   [hl], a                                  ; $6DF8: $77
-    ldh  a, [hMultiPurpose1]                           ; $6DF9: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6DF9: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $6DFB: $21 $DA $FF
     sub  [hl]                                     ; $6DFE: $96
     ld   hl, wEntitiesPosYTable                   ; $6DFF: $21 $10 $C2
@@ -6536,7 +6536,7 @@ jr_018_6E74:
     ld   a, $20                                   ; $6E9F: $3E $20
     call GetVectorTowardsLink_trampoline          ; $6EA1: $CD $B5 $3B
     pop  de                                       ; $6EA4: $D1
-    ldh  a, [hMultiPurpose1]                           ; $6EA5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6EA5: $F0 $D8
     cpl                                           ; $6EA7: $2F
     inc  a                                        ; $6EA8: $3C
     jr   nz, jr_018_6EAD                          ; $6EA9: $20 $02
@@ -6547,7 +6547,7 @@ jr_018_6EAD:
     ld   hl, wEntitiesSpeedXTable                 ; $6EAD: $21 $40 $C2
     add  hl, bc                                   ; $6EB0: $09
     ld   [hl], a                                  ; $6EB1: $77
-    ldh  a, [hMultiPurpose0]                           ; $6EB2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6EB2: $F0 $D7
     cpl                                           ; $6EB4: $2F
     inc  a                                        ; $6EB5: $3C
     jr   nz, jr_018_6EBA                          ; $6EB6: $20 $02
@@ -6625,9 +6625,9 @@ label_018_6F1F:
     jr   z, jr_018_6F54                           ; $6F42: $28 $10
 
     ldh  a, [hActiveEntityPosX]                   ; $6F44: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6F46: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6F46: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $6F48: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $6F4A: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6F4A: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $6F4C: $3E $02
     call AddTranscientVfx                         ; $6F4E: $CD $C7 $0C
 
@@ -7395,14 +7395,14 @@ jr_018_7416:
     ld   [hl], a                                  ; $7431: $77
     ld   hl, Data_018_73EE                        ; $7432: $21 $EE $73
     add  hl, bc                                   ; $7435: $09
-    ldh  a, [hMultiPurpose0]                           ; $7436: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7436: $F0 $D7
     add  [hl]                                     ; $7438: $86
     ld   hl, wEntitiesPosXTable                   ; $7439: $21 $00 $C2
     add  hl, de                                   ; $743C: $19
     ld   [hl], a                                  ; $743D: $77
     ld   hl, Data_018_73F4                        ; $743E: $21 $F4 $73
     add  hl, bc                                   ; $7441: $09
-    ldh  a, [hMultiPurpose1]                           ; $7442: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7442: $F0 $D8
     add  [hl]                                     ; $7444: $86
     ld   hl, wEntitiesPosYTable                   ; $7445: $21 $10 $C2
     add  hl, de                                   ; $7448: $19
@@ -7993,15 +7993,15 @@ label_018_78A6:
     ld   hl, wEntitiesUnknowTableH                ; $78B7: $21 $30 $C4
     add  hl, de                                   ; $78BA: $19
     res  0, [hl]                                  ; $78BB: $CB $86
-    ldh  a, [hMultiPurpose0]                           ; $78BD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $78BD: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $78BF: $21 $00 $C2
     add  hl, de                                   ; $78C2: $19
     ld   [hl], a                                  ; $78C3: $77
-    ldh  a, [hMultiPurpose1]                           ; $78C4: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $78C4: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $78C6: $21 $10 $C2
     add  hl, de                                   ; $78C9: $19
     ld   [hl], a                                  ; $78CA: $77
-    ldh  a, [hMultiPurpose3]                           ; $78CB: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $78CB: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $78CD: $21 $10 $C3
     add  hl, de                                   ; $78D0: $19
     ld   [hl], a                                  ; $78D1: $77
@@ -8050,13 +8050,13 @@ jr_018_78F1:
     ld   [hl], $12                                ; $791B: $36 $12
     ld   a, $20                                   ; $791D: $3E $20
     call GetVectorTowardsLink_trampoline          ; $791F: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7922: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7922: $F0 $D7
     cpl                                           ; $7924: $2F
     inc  a                                        ; $7925: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $7926: $21 $50 $C2
     add  hl, bc                                   ; $7929: $09
     ld   [hl], a                                  ; $792A: $77
-    ldh  a, [hMultiPurpose1]                           ; $792B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $792B: $F0 $D8
     cpl                                           ; $792D: $2F
     inc  a                                        ; $792E: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $792F: $21 $40 $C2
@@ -8157,9 +8157,9 @@ jr_018_79B3:
 
     call func_014_5526_trampoline                 ; $79B9: $CD $78 $21
     ldh  a, [hActiveEntityPosX]                   ; $79BC: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $79BE: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $79BE: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $79C0: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $79C2: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $79C2: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $79C4: $3E $02
     call AddTranscientVfx                         ; $79C6: $CD $C7 $0C
     ld   a, JINGLE_POOF                           ; $79C9: $3E $2F
@@ -8401,11 +8401,11 @@ Data_018_7B7D::
     db   $04, $04, $05, $05, $05, $06, $06, $06, $0C, $0C, $0B, $0B, $0B, $0A, $0A, $0A
 
 func_018_7B9D::
-    ldh  a, [hMultiPurpose0]                           ; $7B9D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7B9D: $F0 $D7
     rlca                                          ; $7B9F: $07
     and  $01                                      ; $7BA0: $E6 $01
     ld   e, a                                     ; $7BA2: $5F
-    ldh  a, [hMultiPurpose1]                           ; $7BA3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7BA3: $F0 $D8
     rlca                                          ; $7BA5: $07
     rla                                           ; $7BA6: $17
     and  $02                                      ; $7BA7: $E6 $02
@@ -8415,7 +8415,7 @@ func_018_7B9D::
     rla                                           ; $7BAC: $17
     and  $18                                      ; $7BAD: $E6 $18
     ld   h, a                                     ; $7BAF: $67
-    ldh  a, [hMultiPurpose1]                           ; $7BB0: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7BB0: $F0 $D8
     bit  7, a                                     ; $7BB2: $CB $7F
     jr   z, jr_018_7BB8                           ; $7BB4: $28 $02
 
@@ -8424,7 +8424,7 @@ func_018_7B9D::
 
 jr_018_7BB8:
     ld   d, a                                     ; $7BB8: $57
-    ldh  a, [hMultiPurpose0]                           ; $7BB9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7BB9: $F0 $D7
     bit  7, a                                     ; $7BBB: $CB $7F
     jr   z, jr_018_7BC1                           ; $7BBD: $28 $02
 
@@ -8470,15 +8470,15 @@ func_018_7CC8::
     sub  [hl]                                     ; $7CD3: $96
     sra  a                                        ; $7CD4: $CB $2F
     sra  a                                        ; $7CD6: $CB $2F
-    ldh  [hMultiPurpose0], a                           ; $7CD8: $E0 $D7
-    ldh  [hMultiPurpose2], a                           ; $7CDA: $E0 $D9
+    ldh  [hMultiPurpose0], a                      ; $7CD8: $E0 $D7
+    ldh  [hMultiPurpose2], a                      ; $7CDA: $E0 $D9
     ldh  a, [hActiveEntityPosY]                   ; $7CDC: $F0 $EF
     ld   hl, hLinkPositionY                       ; $7CDE: $21 $99 $FF
     sub  [hl]                                     ; $7CE1: $96
     sra  a                                        ; $7CE2: $CB $2F
     sra  a                                        ; $7CE4: $CB $2F
-    ldh  [hMultiPurpose1], a                           ; $7CE6: $E0 $D8
-    ldh  [hMultiPurpose3], a                           ; $7CE8: $E0 $DA
+    ldh  [hMultiPurpose1], a                      ; $7CE6: $E0 $D8
+    ldh  [hMultiPurpose3], a                      ; $7CE8: $E0 $DA
     ld   a, [wOAMNextAvailableSlot]               ; $7CEA: $FA $C0 $C3
     ld   e, a                                     ; $7CED: $5F
     ld   d, $00                                   ; $7CEE: $16 $00
@@ -8489,7 +8489,7 @@ func_018_7CC8::
     ld   a, $03                                   ; $7CF6: $3E $03
 
 jr_018_7CF8:
-    ldh  [hMultiPurpose4], a                           ; $7CF8: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $7CF8: $E0 $DB
     ld   hl, hFrameCounter                        ; $7CFA: $21 $E7 $FF
     xor  [hl]                                     ; $7CFD: $AE
     and  $01                                      ; $7CFE: $E6 $01
@@ -8514,15 +8514,15 @@ jr_018_7D09:
     ld   a, $00                                   ; $7D18: $3E $00
     ld   [de], a                                  ; $7D1A: $12
     inc  de                                       ; $7D1B: $13
-    ldh  a, [hMultiPurpose0]                           ; $7D1C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7D1C: $F0 $D7
     ld   hl, hMultiPurpose2                            ; $7D1E: $21 $D9 $FF
     add  [hl]                                     ; $7D21: $86
-    ldh  [hMultiPurpose0], a                           ; $7D22: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $7D24: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $7D22: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $7D24: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $7D26: $21 $DA $FF
     add  [hl]                                     ; $7D29: $86
-    ldh  [hMultiPurpose1], a                           ; $7D2A: $E0 $D8
-    ldh  a, [hMultiPurpose4]                           ; $7D2C: $F0 $DB
+    ldh  [hMultiPurpose1], a                      ; $7D2A: $E0 $D8
+    ldh  a, [hMultiPurpose4]                      ; $7D2C: $F0 $DB
     dec  a                                        ; $7D2E: $3D
     jr   nz, jr_018_7CF8                          ; $7D2F: $20 $C7
 
@@ -8876,7 +8876,7 @@ jr_018_7EDF:
 func_018_7EE1::
     call func_018_7EB2                            ; $7EE1: $CD $B2 $7E
     ld   a, e                                     ; $7EE4: $7B
-    ldh  [hMultiPurpose0], a                           ; $7EE5: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7EE5: $E0 $D7
     ld   a, d                                     ; $7EE7: $7A
     bit  7, a                                     ; $7EE8: $CB $7F
     jr   z, jr_018_7EEE                           ; $7EEA: $28 $02
@@ -8888,7 +8888,7 @@ jr_018_7EEE:
     push af                                       ; $7EEE: $F5
     call func_018_7EC2                            ; $7EEF: $CD $C2 $7E
     ld   a, e                                     ; $7EF2: $7B
-    ldh  [hMultiPurpose1], a                           ; $7EF3: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7EF3: $E0 $D8
     ld   a, d                                     ; $7EF5: $7A
     bit  7, a                                     ; $7EF6: $CB $7F
     jr   z, jr_018_7EFC                           ; $7EF8: $28 $02
@@ -8901,11 +8901,11 @@ jr_018_7EFC:
     cp   d                                        ; $7EFD: $BA
     jr   nc, jr_018_7F04                          ; $7EFE: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $7F00: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7F00: $F0 $D7
     jr   jr_018_7F06                              ; $7F02: $18 $02
 
 jr_018_7F04:
-    ldh  a, [hMultiPurpose1]                           ; $7F04: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7F04: $F0 $D8
 
 jr_018_7F06:
     ld   e, a                                     ; $7F06: $5F
@@ -8984,9 +8984,9 @@ label_018_7F4F:
 label_018_7F6F:
     call func_018_7DEE                            ; $7F6F: $CD $EE $7D
     ldh  a, [hActiveEntityPosX]                   ; $7F72: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $7F74: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7F74: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7F76: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7F78: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7F78: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $7F7A: $3E $02
     call AddTranscientVfx                         ; $7F7C: $CD $C7 $0C
     ld   a, $13                                   ; $7F7F: $3E $13
@@ -8995,11 +8995,11 @@ label_018_7F6F:
 
     ld   a, $36                                   ; $7F84: $3E $36
     call SpawnNewEntity_trampoline                ; $7F86: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7F89: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7F89: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7F8B: $21 $00 $C2
     add  hl, de                                   ; $7F8E: $19
     ld   [hl], a                                  ; $7F8F: $77
-    ldh  a, [hMultiPurpose1]                           ; $7F90: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7F90: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7F92: $21 $10 $C2
     add  hl, de                                   ; $7F95: $19
     ld   [hl], a                                  ; $7F96: $77

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -248,19 +248,19 @@ jr_019_4193:
     ld   c, a                                     ; $419C: $4F
     ld   hl, Data_019_4165                        ; $419D: $21 $65 $41
     add  hl, bc                                   ; $41A0: $09
-    ldh  a, [hMultiPurpose0]                           ; $41A1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $41A1: $F0 $D7
     add  [hl]                                     ; $41A3: $86
     ld   hl, wEntitiesPosXTable                   ; $41A4: $21 $00 $C2
     add  hl, de                                   ; $41A7: $19
     ld   [hl], a                                  ; $41A8: $77
     ld   hl, Data_019_416B                        ; $41A9: $21 $6B $41
     add  hl, bc                                   ; $41AC: $09
-    ldh  a, [hMultiPurpose1]                           ; $41AD: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $41AD: $F0 $D8
     add  [hl]                                     ; $41AF: $86
     ld   hl, wEntitiesPosYTable                   ; $41B0: $21 $10 $C2
     add  hl, de                                   ; $41B3: $19
     ld   [hl], a                                  ; $41B4: $77
-    ldh  a, [hMultiPurpose3]                           ; $41B5: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $41B5: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $41B7: $21 $10 $C3
     add  hl, de                                   ; $41BA: $19
     ld   [hl], a                                  ; $41BB: $77
@@ -292,14 +292,14 @@ jr_019_41E2:
     ld   a, $29                                   ; $41E2: $3E $29
     ldh  [hNoiseSfx], a                           ; $41E4: $E0 $F4
     ldh  a, [hActiveEntityPosX]                   ; $41E6: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $41E8: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $41E8: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $41EA: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $41EC: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $41EC: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $41EE: $3E $02
     call AddTranscientVfx                         ; $41F0: $CD $C7 $0C
     ldh  a, [hActiveEntityVisualPosY]             ; $41F3: $F0 $EC
     sub  $10                                      ; $41F5: $D6 $10
-    ldh  [hMultiPurpose1], a                           ; $41F7: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $41F7: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $41F9: $3E $02
     call AddTranscientVfx                         ; $41FB: $CD $C7 $0C
     jp   ClearEntityStatus_19                            ; $41FE: $C3 $61 $7E
@@ -730,9 +730,9 @@ jr_019_4562:
     jr   nz, jr_019_459F                          ; $4583: $20 $1A
 
     ldh  a, [hActiveEntityPosX]                   ; $4585: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4587: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4587: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4589: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $458B: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $458B: $E0 $D8
     ld   a, TRANSCIENT_VFX_SWORD_BEAM             ; $458D: $3E $0D
     call AddTranscientVfx                         ; $458F: $CD $C7 $0C
     ld   hl, wTranscientVfxCountdownTable                                ; $4592: $21 $20 $C5
@@ -751,10 +751,10 @@ jr_019_45A0:
 
 func_019_45A3::
     ldh  a, [hActiveEntityPosX]                   ; $45A3: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $45A5: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $45A5: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $45A7: $F0 $EC
     add  $03                                      ; $45A9: $C6 $03
-    ldh  [hMultiPurpose1], a                           ; $45AB: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $45AB: $E0 $D8
     ld   a, TRANSCIENT_VFX_SWORD_POKE             ; $45AD: $3E $05
     jp   AddTranscientVfx                         ; $45AF: $C3 $C7 $0C
 
@@ -2006,11 +2006,11 @@ func_019_4E09::
     call SpawnNewEntity_trampoline                ; $4E1F: $CD $86 $3B
     ld   hl, wEntitiesPosXTable                   ; $4E22: $21 $00 $C2
     add  hl, de                                   ; $4E25: $19
-    ldh  a, [hMultiPurpose0]                           ; $4E26: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4E26: $F0 $D7
     ld   [hl], a                                  ; $4E28: $77
     ld   hl, wEntitiesPosYTable                   ; $4E29: $21 $10 $C2
     add  hl, de                                   ; $4E2C: $19
-    ldh  a, [hMultiPurpose1]                           ; $4E2D: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4E2D: $F0 $D8
     ld   [hl], a                                  ; $4E2F: $77
     ld   hl, wEntitiesTransitionCountdownTable    ; $4E30: $21 $E0 $C2
     add  hl, de                                   ; $4E33: $19
@@ -2065,11 +2065,11 @@ func_019_4E74::
 
     ld   a, $D5                                   ; $4E88: $3E $D5
     call SpawnNewEntity_trampoline                ; $4E8A: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4E8D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4E8D: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4E8F: $21 $00 $C2
     add  hl, de                                   ; $4E92: $19
     ld   [hl], a                                  ; $4E93: $77
-    ldh  a, [hMultiPurpose1]                           ; $4E94: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4E94: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4E96: $21 $10 $C2
     add  hl, de                                   ; $4E99: $19
     ld   [hl], a                                  ; $4E9A: $77
@@ -2191,11 +2191,11 @@ jr_019_4F8F:
     call SpawnNewEntity_trampoline                ; $4FBC: $CD $86 $3B
     ret  c                                        ; $4FBF: $D8
 
-    ldh  a, [hMultiPurpose0]                           ; $4FC0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4FC0: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4FC2: $21 $00 $C2
     add  hl, de                                   ; $4FC5: $19
     ld   [hl], a                                  ; $4FC6: $77
-    ldh  a, [hMultiPurpose1]                           ; $4FC7: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4FC7: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4FC9: $21 $10 $C2
     add  hl, de                                   ; $4FCC: $19
     ld   [hl], a                                  ; $4FCD: $77
@@ -2295,12 +2295,12 @@ jr_019_506C:
     srl  c                                        ; $5071: $CB $39
     ld   hl, Data_019_500B                        ; $5073: $21 $0B $50
     add  hl, bc                                   ; $5076: $09
-    ldh  a, [hMultiPurpose0]                           ; $5077: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5077: $F0 $D7
     add  [hl]                                     ; $5079: $86
     ld   hl, wEntitiesPosXTable                   ; $507A: $21 $00 $C2
     add  hl, de                                   ; $507D: $19
     ld   [hl], a                                  ; $507E: $77
-    ldh  a, [hMultiPurpose1]                           ; $507F: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $507F: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5081: $21 $10 $C2
     add  hl, de                                   ; $5084: $19
     ld   [hl], a                                  ; $5085: $77
@@ -2868,7 +2868,7 @@ jr_019_542C:
     call SpawnNewEntity_trampoline                ; $5430: $CD $86 $3B
     ret  c                                        ; $5433: $D8
 
-    ldh  a, [hMultiPurpose1]                           ; $5434: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5434: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5436: $21 $10 $C2
     add  hl, de                                   ; $5439: $19
     ld   [hl], a                                  ; $543A: $77
@@ -2880,7 +2880,7 @@ jr_019_542C:
     ld   c, a                                     ; $5444: $4F
     ld   hl, Data_019_5410                        ; $5445: $21 $10 $54
     add  hl, bc                                   ; $5448: $09
-    ldh  a, [hMultiPurpose0]                           ; $5449: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5449: $F0 $D7
     add  [hl]                                     ; $544B: $86
     ld   hl, wEntitiesPosXTable                   ; $544C: $21 $00 $C2
     add  hl, de                                   ; $544F: $19
@@ -2954,11 +2954,11 @@ jr_019_54AC:
     call SpawnNewEntity_trampoline                ; $54B4: $CD $86 $3B
     ret  c                                        ; $54B7: $D8
 
-    ldh  a, [hMultiPurpose0]                           ; $54B8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $54B8: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $54BA: $21 $00 $C2
     add  hl, de                                   ; $54BD: $19
     ld   [hl], a                                  ; $54BE: $77
-    ldh  a, [hMultiPurpose1]                           ; $54BF: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $54BF: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $54C1: $21 $10 $C2
     add  hl, de                                   ; $54C4: $19
     ld   [hl], a                                  ; $54C5: $77
@@ -3171,11 +3171,11 @@ Data_019_565B::
     db   $04, $04, $05, $05, $05, $06, $06, $06, $0C, $0C, $0B, $0B, $0B, $0A, $0A, $0A
 
 func_019_567B::
-    ldh  a, [hMultiPurpose0]                           ; $567B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $567B: $F0 $D7
     rlca                                          ; $567D: $07
     and  $01                                      ; $567E: $E6 $01
     ld   e, a                                     ; $5680: $5F
-    ldh  a, [hMultiPurpose1]                           ; $5681: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5681: $F0 $D8
     rlca                                          ; $5683: $07
     rla                                           ; $5684: $17
     and  $02                                      ; $5685: $E6 $02
@@ -3185,7 +3185,7 @@ func_019_567B::
     rla                                           ; $568A: $17
     and  $18                                      ; $568B: $E6 $18
     ld   h, a                                     ; $568D: $67
-    ldh  a, [hMultiPurpose1]                           ; $568E: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $568E: $F0 $D8
     bit  7, a                                     ; $5690: $CB $7F
     jr   z, jr_019_5696                           ; $5692: $28 $02
 
@@ -3194,7 +3194,7 @@ func_019_567B::
 
 jr_019_5696:
     ld   d, a                                     ; $5696: $57
-    ldh  a, [hMultiPurpose0]                           ; $5697: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5697: $F0 $D7
     bit  7, a                                     ; $5699: $CB $7F
     jr   z, jr_019_569F                           ; $569B: $28 $02
 
@@ -3498,9 +3498,9 @@ func_019_58A2::
     call label_3B18                               ; $58AF: $CD $18 $3B
     ld   a, $10                                   ; $58B2: $3E $10
     call GetVectorTowardsLink_trampoline          ; $58B4: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $58B7: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $58B7: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $58B9: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $58BB: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $58BB: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $58BD: $E0 $9A
     ret                                           ; $58BF: $C9
 
@@ -6019,9 +6019,9 @@ jr_019_6CC2:
     ldh  a, [hActiveEntityVisualPosY]             ; $6CD1: $F0 $EC
 
 func_019_6CD3::
-    ldh  [hMultiPurpose1], a                           ; $6CD3: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6CD3: $E0 $D8
     ldh  a, [hActiveEntityPosX]                   ; $6CD5: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6CD7: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6CD7: $E0 $D7
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $6CD9: $3E $01
     call AddTranscientVfx                         ; $6CDB: $CD $C7 $0C
     ld   a, JINGLE_WATER_DIVE                     ; $6CDE: $3E $0E
@@ -6142,12 +6142,12 @@ BananasSchuleState2Handler::
 
     ld   a, $CD                                   ; $6D90: $3E $CD
     call SpawnNewEntity_trampoline                ; $6D92: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6D95: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6D95: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6D97: $21 $00 $C2
     add  hl, de                                   ; $6D9A: $19
     sub  $02                                      ; $6D9B: $D6 $02
     ld   [hl], a                                  ; $6D9D: $77
-    ldh  a, [hMultiPurpose1]                           ; $6D9E: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6D9E: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6DA0: $21 $10 $C2
     add  hl, de                                   ; $6DA3: $19
     ld   [hl], a                                  ; $6DA4: $77
@@ -7545,42 +7545,42 @@ jr_019_796C:
     ld   hl, Data_019_794E                        ; $7972: $21 $4E $79
     add  hl, de                                   ; $7975: $19
     ld   a, [hl]                                  ; $7976: $7E
-    ldh  [hMultiPurpose0], a                           ; $7977: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7977: $E0 $D7
     ld   hl, Data_019_7952                        ; $7979: $21 $52 $79
     add  hl, de                                   ; $797C: $19
     ld   a, [hl]                                  ; $797D: $7E
-    ldh  [hMultiPurpose1], a                           ; $797E: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $797E: $E0 $D8
     ld   hl, Data_019_7956                        ; $7980: $21 $56 $79
     add  hl, de                                   ; $7983: $19
     ld   a, [hl]                                  ; $7984: $7E
 
 jr_019_7985:
-    ldh  [hMultiPurpose2], a                           ; $7985: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $7985: $E0 $D9
     ld   hl, Data_019_795A                        ; $7987: $21 $5A $79
     add  hl, de                                   ; $798A: $19
     ld   a, [hl]                                  ; $798B: $7E
-    ldh  [hMultiPurpose3], a                           ; $798C: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $798C: $E0 $DA
     ld   hl, wEntitiesPosXTable                   ; $798E: $21 $00 $C2
     add  hl, bc                                   ; $7991: $09
-    ldh  a, [hMultiPurpose0]                           ; $7992: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7992: $F0 $D7
     add  [hl]                                     ; $7994: $86
     rl   d                                        ; $7995: $CB $12
     ld   [hl], a                                  ; $7997: $77
     ld   hl, wEntitiesPosXSignTable               ; $7998: $21 $20 $C2
     add  hl, bc                                   ; $799B: $09
-    ldh  a, [hMultiPurpose1]                           ; $799C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $799C: $F0 $D8
     rr   d                                        ; $799E: $CB $1A
     adc  [hl]                                     ; $79A0: $8E
     ld   [hl], a                                  ; $79A1: $77
     ld   hl, wEntitiesPosYTable                   ; $79A2: $21 $10 $C2
     add  hl, bc                                   ; $79A5: $09
-    ldh  a, [hMultiPurpose2]                           ; $79A6: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $79A6: $F0 $D9
     add  [hl]                                     ; $79A8: $86
     rl   d                                        ; $79A9: $CB $12
     ld   [hl], a                                  ; $79AB: $77
     ld   hl, wEntitiesPosYSignTable               ; $79AC: $21 $30 $C2
     add  hl, bc                                   ; $79AF: $09
-    ldh  a, [hMultiPurpose3]                           ; $79B0: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $79B0: $F0 $DA
     rr   d                                        ; $79B2: $CB $1A
     adc  [hl]                                     ; $79B4: $8E
     ld   [hl], a                                  ; $79B5: $77
@@ -7591,12 +7591,12 @@ jr_019_7985:
 
     ld   hl, wEntitiesUnknowTableP                ; $79BC: $21 $40 $C4
     add  hl, bc                                   ; $79BF: $09
-    ldh  a, [hMultiPurpose0]                           ; $79C0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $79C0: $F0 $D7
     add  [hl]                                     ; $79C2: $86
     ld   [hl], a                                  ; $79C3: $77
     ld   hl, wEntitiesUnknownTableD               ; $79C4: $21 $D0 $C2
     add  hl, bc                                   ; $79C7: $09
-    ldh  a, [hMultiPurpose2]                           ; $79C8: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $79C8: $F0 $D9
     add  [hl]                                     ; $79CA: $86
     ld   [hl], a                                  ; $79CB: $77
     jp   label_019_7A74                           ; $79CC: $C3 $74 $7A
@@ -7630,7 +7630,7 @@ jr_019_7985:
     ld   d, b                                     ; $79F3: $50
     ld   hl, wIsFileSelectionArrowShifted         ; $79F4: $21 $00 $D0
     add  hl, de                                   ; $79F7: $19
-    ldh  a, [hMultiPurpose0]                           ; $79F8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $79F8: $F0 $D7
     add  [hl]                                     ; $79FA: $86
     ld   [hl], a                                  ; $79FB: $77
     ldh  a, [hFreeWarpDataAddress]                ; $79FC: $F0 $E6
@@ -7640,7 +7640,7 @@ jr_019_7985:
     ld   d, b                                     ; $7A01: $50
     ld   hl, wD100                                ; $7A02: $21 $00 $D1
     add  hl, de                                   ; $7A05: $19
-    ldh  a, [hMultiPurpose2]                           ; $7A06: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7A06: $F0 $D9
     add  [hl]                                     ; $7A08: $86
     ld   [hl], a                                  ; $7A09: $77
     ldh  a, [hMultiPurposeG]                               ; $7A0A: $F0 $E8
@@ -7659,7 +7659,7 @@ jr_019_7985:
     ld   e, $10                                   ; $7A19: $1E $10
     ld   hl, $D155                                ; $7A1B: $21 $55 $D1
 .loop_019_7A1E
-    ldh  a, [hMultiPurpose0]                           ; $7A1E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7A1E: $F0 $D7
     add  [hl]                                     ; $7A20: $86
     ld   [hl+], a                                 ; $7A21: $22
     dec  e                                        ; $7A22: $1D
@@ -7669,7 +7669,7 @@ jr_019_7985:
     ld   e, $10                                   ; $7A25: $1E $10
     ld   hl, $D175                                ; $7A27: $21 $75 $D1
 .loop_019_7A2A
-    ldh  a, [hMultiPurpose2]                           ; $7A2A: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7A2A: $F0 $D9
     add  [hl]                                     ; $7A2C: $86
     ld   [hl+], a                                 ; $7A2D: $22
     dec  e                                        ; $7A2E: $1D
@@ -7700,7 +7700,7 @@ jr_019_7985:
     ld   e, $06                                   ; $7A4C: $1E $06
     ld   hl, wD100                                ; $7A4E: $21 $00 $D1
 .loop_019_7A51
-    ldh  a, [hMultiPurpose0]                           ; $7A51: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7A51: $F0 $D7
     add  [hl]                                     ; $7A53: $86
     ld   [hl+], a                                 ; $7A54: $22
     dec  e                                        ; $7A55: $1D
@@ -7710,7 +7710,7 @@ jr_019_7985:
     ld   e, $06                                   ; $7A58: $1E $06
     ld   hl, wD110                                ; $7A5A: $21 $10 $D1
 .loop_019_7A5D
-    ldh  a, [hMultiPurpose2]                           ; $7A5D: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7A5D: $F0 $D9
     add  [hl]                                     ; $7A5F: $86
     ld   [hl+], a                                 ; $7A60: $22
     dec  e                                        ; $7A61: $1D
@@ -7719,12 +7719,12 @@ jr_019_7985:
 .jr_019_7A64
     ld   hl, wEntitiesPrivateState1Table          ; $7A64: $21 $B0 $C2
     add  hl, bc                                   ; $7A67: $09
-    ldh  a, [hMultiPurpose0]                           ; $7A68: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7A68: $F0 $D7
     add  [hl]                                     ; $7A6A: $86
     ld   [hl], a                                  ; $7A6B: $77
     ld   hl, wEntitiesPrivateState2Table          ; $7A6C: $21 $C0 $C2
     add  hl, bc                                   ; $7A6F: $09
-    ldh  a, [hMultiPurpose2]                           ; $7A70: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7A70: $F0 $D9
     add  [hl]                                     ; $7A72: $86
     ld   [hl], a                                  ; $7A73: $77
 
@@ -7903,7 +7903,7 @@ jr_019_7C56:
     cp   $01                                      ; $7C56: $FE $01
     jr   z, jr_019_7C6D                           ; $7C58: $28 $13
 
-    ldh  a, [hMultiPurpose0]                           ; $7C5A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7C5A: $F0 $D7
     and  $0C                                      ; $7C5C: $E6 $0C
 
 jr_019_7C5E:
@@ -7945,7 +7945,7 @@ jr_019_7C8D:
     ld   hl, Data_019_7B50                        ; $7C8D: $21 $50 $7B
 
 jr_019_7C90:
-    ldh  a, [hMultiPurpose0]                           ; $7C90: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7C90: $F0 $D7
     and  $1C                                      ; $7C92: $E6 $1C
     xor  $1C                                      ; $7C94: $EE $1C
     sla  a                                        ; $7C96: $CB $27
@@ -8286,7 +8286,7 @@ jr_019_7E38:
 func_019_7E3A::
     call func_019_7E0B                            ; $7E3A: $CD $0B $7E
     ld   a, e                                     ; $7E3D: $7B
-    ldh  [hMultiPurpose0], a                           ; $7E3E: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7E3E: $E0 $D7
     ld   a, d                                     ; $7E40: $7A
     bit  7, a                                     ; $7E41: $CB $7F
     jr   z, jr_019_7E47                           ; $7E43: $28 $02
@@ -8298,7 +8298,7 @@ jr_019_7E47:
     push af                                       ; $7E47: $F5
     call func_019_7E1B                            ; $7E48: $CD $1B $7E
     ld   a, e                                     ; $7E4B: $7B
-    ldh  [hMultiPurpose1], a                           ; $7E4C: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7E4C: $E0 $D8
     ld   a, d                                     ; $7E4E: $7A
     bit  7, a                                     ; $7E4F: $CB $7F
     jr   z, jr_019_7E55                           ; $7E51: $28 $02
@@ -8311,11 +8311,11 @@ jr_019_7E55:
     cp   d                                        ; $7E56: $BA
     jr   nc, jr_019_7E5D                          ; $7E57: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $7E59: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7E59: $F0 $D7
     jr   jr_019_7E5F                              ; $7E5B: $18 $02
 
 jr_019_7E5D:
-    ldh  a, [hMultiPurpose1]                           ; $7E5D: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7E5D: $F0 $D8
 
 jr_019_7E5F:
     ld   e, a                                     ; $7E5F: $5F
@@ -8392,9 +8392,9 @@ label_019_7EA4:
 label_019_7EC4:
     call func_019_7D43                            ; $7EC4: $CD $43 $7D
     ldh  a, [hActiveEntityPosX]                   ; $7EC7: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $7EC9: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7EC9: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7ECB: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7ECD: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7ECD: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $7ECF: $3E $02
     call AddTranscientVfx                         ; $7ED1: $CD $C7 $0C
     ld   a, $13                                   ; $7ED4: $3E $13
@@ -8403,11 +8403,11 @@ label_019_7EC4:
 
     ld   a, $36                                   ; $7ED9: $3E $36
     call SpawnNewEntity_trampoline                ; $7EDB: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7EDE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7EDE: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7EE0: $21 $00 $C2
     add  hl, de                                   ; $7EE3: $19
     ld   [hl], a                                  ; $7EE4: $77
-    ldh  a, [hMultiPurpose1]                           ; $7EE5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7EE5: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7EE7: $21 $10 $C2
     add  hl, de                                   ; $7EEA: $19
     ld   [hl], a                                  ; $7EEB: $77

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -2148,11 +2148,11 @@ SmashRock::
     ; Smash rock
     ;
 
-    ldh  a, [hMultiPurpose0]                           ; $540D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $540D: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $540F: $21 $00 $C2
     add  hl, de                                   ; $5412: $19
     ld   [hl], a                                  ; $5413: $77
-    ldh  a, [hMultiPurpose1]                           ; $5414: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5414: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $5416: $21 $DA $FF
     sub  [hl]                                     ; $5419: $96
     ld   hl, wEntitiesPosYTable                   ; $541A: $21 $10 $C2
@@ -2197,7 +2197,7 @@ jr_003_5455:
     ld   a, $20                                   ; $5459: $3E $20
     ldh  [hSwordIntersectedAreaY], a              ; $545B: $E0 $CD
     ld   a, $19                                   ; $545D: $3E $19
-    ldh  [hMultiPurpose8], a                           ; $545F: $E0 $DF
+    ldh  [hMultiPurpose8], a                      ; $545F: $E0 $DF
     call label_3E4D                               ; $5461: $CD $4D $3E
     jp   MarkTriggerAsResolved                    ; $5464: $C3 $60 $0C
 
@@ -2426,7 +2426,7 @@ SpawnEnemyDrop::
     ldh  a, [hActiveEntityType]                   ; $55CF: $F0 $EB
     cp   ENTITY_LIKE_LIKE                         ; $55D1: $FE $23
     jr   nz, .likeLikeEnd                         ; $55D3: $20 $0D
-    ; if active entity is Like-Like 
+    ; if active entity is Like-Like
     ld   hl, wEntitiesPrivateState1Table          ; $55D5: $21 $B0 $C2
     add  hl, bc                                   ; $55D8: $09
     ld   a, [hl]                                  ; $55D9: $7E
@@ -2534,7 +2534,7 @@ SpawnEnemyDrop::
     call GetRandomByte                            ; $5656: $CD $0D $28
     and  [hl]                                     ; $5659: $A6
     ret  nz                                       ; $565A: $C0
-    
+
     ld   hl, (DropTableByIndex - 1)               ; $565B: $21 $9C $55
     add  hl, de                                   ; $565E: $19
     ld   a, [hl]                                  ; $565F: $7E
@@ -3016,18 +3016,18 @@ SpawnMoblinArrow::
     jr   c, jr_003_598B                           ; $594C: $38 $3D
 
     push bc                                       ; $594E: $C5
-    ldh  a, [hMultiPurpose2]                           ; $594F: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $594F: $F0 $D9
     ld   c, a                                     ; $5951: $4F
     ld   hl, Data_003_5937                        ; $5952: $21 $37 $59
     add  hl, bc                                   ; $5955: $09
-    ldh  a, [hMultiPurpose0]                           ; $5956: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5956: $F0 $D7
     add  [hl]                                     ; $5958: $86
     ld   hl, wEntitiesPosXTable                   ; $5959: $21 $00 $C2
     add  hl, de                                   ; $595C: $19
     ld   [hl], a                                  ; $595D: $77
     ld   hl, Data_003_593B                        ; $595E: $21 $3B $59
     add  hl, bc                                   ; $5961: $09
-    ldh  a, [hMultiPurpose1]                           ; $5962: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5962: $F0 $D8
     add  [hl]                                     ; $5964: $86
     ld   hl, wEntitiesPosYTable                   ; $5965: $21 $10 $C2
     add  hl, de                                   ; $5968: $19
@@ -3046,7 +3046,7 @@ jr_003_5974:
     ld   hl, wEntitiesSpeedYTable                 ; $5979: $21 $50 $C2
     add  hl, de                                   ; $597C: $19
     ld   [hl], a                                  ; $597D: $77
-    ldh  a, [hMultiPurpose2]                           ; $597E: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $597E: $F0 $D9
     ld   hl, wEntitiesSpriteVariantTable          ; $5980: $21 $B0 $C3
     add  hl, de                                   ; $5983: $19
     ld   [hl], a                                  ; $5984: $77
@@ -3076,21 +3076,21 @@ SpawnOctorockRock::
     jr   c, jr_003_59D6                           ; $599D: $38 $37
 
     push bc                                       ; $599F: $C5
-    ldh  a, [hMultiPurpose2]                           ; $59A0: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $59A0: $F0 $D9
     ld   hl, wEntitiesDirectionTable              ; $59A2: $21 $80 $C3
     add  hl, de                                   ; $59A5: $19
     ld   [hl], a                                  ; $59A6: $77
     ld   c, a                                     ; $59A7: $4F
     ld   hl, Data_003_598C                        ; $59A8: $21 $8C $59
     add  hl, bc                                   ; $59AB: $09
-    ldh  a, [hMultiPurpose0]                           ; $59AC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $59AC: $F0 $D7
     add  [hl]                                     ; $59AE: $86
     ld   hl, wEntitiesPosXTable                   ; $59AF: $21 $00 $C2
     add  hl, de                                   ; $59B2: $19
     ld   [hl], a                                  ; $59B3: $77
     ld   hl, Data_003_598E                        ; $59B4: $21 $8E $59
     add  hl, bc                                   ; $59B7: $09
-    ldh  a, [hMultiPurpose1]                           ; $59B8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $59B8: $F0 $D8
     add  [hl]                                     ; $59BA: $86
     ld   hl, wEntitiesPosYTable                   ; $59BB: $21 $10 $C2
     add  hl, de                                   ; $59BE: $19
@@ -4029,12 +4029,12 @@ func_003_5F33::
 
     ld   a, ENTITY_INSTRUMENT_OF_THE_SIRENS       ; $5F3C: $3E $39
     call SpawnNewEntity                           ; $5F3E: $CD $CA $64
-    ldh  a, [hMultiPurpose0]                           ; $5F41: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5F41: $F0 $D7
     dec  a                                        ; $5F43: $3D
     ld   hl, wEntitiesPosXTable                   ; $5F44: $21 $00 $C2
     add  hl, de                                   ; $5F47: $19
     ld   [hl], a                                  ; $5F48: $77
-    ldh  a, [hMultiPurpose1]                           ; $5F49: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5F49: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5F4B: $21 $10 $C2
     add  hl, de                                   ; $5F4E: $19
     ld   [hl], a                                  ; $5F4F: $77
@@ -4071,7 +4071,7 @@ jr_003_5F5F:
     ld   c, a                                     ; $5F82: $4F
     ld   hl, Data_003_5F2F                        ; $5F83: $21 $2F $5F
     add  hl, bc                                   ; $5F86: $09
-    ldh  a, [hMultiPurpose0]                           ; $5F87: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5F87: $F0 $D7
     add  [hl]                                     ; $5F89: $86
     ld   hl, wEntitiesPosXTable                   ; $5F8A: $21 $00 $C2
     add  hl, de                                   ; $5F8D: $19
@@ -4082,7 +4082,7 @@ jr_003_5F5F:
     ld   hl, wEntitiesSpeedXTable                 ; $5F94: $21 $40 $C2
     add  hl, de                                   ; $5F97: $19
     ld   [hl], a                                  ; $5F98: $77
-    ldh  a, [hMultiPurpose1]                           ; $5F99: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5F99: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5F9B: $21 $10 $C2
     add  hl, de                                   ; $5F9E: $19
     add  $F8                                      ; $5F9F: $C6 $F8
@@ -4554,13 +4554,13 @@ jr_003_626B:
     ld   [hl], $18                                ; $6278: $36 $18
     ld   a, $0C                                   ; $627A: $3E $0C
     call GetVectorTowardsLink                     ; $627C: $CD $45 $7E
-    ldh  a, [hMultiPurpose1]                           ; $627F: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $627F: $F0 $D8
     cpl                                           ; $6281: $2F
     inc  a                                        ; $6282: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $6283: $21 $40 $C2
     add  hl, bc                                   ; $6286: $09
     ld   [hl], a                                  ; $6287: $77
-    ldh  a, [hMultiPurpose0]                           ; $6288: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6288: $F0 $D7
     cpl                                           ; $628A: $2F
     inc  a                                        ; $628B: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $628C: $21 $50 $C2
@@ -4872,12 +4872,12 @@ MovePickupInTheAir::
     add  hl, de                                   ; $6426: $19
     ldh  a, [hLinkPositionX]                      ; $6427: $F0 $98
     add  [hl]                                     ; $6429: $86
-    ldh  [hMultiPurpose0], a                           ; $642A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $642A: $E0 $D7
     ld   hl, Data_003_63F2                        ; $642C: $21 $F2 $63
     add  hl, de                                   ; $642F: $19
     ldh  a, [hLinkPositionY]                      ; $6430: $F0 $99
     add  [hl]                                     ; $6432: $86
-    ldh  [hMultiPurpose1], a                           ; $6433: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6433: $E0 $D8
     ld   a, TRANSCIENT_VFX_MOVING_SPARKLE         ; $6435: $3E $07
     call AddTranscientVfx                         ; $6437: $CD $C7 $0C
     ld   hl, wTranscientVfxCountdownTable         ; $643A: $21 $20 $C5
@@ -5055,25 +5055,25 @@ SpawnNewEntityInRange::
     ld   hl, wEntitiesPosXTable                   ; $64E8: $21 $00 $C2
     add  hl, bc                                   ; $64EB: $09
     ld   a, [hl]                                  ; $64EC: $7E
-    ldh  [hMultiPurpose0], a                           ; $64ED: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $64ED: $E0 $D7
 
     ; hMultiPurpose1 = previous entity pos Y
     ld   hl, wEntitiesPosYTable                   ; $64EF: $21 $10 $C2
     add  hl, bc                                   ; $64F2: $09
     ld   a, [hl]                                  ; $64F3: $7E
-    ldh  [hMultiPurpose1], a                           ; $64F4: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $64F4: $E0 $D8
 
     ; hMultiPurpose2 = previous entity wEntitiesDirectionTable
     ld   hl, wEntitiesDirectionTable              ; $64F6: $21 $80 $C3
     add  hl, bc                                   ; $64F9: $09
     ld   a, [hl]                                  ; $64FA: $7E
-    ldh  [hMultiPurpose2], a                           ; $64FB: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $64FB: $E0 $D9
 
     ; hMultiPurpose3 = previous entity pos Z
     ld   hl, wEntitiesPosZTable                                ; $64FD: $21 $10 $C3
     add  hl, bc                                   ; $6500: $09
     ld   a, [hl]                                  ; $6501: $7E
-    ldh  [hMultiPurpose3], a                           ; $6502: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $6502: $E0 $DA
 
     call ConfigureNewEntity_helper                            ; $6504: $CD $24 $65
 
@@ -5743,11 +5743,11 @@ func_003_6A70::
     call SpawnNewEntity                           ; $6A77: $CD $CA $64
     jr   c, jr_003_6A93                           ; $6A7A: $38 $17
 
-    ldh  a, [hMultiPurpose0]                           ; $6A7C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A7C: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6A7E: $21 $00 $C2
     add  hl, de                                   ; $6A81: $19
     ld   [hl], a                                  ; $6A82: $77
-    ldh  a, [hMultiPurpose1]                           ; $6A83: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6A83: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6A85: $21 $10 $C2
     add  hl, de                                   ; $6A88: $19
     ld   [hl], a                                  ; $6A89: $77
@@ -6072,9 +6072,9 @@ CheckLinkCollisionWithProjectile::
 
     ldh  a, [hActiveEntityPosY]                   ; $6C34: $F0 $EF
 .func_003_6C36
-    ldh  [hMultiPurpose1], a                           ; $6C36: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6C36: $E0 $D8
     ldh  a, [hActiveEntityPosX]                   ; $6C38: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6C3A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6C3A: $E0 $D7
     ld   a, TRANSCIENT_VFX_SWORD_POKE             ; $6C3C: $3E $05
     jp   AddTranscientVfx                         ; $6C3E: $C3 $C7 $0C
 
@@ -6777,13 +6777,13 @@ jr_003_6FB9:
 
 func_003_6FCC::
     call GetVectorTowardsLink                     ; $6FCC: $CD $45 $7E
-    ldh  a, [hMultiPurpose0]                           ; $6FCF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6FCF: $F0 $D7
     cpl                                           ; $6FD1: $2F
     inc  a                                        ; $6FD2: $3C
     ld   hl, wEntitiesUnknowTableS                ; $6FD3: $21 $00 $C4
     add  hl, bc                                   ; $6FD6: $09
     ld   [hl], a                                  ; $6FD7: $77
-    ldh  a, [hMultiPurpose1]                           ; $6FD8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6FD8: $F0 $D8
     cpl                                           ; $6FDA: $2F
     inc  a                                        ; $6FDB: $3C
     ld   hl, wC3F0                                ; $6FDC: $21 $F0 $C3
@@ -6865,13 +6865,13 @@ FinalNightmareForm6Collisions::
 
     ld   a, $30                                   ; $7048: $3E $30
     call GetVectorTowardsLink                     ; $704A: $CD $45 $7E
-    ldh  a, [hMultiPurpose0]                           ; $704D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $704D: $F0 $D7
     cpl                                           ; $704F: $2F
     inc  a                                        ; $7050: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $7051: $21 $50 $C2
     add  hl, bc                                   ; $7054: $09
     ld   [hl], a                                  ; $7055: $77
-    ldh  a, [hMultiPurpose1]                           ; $7056: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7056: $F0 $D8
     cpl                                           ; $7058: $2F
     inc  a                                        ; $7059: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $705A: $21 $40 $C2
@@ -7028,9 +7028,9 @@ label_003_7102:
 
 label_003_713B:
     ldh  a, [hActiveEntityPosX]                   ; $713B: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $713D: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $713D: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $713F: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7141: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7141: $E0 $D8
     jp   label_D15                                ; $7143: $C3 $15 $0D
 
 jr_003_7146:
@@ -7271,14 +7271,14 @@ jr_003_729D:
     ld   hl, wEntitiesPosXTable                   ; $729D: $21 $00 $C2
     add  hl, bc                                   ; $72A0: $09
     ld   a, [hl]                                  ; $72A1: $7E
-    ldh  [hMultiPurpose0], a                           ; $72A2: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $72A2: $E0 $D7
     ld   hl, wEntitiesPosYTable                   ; $72A4: $21 $10 $C2
     add  hl, bc                                   ; $72A7: $09
     ld   a, [hl]                                  ; $72A8: $7E
     ld   hl, wEntitiesPosZTable                   ; $72A9: $21 $10 $C3
     add  hl, bc                                   ; $72AC: $09
     sub  [hl]                                     ; $72AD: $96
-    ldh  [hMultiPurpose1], a                           ; $72AE: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $72AE: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $72B0: $3E $02
     jp   AddTranscientVfx                         ; $72B2: $C3 $C7 $0C
 
@@ -7588,13 +7588,13 @@ jr_003_7440:
     call func_003_7565                            ; $7457: $CD $65 $75
     ld   a, $18                                   ; $745A: $3E $18
     call GetVectorTowardsLink                     ; $745C: $CD $45 $7E
-    ldh  a, [hMultiPurpose0]                           ; $745F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $745F: $F0 $D7
     cpl                                           ; $7461: $2F
     inc  a                                        ; $7462: $3C
     ld   hl, wEntitiesUnknowTableS                ; $7463: $21 $00 $C4
     add  hl, bc                                   ; $7466: $09
     ld   [hl], a                                  ; $7467: $77
-    ldh  a, [hMultiPurpose1]                           ; $7468: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7468: $F0 $D8
     cpl                                           ; $746A: $2F
     inc  a                                        ; $746B: $3C
     ld   hl, wC3F0                                ; $746C: $21 $F0 $C3
@@ -7659,12 +7659,12 @@ jr_003_74C1:
     add  hl, de                                   ; $74C8: $19
     ld   a, [wC140]                               ; $74C9: $FA $40 $C1
     add  [hl]                                     ; $74CC: $86
-    ldh  [hMultiPurpose0], a                           ; $74CD: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $74CD: $E0 $D7
     ld   hl, Data_003_74E8                        ; $74CF: $21 $E8 $74
     add  hl, de                                   ; $74D2: $19
     ld   a, [wC142]                               ; $74D3: $FA $42 $C1
     add  [hl]                                     ; $74D6: $86
-    ldh  [hMultiPurpose1], a                           ; $74D7: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $74D7: $E0 $D8
     call label_D15                                ; $74D9: $CD $15 $0D
 
 jr_003_74DC:
@@ -7695,10 +7695,10 @@ label_003_74EC:
 
     ldh  a, [hLinkPositionX]                      ; $74F2: $F0 $98
     add  $08                                      ; $74F4: $C6 $08
-    ldh  [hMultiPurpose0], a                           ; $74F6: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $74F6: $E0 $D7
     ldh  a, [hLinkPositionY]                      ; $74F8: $F0 $99
     add  $08                                      ; $74FA: $C6 $08
-    ldh  [hMultiPurpose2], a                           ; $74FC: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $74FC: $E0 $D9
     ld   de, hActiveEntityPosX                    ; $74FE: $11 $EE $FF
     ld   hl, wD5C0                                ; $7501: $21 $C0 $D5
     ld   a, [de]                                  ; $7504: $1A
@@ -7777,9 +7777,9 @@ jr_003_752D:
 
 func_003_7565::
     call GetVectorTowardsLink                     ; $7565: $CD $45 $7E
-    ldh  a, [hMultiPurpose0]                           ; $7568: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7568: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $756A: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $756C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $756C: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $756E: $E0 $9A
 
 jr_003_7570:
@@ -8053,11 +8053,11 @@ jr_003_76AC:
     call SpawnNewEntity                           ; $76EA: $CD $CA $64
     jr   c, jr_003_770D                           ; $76ED: $38 $1E
 
-    ldh  a, [hMultiPurpose0]                           ; $76EF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $76EF: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $76F1: $21 $00 $C2
     add  hl, de                                   ; $76F4: $19
     ld   [hl], a                                  ; $76F5: $77
-    ldh  a, [hMultiPurpose1]                           ; $76F6: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $76F6: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $76F8: $21 $10 $C2
     add  hl, de                                   ; $76FB: $19
     ld   [hl], a                                  ; $76FC: $77
@@ -8066,7 +8066,7 @@ jr_003_76AC:
     ld   a, c                                     ; $7701: $79
     inc  a                                        ; $7702: $3C
     ld   [hl], a                                  ; $7703: $77
-    ldh  a, [hMultiPurpose2]                           ; $7704: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7704: $F0 $D9
     and  $01                                      ; $7706: $E6 $01
     ld   hl, wEntitiesSpriteVariantTable          ; $7708: $21 $B0 $C3
     add  hl, de                                   ; $770B: $19
@@ -8282,11 +8282,11 @@ jr_003_77DD:
     call func_003_783B                            ; $7823: $CD $3B $78
     ld   hl, wEntitiesUnknowTableS                ; $7826: $21 $00 $C4
     add  hl, de                                   ; $7829: $19
-    ldh  a, [hMultiPurpose0]                           ; $782A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $782A: $F0 $D7
     ld   [hl], a                                  ; $782C: $77
     ld   hl, wC3F0                                ; $782D: $21 $F0 $C3
     add  hl, de                                   ; $7830: $19
-    ldh  a, [hMultiPurpose1]                           ; $7831: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7831: $F0 $D8
     ld   [hl], a                                  ; $7833: $77
 
 jr_003_7834:
@@ -8298,7 +8298,7 @@ jr_003_7834:
     ret                                           ; $783A: $C9
 
 func_003_783B::
-    ldh  [hMultiPurpose0], a                           ; $783B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $783B: $E0 $D7
     ldh  a, [hLinkPositionX]                      ; $783D: $F0 $98
     push af                                       ; $783F: $F5
     ld   hl, wEntitiesPosXTable                   ; $7840: $21 $00 $C2
@@ -8312,7 +8312,7 @@ func_003_783B::
     ld   a, [hl]                                  ; $784E: $7E
     ldh  [hLinkPositionY], a                      ; $784F: $E0 $99
     push de                                       ; $7851: $D5
-    ldh  a, [hMultiPurpose0]                           ; $7852: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7852: $F0 $D7
     call GetVectorTowardsLink                     ; $7854: $CD $45 $7E
     pop  de                                       ; $7857: $D1
     pop  af                                       ; $7858: $F1
@@ -8342,11 +8342,11 @@ func_003_7893::
     ld   hl, wEntitiesUnknowTableI                ; $7893: $21 $70 $C4
     add  hl, bc                                   ; $7896: $09
     ld   a, [hl]                                  ; $7897: $7E
-    ldh  [hMultiPurpose0], a                           ; $7898: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7898: $E0 $D7
 
     xor  a                                        ; $789A: $AF
     ld   [hl], a                                  ; $789B: $77
-    ldh  [hMultiPurpose1], a                           ; $789C: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $789C: $E0 $D8
     ld   [wC503], a                               ; $789E: $EA $03 $C5
     ld   [wC50D], a                               ; $78A1: $EA $0D $C5
 
@@ -8400,7 +8400,7 @@ jr_003_78E3:
     cp   $67                                      ; $78E7: $FE $67
     jr   z, jr_003_7907                           ; $78E9: $28 $1C
 
-    ldh  a, [hMultiPurpose3]                           ; $78EB: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $78EB: $F0 $DA
     and  a                                        ; $78ED: $A7
     jp   z, jr_003_7A18                           ; $78EE: $CA $18 $7A
 
@@ -8436,7 +8436,7 @@ jr_003_790C:
 
     ld   hl, wEntitiesUnknowTableI                ; $7915: $21 $70 $C4
     add  hl, bc                                   ; $7918: $09
-    ldh  a, [hMultiPurpose0]                           ; $7919: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7919: $F0 $D7
     cp   [hl]                                     ; $791B: $BE
     jr   z, jr_003_7973                           ; $791C: $28 $55
 
@@ -8444,7 +8444,7 @@ jr_003_790C:
     cp   $03                                      ; $791F: $FE $03
     jr   z, jr_003_7973                           ; $7921: $28 $50
 
-    ldh  a, [hMultiPurpose0]                           ; $7923: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7923: $F0 $D7
     cp   $03                                      ; $7925: $FE $03
     jr   z, jr_003_7973                           ; $7927: $28 $4A
 
@@ -8490,18 +8490,18 @@ label_003_795C:
     ld   hl, wEntitiesPosXTable                   ; $795C: $21 $00 $C2
     add  hl, bc                                   ; $795F: $09
     ld   a, [hl]                                  ; $7960: $7E
-    ldh  [hMultiPurpose0], a                           ; $7961: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7961: $E0 $D7
     ld   hl, wEntitiesPosYTable                   ; $7963: $21 $10 $C2
     add  hl, bc                                   ; $7966: $09
     ld   a, [hl]                                  ; $7967: $7E
-    ldh  [hMultiPurpose1], a                           ; $7968: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7968: $E0 $D8
     ld   a, JINGLE_WATER_DIVE                     ; $796A: $3E $0E
     ldh  [hJingle], a                             ; $796C: $E0 $F2
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $796E: $3E $01
     call AddTranscientVfx                         ; $7970: $CD $C7 $0C
 
 jr_003_7973:
-    ldh  a, [hMultiPurpose3]                           ; $7973: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7973: $F0 $DA
     inc  a                                        ; $7975: $3C
     cp   $F1                                      ; $7976: $FE $F1
     jr   c, jr_003_799C                           ; $7978: $38 $22
@@ -8536,7 +8536,7 @@ jr_003_799C:
     cp   $61                                      ; $799E: $FE $61
     jr   z, jr_003_79AC                           ; $79A0: $28 $0A
 
-    ldh  a, [hMultiPurpose3]                           ; $79A2: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $79A2: $F0 $DA
     cp   $50                                      ; $79A4: $FE $50
     jr   z, jr_003_79AC                           ; $79A6: $28 $04
 
@@ -8627,7 +8627,7 @@ jr_003_7A18:
     and  $03                                      ; $7A28: $E6 $03
     sla  a                                        ; $7A2A: $CB $27
     sla  a                                        ; $7A2C: $CB $27
-    ldh  [hMultiPurpose0], a                           ; $7A2E: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7A2E: $E0 $D7
     ld   hl, wEntitiesCollisionsTable             ; $7A30: $21 $A0 $C2
     add  hl, bc                                   ; $7A33: $09
     xor  a                                        ; $7A34: $AF
@@ -8719,17 +8719,17 @@ ApplyEntityPhysics::
     ld   a, [hl]                                  ; $7AD2: $7E
     sub  $08                                      ; $7AD3: $D6 $08
     push af                                       ; $7AD5: $F5
-    ldh  a, [hMultiPurpose0]                           ; $7AD6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7AD6: $F0 $D7
     ld   c, a                                     ; $7AD8: $4F
     pop  af                                       ; $7AD9: $F1
     ld   hl, Data_003_785F                        ; $7ADA: $21 $5F $78
     add  hl, bc                                   ; $7ADD: $09
     add  hl, de                                   ; $7ADE: $19
     add  [hl]                                     ; $7ADF: $86
-    ldh  [hMultiPurpose4], a                           ; $7AE0: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $7AE0: $E0 $DB
     swap a                                        ; $7AE2: $CB $37
     and  $0F                                      ; $7AE4: $E6 $0F
-    ldh  [hMultiPurpose1], a                           ; $7AE6: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7AE6: $E0 $D8
     pop  bc                                       ; $7AE8: $C1
     push bc                                       ; $7AE9: $C5
     ld   a, e                                     ; $7AEA: $7B
@@ -8768,14 +8768,14 @@ jr_003_7B0E:
 jr_003_7B13:
     sub  $10                                      ; $7B13: $D6 $10
     push af                                       ; $7B15: $F5
-    ldh  a, [hMultiPurpose0]                           ; $7B16: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7B16: $F0 $D7
     ld   c, a                                     ; $7B18: $4F
     pop  af                                       ; $7B19: $F1
     ld   hl, Data_003_786F                        ; $7B1A: $21 $6F $78
     add  hl, bc                                   ; $7B1D: $09
     add  hl, de                                   ; $7B1E: $19
     add  [hl]                                     ; $7B1F: $86
-    ldh  [hMultiPurpose5], a                           ; $7B20: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $7B20: $E0 $DC
     and  $F0                                      ; $7B22: $E6 $F0
     ld   hl, hMultiPurpose1                            ; $7B24: $21 $D8 $FF
     or   [hl]                                     ; $7B27: $B6
@@ -8804,7 +8804,7 @@ jr_003_7B13:
     ld   d, a                                     ; $7B3D: $57
     call GetObjectPhysicsFlagsAndRestoreBank3     ; $7B3E: $CD $2C $2A
     pop  de                                       ; $7B41: $D1
-    ldh  [hMultiPurpose3], a                           ; $7B42: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7B42: $E0 $DA
 
     ldh  a, [hActiveEntityType]                   ; $7B44: $F0 $EB
     cp   ENTITY_FISH                              ; $7B46: $FE $CC
@@ -8814,7 +8814,7 @@ jr_003_7B13:
     jr   nz, jr_003_7B5D                          ; $7B4C: $20 $0F
 
 jr_003_7B4E:
-    ldh  a, [hMultiPurpose3]                           ; $7B4E: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7B4E: $F0 $DA
     cp   $05                                      ; $7B50: $FE $05
     jp   z, setCarryFlagAndReturn                 ; $7B52: $CA $A7 $7C
 
@@ -8824,7 +8824,7 @@ jr_003_7B4E:
     jp   jr_003_7C75                              ; $7B5A: $C3 $75 $7C
 
 jr_003_7B5D:
-    ldh  a, [hMultiPurpose3]                           ; $7B5D: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7B5D: $F0 $DA
     and  a                                        ; $7B5F: $A7
     jp   z, setCarryFlagAndReturn                 ; $7B60: $CA $A7 $7C
 
@@ -8890,7 +8890,7 @@ jr_003_7BA7:
 
 jr_003_7BBB:
     push de                                       ; $7BBB: $D5
-    ldh  a, [hMultiPurpose3]                           ; $7BBC: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7BBC: $F0 $DA
     sub  $7C                                      ; $7BBE: $D6 $7C
     sla  a                                        ; $7BC0: $CB $27
     sla  a                                        ; $7BC2: $CB $27
@@ -8898,13 +8898,13 @@ jr_003_7BBB:
     ld   d, $00                                   ; $7BC5: $16 $00
     ld   hl, Data_003_7A85                        ; $7BC7: $21 $85 $7A
     add  hl, de                                   ; $7BCA: $19
-    ldh  a, [hMultiPurpose4]                           ; $7BCB: $F0 $DB
+    ldh  a, [hMultiPurpose4]                      ; $7BCB: $F0 $DB
     rra                                           ; $7BCD: $1F
     rra                                           ; $7BCE: $1F
     rra                                           ; $7BCF: $1F
     and  $01                                      ; $7BD0: $E6 $01
     ld   e, a                                     ; $7BD2: $5F
-    ldh  a, [hMultiPurpose5]                           ; $7BD3: $F0 $DC
+    ldh  a, [hMultiPurpose5]                      ; $7BD3: $F0 $DC
     rra                                           ; $7BD5: $1F
     rra                                           ; $7BD6: $1F
     and  $02                                      ; $7BD7: $E6 $02
@@ -8918,7 +8918,7 @@ jr_003_7BBB:
     jp   z, setCarryFlagAndReturn                 ; $7BE1: $CA $A7 $7C
 
 label_003_7BE4:
-    ldh  a, [hMultiPurpose3]                           ; $7BE4: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7BE4: $F0 $DA
     cp   $D0                                      ; $7BE6: $FE $D0
     jr   c, jr_003_7C2B                           ; $7BE8: $38 $41
 
@@ -9024,7 +9024,7 @@ jr_003_7C5A:
     jr   z, setCarryFlagAndReturn                 ; $7C73: $28 $32
 
 jr_003_7C75:
-    ldh  a, [hMultiPurpose3]                           ; $7C75: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7C75: $F0 $DA
     cp   $60                                      ; $7C77: $FE $60
     jr   nz, hookshotEnd                          ; $7C79: $20 $16
 
@@ -9082,7 +9082,7 @@ ApplySwordIntersectionWithObjects::
     ld   hl, wEntitiesPosXTable                   ; $7CAF: $21 $00 $C2
     add  hl, bc                                   ; $7CB2: $09
     ld   a, [hl]                                  ; $7CB3: $7E
-    ldh  [hMultiPurpose4], a                           ; $7CB4: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $7CB4: $E0 $DB
     and  $F0                                      ; $7CB6: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $7CB8: $E0 $CE
     swap a                                        ; $7CBA: $CB $37
@@ -9091,7 +9091,7 @@ ApplySwordIntersectionWithObjects::
     ld   c, a                                     ; $7CC0: $4F
     ld   a, [hl]                                  ; $7CC1: $7E
     sub  $08                                      ; $7CC2: $D6 $08
-    ldh  [hMultiPurpose5], a                           ; $7CC4: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $7CC4: $E0 $DC
     and  $F0                                      ; $7CC6: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $7CC8: $E0 $CD
     or   c                                        ; $7CCA: $B1
@@ -9204,11 +9204,11 @@ jr_003_7D6B:
     ld   a, [wIsIndoor]                           ; $7D6D: $FA $A5 $DB
     ld   d, a                                     ; $7D70: $57
     call GetObjectPhysicsFlagsAndRestoreBank3     ; $7D71: $CD $2C $2A
-    ldh  [hMultiPurpose1], a                           ; $7D74: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7D74: $E0 $D8
     and  a                                        ; $7D76: $A7
     jp   z, jr_003_7E03                           ; $7D77: $CA $03 $7E
 
-    ldh  [hMultiPurpose3], a                           ; $7D7A: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7D7A: $E0 $DA
     cp   $FF                                      ; $7D7C: $FE $FF
     jp   z, label_003_7E05                        ; $7D7E: $CA $05 $7E
 
@@ -9272,7 +9272,7 @@ ELSE
 ENDC
 
 label_003_7DCD:
-    ldh  a, [hMultiPurpose3]                           ; $7DCD: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7DCD: $F0 $DA
     cp   $A0                                      ; $7DCF: $FE $A0
     jr   nc, jr_003_7E03                          ; $7DD1: $30 $30
 
@@ -9330,7 +9330,7 @@ func_003_7E0E::
     add  hl, bc                                   ; $7E12: $09
     ld   a, [hl]                                  ; $7E13: $7E
     sub  $01                                      ; $7E14: $D6 $01
-    ldh  [hMultiPurpose4], a                           ; $7E16: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $7E16: $E0 $DB
     and  $F0                                      ; $7E18: $E6 $F0
     ldh  [hSwordIntersectedAreaX], a              ; $7E1A: $E0 $CE
     swap a                                        ; $7E1C: $CB $37
@@ -9339,7 +9339,7 @@ func_003_7E0E::
     ld   c, a                                     ; $7E22: $4F
     ld   a, [hl]                                  ; $7E23: $7E
     sub  $07                                      ; $7E24: $D6 $07
-    ldh  [hMultiPurpose5], a                           ; $7E26: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $7E26: $E0 $DC
     and  $F0                                      ; $7E28: $E6 $F0
     ldh  [hSwordIntersectedAreaY], a              ; $7E2A: $E0 $CD
     or   c                                        ; $7E2C: $B1
@@ -9356,7 +9356,7 @@ func_003_7E0E::
     ld   a, [wIsIndoor]                           ; $7E3B: $FA $A5 $DB
     ld   d, a                                     ; $7E3E: $57
     call GetObjectPhysicsFlagsAndRestoreBank3     ; $7E3F: $CD $2C $2A
-    ldh  [hMultiPurpose3], a                           ; $7E42: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7E42: $E0 $DA
     ret                                           ; $7E44: $C9
 
 ; Compute an (X, Y) vector of length A pointing from an entity position
@@ -9371,7 +9371,7 @@ func_003_7E0E::
 ;   hMultiPurpose0   resulting vector Y
 ;   hMultiPurpose1   resulting vector X
 GetVectorTowardsLink::
-    ldh  [hMultiPurpose1], a                           ; $7E45: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7E45: $E0 $D8
     and  a                                        ; $7E47: $A7
     jp   z, .cancelAndReturn                      ; $7E48: $CA $C3 $7E
 
@@ -9380,7 +9380,7 @@ GetVectorTowardsLink::
     dec  e                                        ; $7E4F: $1D
     ld   a, e                                     ; $7E50: $7B
     ; hMultiPurpose2 = dy < 0 ? 0 : 1
-    ldh  [hMultiPurpose2], a                           ; $7E51: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $7E51: $E0 $D9
     ld   a, d                                     ; $7E53: $7A
     bit  7, a                                     ; $7E54: $CB $7F
     jr   z, .absoluteY                            ; $7E56: $28 $02
@@ -9393,7 +9393,7 @@ GetVectorTowardsLink::
     call GetEntityXDistanceAwayFromLink           ; $7E5C: $CD $D9 $7E
     ld   a, e                                     ; $7E5F: $7B
     ; hMultiPurpose3 = dx < 0 ? 1 : 0
-    ldh  [hMultiPurpose3], a                           ; $7E60: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7E60: $E0 $DA
     ld   a, d                                     ; $7E62: $7A
     bit  7, a                                     ; $7E63: $CB $7F
     jr   z, .absoluteX                            ; $7E65: $28 $02
@@ -9423,9 +9423,9 @@ GetVectorTowardsLink::
 
     xor  a                                        ; $7E7E: $AF
     ldh  [hMultiPurposeB], a                           ; $7E7F: $E0 $E2
-    ldh  [hMultiPurpose0], a                           ; $7E81: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7E81: $E0 $D7
 
-    ldh  a, [hMultiPurpose1]                           ; $7E83: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7E83: $F0 $D8
     ld   d, a                                     ; $7E85: $57
 
 .divideLoop
@@ -9454,50 +9454,50 @@ GetVectorTowardsLink::
     jr   z, .noSwap2                              ; $7EA0: $28 $0A
 
     ; ...swap them back
-    ldh  a, [hMultiPurpose0]                           ; $7EA2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7EA2: $F0 $D7
     push af                                       ; $7EA4: $F5
-    ldh  a, [hMultiPurpose1]                           ; $7EA5: $F0 $D8
-    ldh  [hMultiPurpose0], a                           ; $7EA7: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $7EA5: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $7EA7: $E0 $D7
     pop  af                                       ; $7EA9: $F1
-    ldh  [hMultiPurpose1], a                           ; $7EAA: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7EAA: $E0 $D8
 
 .noSwap2
-    ldh  a, [hMultiPurpose2]                           ; $7EAC: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7EAC: $F0 $D9
     ; If the distance was negative...
     and  a                                        ; $7EAE: $A7
-    ldh  a, [hMultiPurpose0]                           ; $7EAF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7EAF: $F0 $D7
     jr   nz, .positiveResultY                     ; $7EB1: $20 $04
 
     ; ...make the result negative
     cpl                                           ; $7EB3: $2F
     inc  a                                        ; $7EB4: $3C
-    ldh  [hMultiPurpose0], a                           ; $7EB5: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7EB5: $E0 $D7
 
 .positiveResultY
-    ldh  a, [hMultiPurpose3]                           ; $7EB7: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7EB7: $F0 $DA
     and  a                                        ; $7EB9: $A7
-    ldh  a, [hMultiPurpose1]                           ; $7EBA: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7EBA: $F0 $D8
     jr   z, .positiveResultX                      ; $7EBC: $28 $04
 
     cpl                                           ; $7EBE: $2F
     inc  a                                        ; $7EBF: $3C
-    ldh  [hMultiPurpose1], a                           ; $7EC0: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7EC0: $E0 $D8
 .positiveResultX
     ret                                           ; $7EC2: $C9
 
 .cancelAndReturn
     xor  a                                        ; $7EC3: $AF
-    ldh  [hMultiPurpose0], a                           ; $7EC4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7EC4: $E0 $D7
     ret                                           ; $7EC6: $C9
 
 ApplyVectorTowardsLink::
 ApplyVectorTowardsLinkAndReturn::
     call GetVectorTowardsLink                     ; $7EC7: $CD $45 $7E
-    ldh  a, [hMultiPurpose0]                           ; $7ECA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7ECA: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $7ECC: $21 $50 $C2
     add  hl, bc                                   ; $7ECF: $09
     ld   [hl], a                                  ; $7ED0: $77
-    ldh  a, [hMultiPurpose1]                           ; $7ED1: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7ED1: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $7ED3: $21 $40 $C2
     add  hl, bc                                   ; $7ED6: $09
     ld   [hl], a                                  ; $7ED7: $77
@@ -9539,7 +9539,7 @@ GetEntityYDistanceAwayFromLink::
 func_003_7EFE::
     call GetEntityXDistanceAwayFromLink           ; $7EFE: $CD $D9 $7E
     ld   a, e                                     ; $7F01: $7B
-    ldh  [hMultiPurpose0], a                           ; $7F02: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7F02: $E0 $D7
     ld   a, d                                     ; $7F04: $7A
     bit  7, a                                     ; $7F05: $CB $7F
     jr   z, jr_003_7F0B                           ; $7F07: $28 $02
@@ -9551,7 +9551,7 @@ jr_003_7F0B:
     push af                                       ; $7F0B: $F5
     call GetEntityYDistanceAwayFromLink           ; $7F0C: $CD $E9 $7E
     ld   a, e                                     ; $7F0F: $7B
-    ldh  [hMultiPurpose1], a                           ; $7F10: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7F10: $E0 $D8
     ld   a, d                                     ; $7F12: $7A
     bit  7, a                                     ; $7F13: $CB $7F
     jr   z, jr_003_7F19                           ; $7F15: $28 $02
@@ -9564,11 +9564,11 @@ jr_003_7F19:
     cp   d                                        ; $7F1A: $BA
     jr   nc, jr_003_7F21                          ; $7F1B: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $7F1D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7F1D: $F0 $D7
     jr   jr_003_7F23                              ; $7F1F: $18 $02
 
 jr_003_7F21:
-    ldh  a, [hMultiPurpose1]                           ; $7F21: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7F21: $F0 $D8
 
 jr_003_7F23:
     ld   e, a                                     ; $7F23: $5F

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -1743,7 +1743,7 @@ jr_036_4A6A:
     ld   l, a                                     ; $4A70: $6F
     add  hl, bc                                   ; $4A71: $09
     ld   a, [hl]                                  ; $4A72: $7E
-    ldh  [hMultiPurpose0], a                           ; $4A73: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4A73: $E0 $D7
     pop  bc                                       ; $4A75: $C1
     ret                                           ; $4A76: $C9
 
@@ -2106,10 +2106,10 @@ func_036_4C82::
     ret  nc                                       ; $4CA5: $D0
 
     ldh  a, [hActiveEntityPosX]                   ; $4CA6: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4CA8: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4CA8: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4CAA: $F0 $EC
     add  $0C                                      ; $4CAC: $C6 $0C
-    ldh  [hMultiPurpose1], a                           ; $4CAE: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4CAE: $E0 $D8
     call label_D15                                ; $4CB0: $CD $15 $0D
     ret                                           ; $4CB3: $C9
 
@@ -2225,9 +2225,9 @@ jr_036_4D5C:
     ld   [wC13E], a                               ; $4D5E: $EA $3E $C1
     ld   a, $14                                   ; $4D61: $3E $14
     call GetVectorTowardsLink_trampoline          ; $4D63: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4D66: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D66: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $4D68: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $4D6A: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4D6A: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $4D6C: $E0 $9A
 
 jr_036_4D6E:
@@ -2415,7 +2415,7 @@ jr_036_4E5C:
 
 func_036_4E7F::
     xor  a                                        ; $4E7F: $AF
-    ldh  [hMultiPurpose0], a                           ; $4E80: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4E80: $E0 $D7
     ld   e, a                                     ; $4E82: $5F
     ld   d, a                                     ; $4E83: $57
 
@@ -2441,7 +2441,7 @@ jr_036_4E99:
     and  $0F                                      ; $4E9B: $E6 $0F
     jr   nz, jr_036_4E84                          ; $4E9D: $20 $E5
 
-    ldh  a, [hMultiPurpose0]                           ; $4E9F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4E9F: $F0 $D7
     ret                                           ; $4EA1: $C9
 
 func_036_4EA2::
@@ -2920,7 +2920,7 @@ func_036_51DF::
     ret                                           ; $51F5: $C9
 
 func_036_51F6::
-    ldh  a, [hMultiPurpose0]                           ; $51F6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $51F6: $F0 $D7
     inc  a                                        ; $51F8: $3C
     bit  5, a                                     ; $51F9: $CB $6F
     jr   z, jr_036_51FF                           ; $51FB: $28 $02
@@ -2928,8 +2928,8 @@ func_036_51F6::
     ld   a, $1F                                   ; $51FD: $3E $1F
 
 jr_036_51FF:
-    ldh  [hMultiPurpose0], a                           ; $51FF: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $5201: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $51FF: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $5201: $F0 $D8
     sub  $02                                      ; $5203: $D6 $02
     and  a                                        ; $5205: $A7
     jr   nz, jr_036_520A                          ; $5206: $20 $02
@@ -2937,8 +2937,8 @@ jr_036_51FF:
     ld   a, $02                                   ; $5208: $3E $02
 
 jr_036_520A:
-    ldh  [hMultiPurpose1], a                           ; $520A: $E0 $D8
-    ldh  a, [hMultiPurpose2]                           ; $520C: $F0 $D9
+    ldh  [hMultiPurpose1], a                      ; $520A: $E0 $D8
+    ldh  a, [hMultiPurpose2]                      ; $520C: $F0 $D9
     sub  $04                                      ; $520E: $D6 $04
     cp   $14                                      ; $5210: $FE $14
     jr   nc, jr_036_5216                          ; $5212: $30 $02
@@ -2946,11 +2946,11 @@ jr_036_520A:
     ld   a, $14                                   ; $5214: $3E $14
 
 jr_036_5216:
-    ldh  [hMultiPurpose2], a                           ; $5216: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5216: $E0 $D9
     ret                                           ; $5218: $C9
 
 func_036_5219::
-    ldh  a, [hMultiPurpose0]                           ; $5219: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5219: $F0 $D7
     dec  a                                        ; $521B: $3D
     cp   $03                                      ; $521C: $FE $03
     jr   nc, jr_036_5222                          ; $521E: $30 $02
@@ -2958,8 +2958,8 @@ func_036_5219::
     ld   a, $03                                   ; $5220: $3E $03
 
 jr_036_5222:
-    ldh  [hMultiPurpose0], a                           ; $5222: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $5224: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $5222: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $5224: $F0 $D8
     bit  5, a                                     ; $5226: $CB $6F
     jr   nz, jr_036_5234                          ; $5228: $20 $0A
 
@@ -2978,8 +2978,8 @@ jr_036_5234:
     ld   a, $20                                   ; $523A: $3E $20
 
 jr_036_523C:
-    ldh  [hMultiPurpose1], a                           ; $523C: $E0 $D8
-    ldh  a, [hMultiPurpose2]                           ; $523E: $F0 $D9
+    ldh  [hMultiPurpose1], a                      ; $523C: $E0 $D8
+    ldh  a, [hMultiPurpose2]                      ; $523E: $F0 $D9
     add  $04                                      ; $5240: $C6 $04
     bit  7, a                                     ; $5242: $CB $7F
     jr   z, jr_036_5248                           ; $5244: $28 $02
@@ -2987,7 +2987,7 @@ jr_036_523C:
     ld   a, $7C                                   ; $5246: $3E $7C
 
 jr_036_5248:
-    ldh  [hMultiPurpose2], a                           ; $5248: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5248: $E0 $D9
     ret                                           ; $524A: $C9
 
 TunicFairyState6::
@@ -3017,7 +3017,7 @@ jr_036_526E:
     push hl                                       ; $526E: $E5
     ld   a, [hl]                                  ; $526F: $7E
     and  $1F                                      ; $5270: $E6 $1F
-    ldh  [hMultiPurpose0], a                           ; $5272: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5272: $E0 $D7
     ld   a, [hl+]                                 ; $5274: $2A
     and  $E0                                      ; $5275: $E6 $E0
     swap a                                        ; $5277: $CB $37
@@ -3026,10 +3026,10 @@ jr_036_526E:
     and  $03                                      ; $527B: $E6 $03
     swap a                                        ; $527D: $CB $37
     or   e                                        ; $527F: $B3
-    ldh  [hMultiPurpose1], a                           ; $5280: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5280: $E0 $D8
     ld   a, [hl]                                  ; $5282: $7E
     and  $7C                                      ; $5283: $E6 $7C
-    ldh  [hMultiPurpose2], a                           ; $5285: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $5285: $E0 $D9
     ld   hl, wEntitiesPrivateState2Table          ; $5287: $21 $C0 $C2
     add  hl, bc                                   ; $528A: $09
     ld   a, [hl]                                  ; $528B: $7E
@@ -3044,18 +3044,18 @@ jr_036_5294:
 
 jr_036_5297:
     pop  hl                                       ; $5297: $E1
-    ldh  a, [hMultiPurpose0]                           ; $5298: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5298: $F0 $D7
     ld   e, a                                     ; $529A: $5F
-    ldh  a, [hMultiPurpose1]                           ; $529B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $529B: $F0 $D8
     and  $0E                                      ; $529D: $E6 $0E
     swap a                                        ; $529F: $CB $37
     or   e                                        ; $52A1: $B3
     ld   [hl+], a                                 ; $52A2: $22
-    ldh  a, [hMultiPurpose1]                           ; $52A3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $52A3: $F0 $D8
     and  $30                                      ; $52A5: $E6 $30
     swap a                                        ; $52A7: $CB $37
     ld   e, a                                     ; $52A9: $5F
-    ldh  a, [hMultiPurpose2]                           ; $52AA: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $52AA: $F0 $D9
     or   e                                        ; $52AC: $B3
     ld   [hl], a                                  ; $52AD: $77
     ld   a, $02                                   ; $52AE: $3E $02
@@ -3609,9 +3609,9 @@ jr_036_5661:
     ld   [wC13E], a                               ; $5663: $EA $3E $C1
     ld   a, $20                                   ; $5666: $3E $20
     call GetVectorTowardsLink_trampoline          ; $5668: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $566B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $566B: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $566D: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $566F: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $566F: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $5671: $E0 $9A
 
 jr_036_5673:
@@ -4635,9 +4635,9 @@ func_036_5C8B::
 
 func_036_5CAB::
     ldh  a, [hActiveEntityPosX]                   ; $5CAB: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $5CAD: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5CAD: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $5CAF: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $5CB1: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5CB1: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $5CB3: $3E $02
     call AddTranscientVfx                         ; $5CB5: $CD $C7 $0C
     ld   a, $13                                   ; $5CB8: $3E $13
@@ -4668,9 +4668,9 @@ ENDC
     ld   [wC13E], a                               ; $5CC9: $EA $3E $C1
     ld   a, $20                                   ; $5CCC: $3E $20
     call GetVectorTowardsLink_trampoline          ; $5CCE: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $5CD1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5CD1: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $5CD3: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $5CD5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5CD5: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $5CD7: $E0 $9A
 
 jr_036_5CD9:
@@ -4992,7 +4992,7 @@ func_036_5EC2::
     xor  a                                        ; $5EC2: $AF
     ld   e, a                                     ; $5EC3: $5F
     ld   d, a                                     ; $5EC4: $57
-    ldh  [hMultiPurpose0], a                           ; $5EC5: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5EC5: $E0 $D7
 
 jr_036_5EC7:
     ld   hl, wEntitiesTypeTable                   ; $5EC7: $21 $A0 $C3
@@ -5016,7 +5016,7 @@ jr_036_5EDC:
     and  $0F                                      ; $5EDE: $E6 $0F
     jr   nz, jr_036_5EC7                          ; $5EE0: $20 $E5
 
-    ldh  a, [hMultiPurpose0]                           ; $5EE2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5EE2: $F0 $D7
     cp   $06                                      ; $5EE4: $FE $06
     ret  nc                                       ; $5EE6: $D0
 
@@ -5185,13 +5185,13 @@ HopperState4Handler::
     call PointHLToEntitySpeedZ                    ; $5FDB: $CD $F8 $6B
     dec  [hl]                                     ; $5FDE: $35
     ld   a, [hl]                                  ; $5FDF: $7E
-    ldh  [hMultiPurpose0], a                           ; $5FE0: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5FE0: $E0 $D7
     call func_036_6AEC                            ; $5FE2: $CD $EC $6A
     ld   a, [hl]                                  ; $5FE5: $7E
     bit  7, a                                     ; $5FE6: $CB $7F
     jr   z, jr_036_604E                           ; $5FE8: $28 $64
 
-    ldh  a, [hMultiPurpose0]                           ; $5FEA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5FEA: $F0 $D7
     bit  7, a                                     ; $5FEC: $CB $7F
     jr   z, jr_036_604E                           ; $5FEE: $28 $5E
 
@@ -5234,10 +5234,10 @@ func_036_6021::
     ld   e, [hl]                                  ; $6026: $5E
     call PointHLToEntityPosX                      ; $6027: $CD $23 $6C
     ld   a, [hl]                                  ; $602A: $7E
-    ldh  [hMultiPurpose0], a                           ; $602B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $602B: $E0 $D7
     call PointHLToEntityPosY                      ; $602D: $CD $28 $6C
     ld   a, [hl]                                  ; $6030: $7E
-    ldh  [hMultiPurpose1], a                           ; $6031: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6031: $E0 $D8
     ld   a, $36                                   ; $6033: $3E $36
     call func_020_4874_trampoline                 ; $6035: $CD $DE $09
     ld   hl, wRoomObjects                         ; $6038: $21 $11 $D7
@@ -5302,9 +5302,9 @@ func_036_6084::
     cp   $10                                      ; $6087: $FE $10
     jr   nc, jr_036_60B2                          ; $6089: $30 $27
 
-    ldh  [hMultiPurpose0], a                           ; $608B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $608B: $E0 $D7
     ld   a, e                                     ; $608D: $7B
-    ldh  [hMultiPurpose1], a                           ; $608E: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $608E: $E0 $D8
     call func_036_6B9A                            ; $6090: $CD $9A $6B
     cp   $10                                      ; $6093: $FE $10
     jr   nc, jr_036_60B2                          ; $6095: $30 $1B
@@ -5677,10 +5677,10 @@ jr_036_629E:
 func_036_629F::
     call PointHLToEntityPosX                      ; $629F: $CD $23 $6C
     ld   a, [hl]                                  ; $62A2: $7E
-    ldh  [hMultiPurpose0], a                           ; $62A3: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $62A3: $E0 $D7
     call PointHLToEntityPosY                      ; $62A5: $CD $28 $6C
     ld   a, [hl]                                  ; $62A8: $7E
-    ldh  [hMultiPurpose1], a                           ; $62A9: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $62A9: $E0 $D8
     ld   de, $00                                  ; $62AB: $11 $00 $00
 
 jr_036_62AE:
@@ -5706,7 +5706,7 @@ jr_036_62C3:
     inc  [hl]                                     ; $62C7: $34
     ld   hl, wEntitiesPosXTable                   ; $62C8: $21 $00 $C2
     add  hl, de                                   ; $62CB: $19
-    ldh  a, [hMultiPurpose0]                           ; $62CC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $62CC: $F0 $D7
     cp   [hl]                                     ; $62CE: $BE
     jr   nz, jr_036_62EA                          ; $62CF: $20 $19
 
@@ -5716,7 +5716,7 @@ jr_036_62C3:
 
     ld   hl, wEntitiesPosYTable                   ; $62D7: $21 $10 $C2
     add  hl, de                                   ; $62DA: $19
-    ldh  a, [hMultiPurpose1]                           ; $62DB: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $62DB: $F0 $D8
     sub  [hl]                                     ; $62DD: $96
     bit  7, a                                     ; $62DE: $CB $7F
     jr   z, jr_036_62E4                           ; $62E0: $28 $02
@@ -5733,7 +5733,7 @@ jr_036_62E4:
 jr_036_62EA:
     ld   hl, wEntitiesPosYTable                   ; $62EA: $21 $10 $C2
     add  hl, de                                   ; $62ED: $19
-    ldh  a, [hMultiPurpose1]                           ; $62EE: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $62EE: $F0 $D8
     cp   [hl]                                     ; $62F0: $BE
     jr   nz, jr_036_631A                          ; $62F1: $20 $27
 
@@ -5743,7 +5743,7 @@ jr_036_62EA:
 
     ld   hl, wEntitiesPosXTable                   ; $62F9: $21 $00 $C2
     add  hl, de                                   ; $62FC: $19
-    ldh  a, [hMultiPurpose0]                           ; $62FD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $62FD: $F0 $D7
     sub  [hl]                                     ; $62FF: $96
     bit  7, a                                     ; $6300: $CB $7F
     jr   z, jr_036_6306                           ; $6302: $28 $02
@@ -5959,7 +5959,7 @@ ColorGhoulState2Handler::
     ld   e, [hl]                                  ; $643E: $5E
     call func_036_6C62                            ; $643F: $CD $62 $6C
     sub  e                                        ; $6442: $93
-    ldh  [hMultiPurpose0], a                           ; $6443: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6443: $E0 $D7
     call PointHLToEntitySpeedX                    ; $6445: $CD $EE $6B
     and  a                                        ; $6448: $A7
     jr   nz, jr_036_644C                          ; $6449: $20 $01
@@ -5980,7 +5980,7 @@ jr_036_6454:
     ld   e, [hl]                                  ; $6457: $5E
     call func_036_6C70                            ; $6458: $CD $70 $6C
     sub  e                                        ; $645B: $93
-    ldh  [hMultiPurpose1], a                           ; $645C: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $645C: $E0 $D8
     call PointHLToEntitySpeedY                    ; $645E: $CD $F3 $6B
     and  a                                        ; $6461: $A7
     jr   nz, jr_036_6465                          ; $6462: $20 $01
@@ -5997,10 +5997,10 @@ jr_036_6465:
     ld   [hl], a                                  ; $646C: $77
 
 jr_036_646D:
-    ldh  a, [hMultiPurpose0]                           ; $646D: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $646D: $F0 $D7
     and  $FE                                      ; $646F: $E6 $FE
     ld   e, a                                     ; $6471: $5F
-    ldh  a, [hMultiPurpose1]                           ; $6472: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6472: $F0 $D8
     and  $FE                                      ; $6474: $E6 $FE
     push af                                       ; $6476: $F5
     push de                                       ; $6477: $D5
@@ -6378,7 +6378,7 @@ jr_036_66EC:
     ret  nz                                       ; $66F2: $C0
 
     xor  a                                        ; $66F3: $AF
-    ldh  [hMultiPurpose0], a                           ; $66F4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $66F4: $E0 $D7
     ld   e, $00                                   ; $66F6: $1E $00
     ld   d, e                                     ; $66F8: $53
 
@@ -6872,12 +6872,12 @@ ColorShellStateDHandler::
     ld   [hl], a                                  ; $69B3: $77
     call PointHLToEntityPosX                      ; $69B4: $CD $23 $6C
     ld   a, [hl]                                  ; $69B7: $7E
-    ldh  [hMultiPurpose0], a                           ; $69B8: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $69B8: $E0 $D7
     call PointHLToEntityPosY                      ; $69BA: $CD $28 $6C
     ld   a, [hl]                                  ; $69BD: $7E
     call PointHLToEntityPosZ                      ; $69BE: $CD $2D $6C
     sub  [hl]                                     ; $69C1: $96
-    ldh  [hMultiPurpose1], a                           ; $69C2: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $69C2: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $69C4: $3E $02
     call AddTranscientVfx                         ; $69C6: $CD $C7 $0C
     call DidKillEnemy.label_3F5E                  ; $69C9: $CD $5E $3F
@@ -6899,7 +6899,7 @@ func_036_69D9::
     ldh  a, [hActiveEntityType]                   ; $69D9: $F0 $EB
     sub  ENTITY_COLOR_SHELL_RED                   ; $69DB: $D6 $E9
     sla  a                                        ; $69DD: $CB $27
-    ldh  [hMultiPurpose0], a                           ; $69DF: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $69DF: $E0 $D7
     ld   d, $00                                   ; $69E1: $16 $00
     call PointHLToEntitySpriteVariant             ; $69E3: $CD $02 $6C
     ldh  a, [hActiveEntityState]                  ; $69E6: $F0 $F0
@@ -6919,7 +6919,7 @@ jr_036_69F2:
     sla  a                                        ; $69F9: $CB $27
     ld   e, a                                     ; $69FB: $5F
     push de                                       ; $69FC: $D5
-    ldh  a, [hMultiPurpose0]                           ; $69FD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $69FD: $F0 $D7
     ld   e, a                                     ; $69FF: $5F
     ld   hl, Data_036_69D3                        ; $6A00: $21 $D3 $69
     add  hl, de                                   ; $6A03: $19
@@ -6938,7 +6938,7 @@ jr_036_6A0A:
     sla  a                                        ; $6A11: $CB $27
     ld   e, a                                     ; $6A13: $5F
     push de                                       ; $6A14: $D5
-    ldh  a, [hMultiPurpose0]                           ; $6A15: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A15: $F0 $D7
     ld   e, a                                     ; $6A17: $5F
     ld   hl, Data_036_69CD                        ; $6A18: $21 $CD $69
     add  hl, de                                   ; $6A1B: $19
@@ -7257,7 +7257,7 @@ func_036_6BAB::
     ld   d, a                                     ; $6BAE: $57
     push af                                       ; $6BAF: $F5
     ld   a, e                                     ; $6BB0: $7B
-    ldh  [hMultiPurpose0], a                           ; $6BB1: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6BB1: $E0 $D7
     call func_036_6B9A                            ; $6BB3: $CD $9A $6B
     ld   d, a                                     ; $6BB6: $57
     ld   a, e                                     ; $6BB7: $7B
@@ -7268,17 +7268,17 @@ func_036_6BAB::
     ld   a, $03                                   ; $6BBE: $3E $03
 
 jr_036_6BC0:
-    ldh  [hMultiPurpose1], a                           ; $6BC0: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6BC0: $E0 $D8
     ld   a, d                                     ; $6BC2: $7A
     pop  de                                       ; $6BC3: $D1
     cp   d                                        ; $6BC4: $BA
     jr   nc, jr_036_6BCB                          ; $6BC5: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $6BC7: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6BC7: $F0 $D7
     jr   jr_036_6BCD                              ; $6BC9: $18 $02
 
 jr_036_6BCB:
-    ldh  a, [hMultiPurpose1]                           ; $6BCB: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6BCB: $F0 $D8
 
 jr_036_6BCD:
     ld   e, a                                     ; $6BCD: $5F
@@ -7715,11 +7715,11 @@ jr_036_6EA0:
     call SpawnNewEntity_trampoline                ; $6EA7: $CD $86 $3B
     jr   c, jr_036_6EC6                           ; $6EAA: $38 $1A
 
-    ldh  a, [hMultiPurpose0]                           ; $6EAC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6EAC: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6EAE: $21 $00 $C2
     add  hl, de                                   ; $6EB1: $19
     ld   [hl], a                                  ; $6EB2: $77
-    ldh  a, [hMultiPurpose1]                           ; $6EB3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6EB3: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6EB5: $21 $10 $C2
     add  hl, de                                   ; $6EB8: $19
     ld   [hl], a                                  ; $6EB9: $77

--- a/src/code/entities/bank4.asm
+++ b/src/code/entities/bank4.asm
@@ -1138,11 +1138,11 @@ jr_004_547E:
 
     ld   a, $0C                                   ; $54AF: $3E $0C
     call GetVectorTowardsLink_trampoline          ; $54B1: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $54B4: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $54B4: $F0 $D7
     cpl                                           ; $54B6: $2F
     inc  a                                        ; $54B7: $3C
     ldh  [hLinkPositionYIncrement], a             ; $54B8: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $54BA: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $54BA: $F0 $D8
     cpl                                           ; $54BC: $2F
     inc  a                                        ; $54BD: $3C
     ldh  [hLinkPositionXIncrement], a             ; $54BE: $E0 $9A
@@ -1379,7 +1379,7 @@ label_004_5623:
     ld   a, $0D                                   ; $5626: $3E $0D
 
 jr_004_5628:
-    ldh  [hMultiPurpose0], a                           ; $5628: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5628: $E0 $D7
     push de                                       ; $562A: $D5
     ldh  a, [hActiveEntityPosY]                   ; $562B: $F0 $EF
     sub  $0F                                      ; $562D: $D6 $0F
@@ -1397,7 +1397,7 @@ jr_004_5628:
     ld   d, $00                                   ; $5642: $16 $00
     ld   hl, wRoomObjects                         ; $5644: $21 $11 $D7
     add  hl, de                                   ; $5647: $19
-    ldh  a, [hMultiPurpose0]                           ; $5648: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5648: $F0 $D7
     ld   [hl], a                                  ; $564A: $77
     call label_2887                               ; $564B: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $564E: $F0 $FE
@@ -1405,7 +1405,7 @@ jr_004_5628:
     jr   z, jr_004_565F                           ; $5651: $28 $0C
 
     push bc                                       ; $5653: $C5
-    ldh  a, [hMultiPurpose0]                           ; $5654: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5654: $F0 $D7
     ld   [wDDD8], a                               ; $5656: $EA $D8 $DD
     ld   a, $04                                   ; $5659: $3E $04
     call func_91D                                ; $565B: $CD $1D $09
@@ -1577,7 +1577,7 @@ BossDestructionHandler::
 DropHeartContainer::
     ld   a, ENTITY_HEART_CONTAINER                ; $5751: $3E $36
     call SpawnNewEntity_trampoline                ; $5753: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $5756: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5756: $F0 $D7
     cp   $88                                      ; $5758: $FE $88
     jr   c, jr_004_575E                           ; $575A: $38 $02
 
@@ -1593,7 +1593,7 @@ jr_004_5764:
     ld   hl, wEntitiesPosXTable                   ; $5764: $21 $00 $C2
     add  hl, de                                   ; $5767: $19
     ld   [hl], a                                  ; $5768: $77
-    ldh  a, [hMultiPurpose1]                           ; $5769: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5769: $F0 $D8
     cp   $70                                      ; $576B: $FE $70
     jr   c, jr_004_5771                           ; $576D: $38 $02
 
@@ -1612,7 +1612,7 @@ jr_004_5777:
     ld   hl, wEntitiesSpeedZTable                 ; $577C: $21 $20 $C3
     add  hl, de                                   ; $577F: $19
     ld   [hl], $10                                ; $5780: $36 $10
-    ldh  a, [hMultiPurpose3]                           ; $5782: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $5782: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $5784: $21 $10 $C3
     add  hl, de                                   ; $5787: $19
     ld   [hl], a                                  ; $5788: $77
@@ -1755,14 +1755,14 @@ jr_004_5924:
     ld   hl, wEntitiesUnknowTableY                ; $592F: $21 $D0 $C3
     add  hl, bc                                   ; $5932: $09
     ld   a, [hl]                                  ; $5933: $7E
-    ldh  [hMultiPurpose0], a                           ; $5934: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5934: $E0 $D7
     ld   hl, wEntitiesUnknownTableD               ; $5936: $21 $D0 $C2
     add  hl, bc                                   ; $5939: $09
     ld   a, [hl]                                  ; $593A: $7E
     cp   $04                                      ; $593B: $FE $04
     jp   nc, jr_004_5A04                          ; $593D: $D2 $04 $5A
 
-    ldh  a, [hMultiPurpose0]                           ; $5940: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5940: $F0 $D7
     sub  $0C                                      ; $5942: $D6 $0C
     and  $7F                                      ; $5944: $E6 $7F
     ld   e, a                                     ; $5946: $5F
@@ -1787,7 +1787,7 @@ jr_004_5963:
     cp   $03                                      ; $5965: $FE $03
     jp   nc, jr_004_5A04                          ; $5967: $D2 $04 $5A
 
-    ldh  a, [hMultiPurpose0]                           ; $596A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $596A: $F0 $D7
     sub  $18                                      ; $596C: $D6 $18
     and  $7F                                      ; $596E: $E6 $7F
     ld   e, a                                     ; $5970: $5F
@@ -1810,7 +1810,7 @@ jr_004_5963:
     cp   $02                                      ; $598F: $FE $02
     jr   nc, jr_004_5A04                          ; $5991: $30 $71
 
-    ldh  a, [hMultiPurpose0]                           ; $5993: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5993: $F0 $D7
     sub  $24                                      ; $5995: $D6 $24
     and  $7F                                      ; $5997: $E6 $7F
     ld   e, a                                     ; $5999: $5F
@@ -1833,7 +1833,7 @@ jr_004_5963:
     and  a                                        ; $59B8: $A7
     jr   nz, jr_004_5A04                          ; $59B9: $20 $49
 
-    ldh  a, [hMultiPurpose0]                           ; $59BB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $59BB: $F0 $D7
     sub  $2E                                      ; $59BD: $D6 $2E
     and  $7F                                      ; $59BF: $E6 $7F
     ld   e, a                                     ; $59C1: $5F
@@ -1882,9 +1882,9 @@ jr_004_5A04:
 func_004_5A05::
     call func_004_7FA9                            ; $5A05: $CD $A9 $7F
     ldh  a, [hActiveEntityPosX]                   ; $5A08: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $5A0A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5A0A: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $5A0C: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $5A0E: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5A0E: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $5A10: $3E $02
     call AddTranscientVfx                         ; $5A12: $CD $C7 $0C
     ld   a, $13                                   ; $5A15: $3E $13
@@ -1966,7 +1966,7 @@ jr_004_5AA9:
     inc  a                                        ; $5AB1: $3C
     and  $1F                                      ; $5AB2: $E6 $1F
     ld   [hl], a                                  ; $5AB4: $77
-    ldh  [hMultiPurpose0], a                           ; $5AB5: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5AB5: $E0 $D7
     ld   hl, wEntitiesLoadOrderTable              ; $5AB7: $21 $60 $C4
     add  hl, bc                                   ; $5ABA: $09
     ld   e, [hl]                                  ; $5ABB: $5E
@@ -1979,7 +1979,7 @@ jr_004_5AA9:
     push de                                       ; $5AC8: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $5AC9: $21 $00 $D0
     add  hl, de                                   ; $5ACC: $19
-    ldh  a, [hMultiPurpose0]                           ; $5ACD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5ACD: $F0 $D7
     ld   e, a                                     ; $5ACF: $5F
     add  hl, de                                   ; $5AD0: $19
     ldh  a, [hActiveEntityPosX]                   ; $5AD1: $F0 $EE
@@ -1987,7 +1987,7 @@ jr_004_5AA9:
     pop  de                                       ; $5AD4: $D1
     ld   hl, wD100                                ; $5AD5: $21 $00 $D1
     add  hl, de                                   ; $5AD8: $19
-    ldh  a, [hMultiPurpose0]                           ; $5AD9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5AD9: $F0 $D7
     ld   e, a                                     ; $5ADB: $5F
     add  hl, de                                   ; $5ADC: $19
     ldh  a, [hActiveEntityVisualPosY]             ; $5ADD: $F0 $EC
@@ -2111,7 +2111,7 @@ func_004_5B7F::
     ld   hl, wEntitiesUnknowTableY                ; $5B88: $21 $D0 $C3
     add  hl, bc                                   ; $5B8B: $09
     ld   a, [hl]                                  ; $5B8C: $7E
-    ldh  [hMultiPurpose0], a                           ; $5B8D: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5B8D: $E0 $D7
     ld   hl, wEntitiesLoadOrderTable              ; $5B8F: $21 $60 $C4
     add  hl, bc                                   ; $5B92: $09
     ld   e, [hl]                                  ; $5B93: $5E
@@ -2125,7 +2125,7 @@ func_004_5B7F::
     push de                                       ; $5BA0: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $5BA1: $21 $00 $D0
     add  hl, de                                   ; $5BA4: $19
-    ldh  a, [hMultiPurpose0]                           ; $5BA5: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5BA5: $F0 $D7
     sub  $09                                      ; $5BA7: $D6 $09
     and  $1F                                      ; $5BA9: $E6 $1F
     ld   e, a                                     ; $5BAB: $5F
@@ -2136,7 +2136,7 @@ func_004_5B7F::
     pop  de                                       ; $5BB1: $D1
     ld   hl, wD100                                ; $5BB2: $21 $00 $D1
     add  hl, de                                   ; $5BB5: $19
-    ldh  a, [hMultiPurpose0]                           ; $5BB6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5BB6: $F0 $D7
     sub  $09                                      ; $5BB8: $D6 $09
     and  $1F                                      ; $5BBA: $E6 $1F
     ld   e, a                                     ; $5BBC: $5F
@@ -2152,7 +2152,7 @@ func_004_5B7F::
     push de                                       ; $5BCD: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $5BCE: $21 $00 $D0
     add  hl, de                                   ; $5BD1: $19
-    ldh  a, [hMultiPurpose0]                           ; $5BD2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5BD2: $F0 $D7
     sub  $10                                      ; $5BD4: $D6 $10
     and  $1F                                      ; $5BD6: $E6 $1F
     ld   e, a                                     ; $5BD8: $5F
@@ -2163,7 +2163,7 @@ func_004_5B7F::
     pop  de                                       ; $5BDE: $D1
     ld   hl, wD100                                ; $5BDF: $21 $00 $D1
     add  hl, de                                   ; $5BE2: $19
-    ldh  a, [hMultiPurpose0]                           ; $5BE3: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5BE3: $F0 $D7
     sub  $10                                      ; $5BE5: $D6 $10
     and  $1F                                      ; $5BE7: $E6 $1F
     ld   e, a                                     ; $5BE9: $5F
@@ -2591,11 +2591,11 @@ SpawnPairoddProjectile::
 
     ld   hl, wEntitiesPosXTable                   ; $5ECD: $21 $00 $C2
     add  hl, de                                   ; $5ED0: $19
-    ldh  a, [hMultiPurpose0]                           ; $5ED1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5ED1: $F0 $D7
     ld   [hl], a                                  ; $5ED3: $77
     ld   hl, wEntitiesPosYTable                   ; $5ED4: $21 $10 $C2
     add  hl, de                                   ; $5ED7: $19
-    ldh  a, [hMultiPurpose1]                           ; $5ED8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5ED8: $F0 $D8
     ld   [hl], a                                  ; $5EDA: $77
     push bc                                       ; $5EDB: $C5
     ld   c, e                                     ; $5EDC: $4B
@@ -3213,9 +3213,9 @@ jr_004_62E7:
 
 label_004_62F6:
     ldh  a, [hActiveEntityVisualPosY]             ; $62F6: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $62F8: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $62F8: $E0 $D8
     ldh  a, [hActiveEntityPosX]                   ; $62FA: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $62FC: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $62FC: $E0 $D7
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $62FE: $3E $01
     call AddTranscientVfx                         ; $6300: $CD $C7 $0C
     ld   a, JINGLE_WATER_DIVE                     ; $6303: $3E $0E
@@ -3692,7 +3692,7 @@ func_004_657A::
     ldh  [hLinkPositionY], a                      ; $65B2: $E0 $99
     ld   a, $08                                   ; $65B4: $3E $08
     call GetVectorTowardsLink_trampoline          ; $65B6: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $65B9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $65B9: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $65BB: $21 $50 $C2
     add  hl, bc                                   ; $65BE: $09
     sub  [hl]                                     ; $65BF: $96
@@ -3704,7 +3704,7 @@ func_004_657A::
     dec  [hl]                                     ; $65C6: $35
 
 jr_004_65C7:
-    ldh  a, [hMultiPurpose1]                           ; $65C7: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $65C7: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $65C9: $21 $40 $C2
     add  hl, bc                                   ; $65CC: $09
     sub  [hl]                                     ; $65CD: $96
@@ -3747,7 +3747,7 @@ jr_004_65F1:
     ldh  [hLinkPositionY], a                      ; $65FD: $E0 $99
     ld   a, $03                                   ; $65FF: $3E $03
     call GetVectorTowardsLink_trampoline          ; $6601: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6604: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6604: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $6606: $21 $50 $C2
     add  hl, bc                                   ; $6609: $09
     sub  [hl]                                     ; $660A: $96
@@ -3762,7 +3762,7 @@ jr_004_65F1:
     dec  [hl]                                     ; $6614: $35
 
 jr_004_6615:
-    ldh  a, [hMultiPurpose1]                           ; $6615: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6615: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $6617: $21 $40 $C2
     add  hl, bc                                   ; $661A: $09
     sub  [hl]                                     ; $661B: $96
@@ -4158,7 +4158,7 @@ jr_004_686D:
     push de                                       ; $686D: $D5
     call GetVectorTowardsLink_trampoline          ; $686E: $CD $B5 $3B
     pop  de                                       ; $6871: $D1
-    ldh  a, [hMultiPurpose0]                           ; $6872: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6872: $F0 $D7
     bit  0, e                                     ; $6874: $CB $43
     jr   z, jr_004_687A                           ; $6876: $28 $02
 
@@ -4167,7 +4167,7 @@ jr_004_686D:
 
 jr_004_687A:
     ldh  [hLinkPositionYIncrement], a             ; $687A: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $687C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $687C: $F0 $D8
     bit  0, e                                     ; $687E: $CB $43
     jr   z, jr_004_6884                           ; $6880: $28 $02
 
@@ -4313,7 +4313,7 @@ label_004_6910:
     inc  e                                        ; $6953: $1C
 
 jr_004_6954:
-    ldh  a, [hMultiPurpose0]                           ; $6954: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6954: $F0 $D7
     bit  0, e                                     ; $6956: $CB $43
     jr   nz, jr_004_695C                          ; $6958: $20 $02
 
@@ -4324,7 +4324,7 @@ jr_004_695C:
     ld   hl, wEntitiesSpeedYTable                 ; $695C: $21 $50 $C2
     add  hl, bc                                   ; $695F: $09
     ld   [hl], a                                  ; $6960: $77
-    ldh  a, [hMultiPurpose1]                           ; $6961: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6961: $F0 $D8
     bit  0, e                                     ; $6963: $CB $43
     jr   nz, jr_004_6969                          ; $6965: $20 $02
 
@@ -4565,7 +4565,7 @@ func_004_6AC7::
     jr   z, jr_004_6B31                           ; $6AD3: $28 $5C
 
     xor  a                                        ; $6AD5: $AF
-    ldh  [hMultiPurpose0], a                           ; $6AD6: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6AD6: $E0 $D7
     ld   hl, wEntitiesDirectionTable              ; $6AD8: $21 $80 $C3
     add  hl, bc                                   ; $6ADB: $09
     ld   a, [hl]                                  ; $6ADC: $7E
@@ -4589,7 +4589,7 @@ jr_004_6AF0:
     ld   [hl], a                                  ; $6AF4: $77
     ld   hl, wEntitiesUnknowTableP                ; $6AF5: $21 $40 $C4
     add  hl, bc                                   ; $6AF8: $09
-    ldh  a, [hMultiPurpose0]                           ; $6AF9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6AF9: $F0 $D7
     and  a                                        ; $6AFB: $A7
     ld   a, [hl]                                  ; $6AFC: $7E
     jr   z, jr_004_6B02                           ; $6AFD: $28 $03
@@ -4620,7 +4620,7 @@ jr_004_6B16:
     ld   [hl], a                                  ; $6B1A: $77
     ld   hl, wEntitiesUnknowTableP                ; $6B1B: $21 $40 $C4
     add  hl, bc                                   ; $6B1E: $09
-    ldh  a, [hMultiPurpose0]                           ; $6B1F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6B1F: $F0 $D7
     and  a                                        ; $6B21: $A7
     ld   a, [hl]                                  ; $6B22: $7E
     jr   nz, jr_004_6B28                          ; $6B23: $20 $03
@@ -4689,16 +4689,16 @@ jr_004_6B7C:
     sub  [hl]                                     ; $6B84: $96
     sra  a                                        ; $6B85: $CB $2F
     sra  a                                        ; $6B87: $CB $2F
-    ldh  [hMultiPurpose0], a                           ; $6B89: $E0 $D7
-    ldh  [hMultiPurpose2], a                           ; $6B8B: $E0 $D9
+    ldh  [hMultiPurpose0], a                      ; $6B89: $E0 $D7
+    ldh  [hMultiPurpose2], a                      ; $6B8B: $E0 $D9
     ldh  a, [hActiveEntityVisualPosY]             ; $6B8D: $F0 $EC
     ld   hl, wEntitiesPosYTable                   ; $6B8F: $21 $10 $C2
     add  hl, bc                                   ; $6B92: $09
     sub  [hl]                                     ; $6B93: $96
     sra  a                                        ; $6B94: $CB $2F
     sra  a                                        ; $6B96: $CB $2F
-    ldh  [hMultiPurpose1], a                           ; $6B98: $E0 $D8
-    ldh  [hMultiPurpose3], a                           ; $6B9A: $E0 $DA
+    ldh  [hMultiPurpose1], a                      ; $6B98: $E0 $D8
+    ldh  [hMultiPurpose3], a                      ; $6B9A: $E0 $DA
     ld   a, [wOAMNextAvailableSlot]               ; $6B9C: $FA $C0 $C3
     ld   e, a                                     ; $6B9F: $5F
     ld   d, $00                                   ; $6BA0: $16 $00
@@ -4710,7 +4710,7 @@ jr_004_6B7C:
     ld   a, $03                                   ; $6BAB: $3E $03
 
 jr_004_6BAD:
-    ldh  [hMultiPurpose4], a                           ; $6BAD: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $6BAD: $E0 $DB
     ldh  a, [hActiveEntityVisualPosY]             ; $6BAF: $F0 $EC
     ld   hl, hMultiPurpose1                            ; $6BB1: $21 $D8 $FF
     add  [hl]                                     ; $6BB4: $86
@@ -4727,15 +4727,15 @@ jr_004_6BAD:
     ld   a, $00                                   ; $6BC3: $3E $00
     ld   [de], a                                  ; $6BC5: $12
     inc  de                                       ; $6BC6: $13
-    ldh  a, [hMultiPurpose0]                           ; $6BC7: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6BC7: $F0 $D7
     ld   hl, hMultiPurpose2                            ; $6BC9: $21 $D9 $FF
     add  [hl]                                     ; $6BCC: $86
-    ldh  [hMultiPurpose0], a                           ; $6BCD: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $6BCF: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $6BCD: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $6BCF: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $6BD1: $21 $DA $FF
     add  [hl]                                     ; $6BD4: $86
-    ldh  [hMultiPurpose1], a                           ; $6BD5: $E0 $D8
-    ldh  a, [hMultiPurpose4]                           ; $6BD7: $F0 $DB
+    ldh  [hMultiPurpose1], a                      ; $6BD5: $E0 $D8
+    ldh  a, [hMultiPurpose4]                      ; $6BD7: $F0 $DB
     dec  a                                        ; $6BD9: $3D
     jr   nz, jr_004_6BAD                          ; $6BDA: $20 $D1
 
@@ -4744,14 +4744,14 @@ jr_004_6BAD:
 
 func_004_6BE1::
     ldh  a, [hActiveEntityPosX]                   ; $6BE1: $F0 $EE
-    ldh  [hMultiPurpose4], a                           ; $6BE3: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $6BE3: $E0 $DB
     swap a                                        ; $6BE5: $CB $37
     and  $0F                                      ; $6BE7: $E6 $0F
     ld   e, a                                     ; $6BE9: $5F
     ldh  a, [hActiveEntityVisualPosY]             ; $6BEA: $F0 $EC
     sub  $10                                      ; $6BEC: $D6 $10
     add  $04                                      ; $6BEE: $C6 $04
-    ldh  [hMultiPurpose5], a                           ; $6BF0: $E0 $DC
+    ldh  [hMultiPurpose5], a                      ; $6BF0: $E0 $DC
     and  $F0                                      ; $6BF2: $E6 $F0
     or   e                                        ; $6BF4: $B3
     ld   e, a                                     ; $6BF5: $5F
@@ -4785,9 +4785,9 @@ func_004_6BE1::
 
 label_004_6C20:
     ldh  a, [hActiveEntityPosX]                   ; $6C20: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6C22: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6C22: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $6C24: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $6C26: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6C26: $E0 $D8
     ld   a, TRANSCIENT_VFX_SWORD_POKE             ; $6C28: $3E $05
     jp   AddTranscientVfx                         ; $6C2A: $C3 $C7 $0C
 
@@ -4823,15 +4823,15 @@ LaserEntityHandler::
 
     ld   a, $08                                   ; $6C86: $3E $08
     ldh  [hNoiseSfx], a                           ; $6C88: $E0 $F4
-    ldh  a, [hMultiPurpose0]                           ; $6C8A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6C8A: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6C8C: $21 $00 $C2
     add  hl, de                                   ; $6C8F: $19
     ld   [hl], a                                  ; $6C90: $77
-    ldh  a, [hMultiPurpose1]                           ; $6C91: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6C91: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6C93: $21 $10 $C2
     add  hl, de                                   ; $6C96: $19
     ld   [hl], a                                  ; $6C97: $77
-    ldh  a, [hMultiPurpose2]                           ; $6C98: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $6C98: $F0 $D9
     ld   hl, wEntitiesDirectionTable              ; $6C9A: $21 $80 $C3
     add  hl, de                                   ; $6C9D: $19
     ld   [hl], a                                  ; $6C9E: $77
@@ -4874,11 +4874,11 @@ jr_004_6CB4:
     call SpawnNewEntity_trampoline                ; $6CD1: $CD $86 $3B
     jr   c, jr_004_6D0E                           ; $6CD4: $38 $38
 
-    ldh  a, [hMultiPurpose0]                           ; $6CD6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6CD6: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $6CD8: $21 $00 $C2
     add  hl, de                                   ; $6CDB: $19
     ld   [hl], a                                  ; $6CDC: $77
-    ldh  a, [hMultiPurpose1]                           ; $6CDD: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6CDD: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6CDF: $21 $10 $C2
     add  hl, de                                   ; $6CE2: $19
     ld   [hl], a                                  ; $6CE3: $77
@@ -4892,7 +4892,7 @@ jr_004_6CB4:
     add  hl, de                                   ; $6CF2: $19
     ld   [hl], $C0                                ; $6CF3: $36 $C0
     push bc                                       ; $6CF5: $C5
-    ldh  a, [hMultiPurpose2]                           ; $6CF6: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $6CF6: $F0 $D9
     ld   c, a                                     ; $6CF8: $4F
     ld   hl, Data_004_6C51                        ; $6CF9: $21 $51 $6C
     add  hl, bc                                   ; $6CFC: $09
@@ -5168,7 +5168,7 @@ jr_004_6E53:
 func_004_6E55::
     call func_004_6E35                            ; $6E55: $CD $35 $6E
     ld   a, e                                     ; $6E58: $7B
-    ldh  [hMultiPurpose0], a                           ; $6E59: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6E59: $E0 $D7
     ld   a, d                                     ; $6E5B: $7A
     bit  7, a                                     ; $6E5C: $CB $7F
     jr   z, jr_004_6E62                           ; $6E5E: $28 $02
@@ -5180,7 +5180,7 @@ jr_004_6E62:
     push af                                       ; $6E62: $F5
     call func_004_6E45                            ; $6E63: $CD $45 $6E
     ld   a, e                                     ; $6E66: $7B
-    ldh  [hMultiPurpose1], a                           ; $6E67: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6E67: $E0 $D8
     ld   a, d                                     ; $6E69: $7A
     bit  7, a                                     ; $6E6A: $CB $7F
     jr   z, jr_004_6E70                           ; $6E6C: $28 $02
@@ -5193,11 +5193,11 @@ jr_004_6E70:
     cp   d                                        ; $6E71: $BA
     jr   nc, jr_004_6E78                          ; $6E72: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $6E74: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6E74: $F0 $D7
     jr   jr_004_6E7A                              ; $6E76: $18 $02
 
 jr_004_6E78:
-    ldh  a, [hMultiPurpose1]                           ; $6E78: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6E78: $F0 $D8
 
 jr_004_6E7A:
     ld   e, a                                     ; $6E7A: $5F
@@ -7293,11 +7293,11 @@ func_004_7AED::
     call SpawnNewEntity_trampoline                ; $7AF5: $CD $86 $3B
     ld   a, $26                                   ; $7AF8: $3E $26
     ldh  [hNoiseSfx], a                           ; $7AFA: $E0 $F4
-    ldh  a, [hMultiPurpose0]                           ; $7AFC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7AFC: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7AFE: $21 $00 $C2
     add  hl, de                                   ; $7B01: $19
     ld   [hl], a                                  ; $7B02: $77
-    ldh  a, [hMultiPurpose1]                           ; $7B03: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7B03: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7B05: $21 $10 $C2
     add  hl, de                                   ; $7B08: $19
     ld   [hl], a                                  ; $7B09: $77
@@ -7907,11 +7907,11 @@ func_004_7EC0::
     jr   c, jr_004_7EE4                           ; $7EC5: $38 $1D
 
     call PlayBombExplosionSfx                     ; $7EC7: $CD $4B $0C
-    ldh  a, [hMultiPurpose0]                           ; $7ECA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7ECA: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7ECC: $21 $00 $C2
     add  hl, de                                   ; $7ECF: $19
     ld   [hl], a                                  ; $7ED0: $77
-    ldh  a, [hMultiPurpose1]                           ; $7ED1: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7ED1: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7ED3: $21 $10 $C2
     add  hl, de                                   ; $7ED6: $19
     ld   [hl], a                                  ; $7ED7: $77

--- a/src/code/entities/bank6.asm
+++ b/src/code/entities/bank6.asm
@@ -361,7 +361,7 @@ jr_006_65B2:
 func_006_65B4::
     call func_006_6594                            ; $65B4: $CD $94 $65
     ld   a, e                                     ; $65B7: $7B
-    ldh  [hMultiPurpose0], a                           ; $65B8: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $65B8: $E0 $D7
     ld   a, d                                     ; $65BA: $7A
     bit  7, a                                     ; $65BB: $CB $7F
     jr   z, jr_006_65C1                           ; $65BD: $28 $02
@@ -373,7 +373,7 @@ jr_006_65C1:
     push af                                       ; $65C1: $F5
     call func_006_65A4                            ; $65C2: $CD $A4 $65
     ld   a, e                                     ; $65C5: $7B
-    ldh  [hMultiPurpose1], a                           ; $65C6: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $65C6: $E0 $D8
     ld   a, d                                     ; $65C8: $7A
     bit  7, a                                     ; $65C9: $CB $7F
     jr   z, jr_006_65CF                           ; $65CB: $28 $02
@@ -386,11 +386,11 @@ jr_006_65CF:
     cp   d                                        ; $65D0: $BA
     jr   nc, jr_006_65D7                          ; $65D1: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $65D3: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $65D3: $F0 $D7
     jr   jr_006_65D9                              ; $65D5: $18 $02
 
 jr_006_65D7:
-    ldh  a, [hMultiPurpose1]                           ; $65D7: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $65D7: $F0 $D8
 
 jr_006_65D9:
     ld   e, a                                     ; $65D9: $5F
@@ -438,9 +438,9 @@ func_006_700A::
 label_006_702A:
     call func_006_64CC                            ; $702A: $CD $CC $64
     ldh  a, [hActiveEntityPosX]                   ; $702D: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $702F: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $702F: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7031: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7033: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7033: $E0 $D8
 
 label_006_7035:
     ld   a, TRANSCIENT_VFX_POOF                   ; $7035: $3E $02
@@ -451,11 +451,11 @@ label_006_7035:
 
     ld   a, $36                                   ; $703F: $3E $36
     call SpawnNewEntity_trampoline                ; $7041: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7044: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7044: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7046: $21 $00 $C2
     add  hl, de                                   ; $7049: $19
     ld   [hl], a                                  ; $704A: $77
-    ldh  a, [hMultiPurpose1]                           ; $704B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $704B: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $704D: $21 $10 $C2
     add  hl, de                                   ; $7050: $19
     ld   [hl], a                                  ; $7051: $77

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -256,11 +256,11 @@ label_007_4198:
     call SpawnNewEntity_trampoline                ; $419A: $CD $86 $3B
     ret  c                                        ; $419D: $D8
 
-    ldh  a, [hMultiPurpose0]                           ; $419E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $419E: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $41A0: $21 $00 $C2
     add  hl, de                                   ; $41A3: $19
     ld   [hl], a                                  ; $41A4: $77
-    ldh  a, [hMultiPurpose1]                           ; $41A5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $41A5: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $41A7: $21 $10 $C2
     add  hl, de                                   ; $41AA: $19
     ld   [hl], a                                  ; $41AB: $77
@@ -374,12 +374,12 @@ FishermanUnderBridgeEntityHandler::
     ld   [hl], a                                  ; $4299: $77
     ld   a, $B8                                   ; $429A: $3E $B8
     call SpawnNewEntity_trampoline                ; $429C: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $429F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $429F: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $42A1: $21 $00 $C2
     add  hl, de                                   ; $42A4: $19
     add  $06                                      ; $42A5: $C6 $06
     ld   [hl], a                                  ; $42A7: $77
-    ldh  a, [hMultiPurpose1]                           ; $42A8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $42A8: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $42AA: $21 $10 $C2
     add  hl, de                                   ; $42AD: $19
     add  $10                                      ; $42AE: $C6 $10
@@ -810,13 +810,13 @@ func_007_4537::
     call IncrementEntityState                     ; $4543: $CD $12 $3B
     ld   a, $54                                   ; $4546: $3E $54
     call SpawnNewEntity_trampoline                ; $4548: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $454B: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $454B: $F0 $D7
     sub  $20                                      ; $454D: $D6 $20
     ld   hl, wEntitiesPosXTable                   ; $454F: $21 $00 $C2
     add  hl, de                                   ; $4552: $19
     ld   [hl], a                                  ; $4553: $77
     ldh  [hActiveEntityPosX], a                   ; $4554: $E0 $EE
-    ldh  a, [hMultiPurpose1]                           ; $4556: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4556: $F0 $D8
     add  $08                                      ; $4558: $C6 $08
     ld   hl, wEntitiesPosYTable                   ; $455A: $21 $10 $C2
     add  hl, de                                   ; $455D: $19
@@ -1229,9 +1229,9 @@ jr_007_4820:
 
     ldh  a, [hLinkPositionY]                      ; $4824: $F0 $99
     sub  $03                                      ; $4826: $D6 $03
-    ldh  [hMultiPurpose1], a                           ; $4828: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4828: $E0 $D8
     ldh  a, [hLinkPositionX]                      ; $482A: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $482C: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $482C: $E0 $D7
     ld   a, JINGLE_WATER_DIVE                     ; $482E: $3E $0E
     ldh  [hJingle], a                             ; $4830: $E0 $F2
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $4832: $3E $01
@@ -1371,9 +1371,9 @@ jr_007_48F0:
 
 func_007_48FD::
     ldh  a, [hActiveEntityVisualPosY]             ; $48FD: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $48FF: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $48FF: $E0 $D8
     ldh  a, [hActiveEntityPosX]                   ; $4901: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4903: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4903: $E0 $D7
     ld   a, TRANSCIENT_VFX_WATER_SPLASH           ; $4905: $3E $01
     call AddTranscientVfx                         ; $4907: $CD $C7 $0C
     ld   a, JINGLE_WATER_DIVE                     ; $490A: $3E $0E
@@ -1918,11 +1918,11 @@ func_007_4CEE::
     call SpawnNewEntity_trampoline                ; $4CF0: $CD $86 $3B
     jr   c, jr_007_4D1D                           ; $4CF3: $38 $28
 
-    ldh  a, [hMultiPurpose0]                           ; $4CF5: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4CF5: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4CF7: $21 $00 $C2
     add  hl, de                                   ; $4CFA: $19
     ld   [hl], a                                  ; $4CFB: $77
-    ldh  a, [hMultiPurpose1]                           ; $4CFC: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4CFC: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4CFE: $21 $10 $C2
     add  hl, de                                   ; $4D01: $19
     ld   [hl], a                                  ; $4D02: $77
@@ -2786,9 +2786,9 @@ jr_007_51F2:
     jr   z, jr_007_529F                           ; $525D: $28 $40
 
     ldh  a, [hActiveEntityPosX]                   ; $525F: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $5261: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5261: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $5263: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $5265: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5265: $E0 $D8
     ld   a, JINGLE_POOF                           ; $5267: $3E $2F
     ldh  [hJingle], a                             ; $5269: $E0 $F2
     ld   a, TRANSCIENT_VFX_POOF                   ; $526B: $3E $02
@@ -2839,11 +2839,11 @@ Data_007_52C0::
     db   $04, $04, $05, $05, $05, $06, $06, $06, $0C, $0C, $0B, $0B, $0B, $0A, $0A, $0A
 
 func_007_52E0::
-    ldh  a, [hMultiPurpose0]                           ; $52E0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $52E0: $F0 $D7
     rlca                                          ; $52E2: $07
     and  $01                                      ; $52E3: $E6 $01
     ld   e, a                                     ; $52E5: $5F
-    ldh  a, [hMultiPurpose1]                           ; $52E6: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $52E6: $F0 $D8
     rlca                                          ; $52E8: $07
     rla                                           ; $52E9: $17
     and  $02                                      ; $52EA: $E6 $02
@@ -2853,7 +2853,7 @@ func_007_52E0::
     rla                                           ; $52EF: $17
     and  $18                                      ; $52F0: $E6 $18
     ld   h, a                                     ; $52F2: $67
-    ldh  a, [hMultiPurpose1]                           ; $52F3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $52F3: $F0 $D8
     bit  7, a                                     ; $52F5: $CB $7F
     jr   z, jr_007_52FB                           ; $52F7: $28 $02
 
@@ -2862,7 +2862,7 @@ func_007_52E0::
 
 jr_007_52FB:
     ld   d, a                                     ; $52FB: $57
-    ldh  a, [hMultiPurpose0]                           ; $52FC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $52FC: $F0 $D7
     bit  7, a                                     ; $52FE: $CB $7F
     jr   z, jr_007_5304                           ; $5300: $28 $02
 
@@ -3073,16 +3073,16 @@ func_007_5453::
     sub  [hl]                                     ; $5464: $96
     sra  a                                        ; $5465: $CB $2F
     sra  a                                        ; $5467: $CB $2F
-    ldh  [hMultiPurpose0], a                           ; $5469: $E0 $D7
-    ldh  [hMultiPurpose2], a                           ; $546B: $E0 $D9
+    ldh  [hMultiPurpose0], a                      ; $5469: $E0 $D7
+    ldh  [hMultiPurpose2], a                      ; $546B: $E0 $D9
     ldh  a, [hActiveEntityVisualPosY]             ; $546D: $F0 $EC
     ld   hl, wEntitiesPrivateState2Table          ; $546F: $21 $C0 $C2
     add  hl, bc                                   ; $5472: $09
     sub  [hl]                                     ; $5473: $96
     sra  a                                        ; $5474: $CB $2F
     sra  a                                        ; $5476: $CB $2F
-    ldh  [hMultiPurpose1], a                           ; $5478: $E0 $D8
-    ldh  [hMultiPurpose3], a                           ; $547A: $E0 $DA
+    ldh  [hMultiPurpose1], a                      ; $5478: $E0 $D8
+    ldh  [hMultiPurpose3], a                      ; $547A: $E0 $DA
     ld   a, [wOAMNextAvailableSlot]               ; $547C: $FA $C0 $C3
     ld   e, a                                     ; $547F: $5F
     ld   d, $00                                   ; $5480: $16 $00
@@ -3093,16 +3093,16 @@ func_007_5453::
     ld   a, $03                                   ; $5488: $3E $03
 
 jr_007_548A:
-    ldh  [hMultiPurpose4], a                           ; $548A: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $548A: $E0 $DB
     ld   hl, wEntitiesPrivateState2Table          ; $548C: $21 $C0 $C2
     add  hl, bc                                   ; $548F: $09
-    ldh  a, [hMultiPurpose1]                           ; $5490: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5490: $F0 $D8
     add  [hl]                                     ; $5492: $86
     ld   [de], a                                  ; $5493: $12
     inc  de                                       ; $5494: $13
     ld   hl, wEntitiesPrivateState1Table          ; $5495: $21 $B0 $C2
     add  hl, bc                                   ; $5498: $09
-    ldh  a, [hMultiPurpose0]                           ; $5499: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5499: $F0 $D7
     add  [hl]                                     ; $549B: $86
 
 jr_007_549C:
@@ -3115,15 +3115,15 @@ jr_007_549C:
     ld   a, $02                                   ; $54A4: $3E $02
     ld   [de], a                                  ; $54A6: $12
     inc  de                                       ; $54A7: $13
-    ldh  a, [hMultiPurpose0]                           ; $54A8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $54A8: $F0 $D7
     ld   hl, hMultiPurpose2                            ; $54AA: $21 $D9 $FF
     add  [hl]                                     ; $54AD: $86
-    ldh  [hMultiPurpose0], a                           ; $54AE: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $54B0: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $54AE: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $54B0: $F0 $D8
     ld   hl, hMultiPurpose3                            ; $54B2: $21 $DA $FF
     add  [hl]                                     ; $54B5: $86
-    ldh  [hMultiPurpose1], a                           ; $54B6: $E0 $D8
-    ldh  a, [hMultiPurpose4]                           ; $54B8: $F0 $DB
+    ldh  [hMultiPurpose1], a                      ; $54B6: $E0 $D8
+    ldh  a, [hMultiPurpose4]                      ; $54B8: $F0 $DB
     dec  a                                        ; $54BA: $3D
     jr   nz, jr_007_548A                          ; $54BB: $20 $CD
 
@@ -3585,21 +3585,21 @@ func_007_57B0::
     ld   hl, wEntitiesSpriteVariantTable          ; $57B8: $21 $B0 $C3
     add  hl, de                                   ; $57BB: $19
     ld   [hl], $01                                ; $57BC: $36 $01
-    ldh  a, [hMultiPurpose2]                           ; $57BE: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $57BE: $F0 $D9
     ld   hl, wEntitiesDirectionTable              ; $57C0: $21 $80 $C3
     add  hl, de                                   ; $57C3: $19
     ld   [hl], a                                  ; $57C4: $77
     ld   c, a                                     ; $57C5: $4F
     ld   hl, Data_007_57A0                        ; $57C6: $21 $A0 $57
     add  hl, bc                                   ; $57C9: $09
-    ldh  a, [hMultiPurpose0]                           ; $57CA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $57CA: $F0 $D7
     add  [hl]                                     ; $57CC: $86
     ld   hl, wEntitiesPosXTable                   ; $57CD: $21 $00 $C2
     add  hl, de                                   ; $57D0: $19
     ld   [hl], a                                  ; $57D1: $77
     ld   hl, Data_007_57A4                        ; $57D2: $21 $A4 $57
     add  hl, bc                                   ; $57D5: $09
-    ldh  a, [hMultiPurpose1]                           ; $57D6: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $57D6: $F0 $D8
     add  [hl]                                     ; $57D8: $86
     ld   hl, wEntitiesPosYTable                   ; $57D9: $21 $10 $C2
     add  hl, de                                   ; $57DC: $19
@@ -4201,12 +4201,12 @@ jr_007_5B94:
     and  a                                        ; $5BA1: $A7
     jr   z, jr_007_5BBE                           ; $5BA2: $28 $1A
 
-    ldh  a, [hMultiPurpose0]                           ; $5BA4: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5BA4: $F0 $D7
     call GetEntitySpeedYAddress                   ; $5BA6: $CD $05 $40
     cpl                                           ; $5BA9: $2F
     inc  a                                        ; $5BAA: $3C
     ld   [hl], a                                  ; $5BAB: $77
-    ldh  a, [hMultiPurpose1]                           ; $5BAC: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5BAC: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $5BAE: $21 $40 $C2
     add  hl, bc                                   ; $5BB1: $09
     cpl                                           ; $5BB2: $2F
@@ -5426,7 +5426,7 @@ func_007_631C::
     add  hl, bc                                   ; $631F: $09
     ld   a, [hl]                                  ; $6320: $7E
     xor  $01                                      ; $6321: $EE $01
-    ldh  [hMultiPurpose0], a                           ; $6323: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6323: $E0 $D7
     ld   e, b                                     ; $6325: $58
     ld   d, b                                     ; $6326: $50
 
@@ -5445,7 +5445,7 @@ jr_007_6327:
 
     ld   hl, wEntitiesLoadOrderTable              ; $6338: $21 $60 $C4
     add  hl, de                                   ; $633B: $19
-    ldh  a, [hMultiPurpose0]                           ; $633C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $633C: $F0 $D7
     cp   [hl]                                     ; $633E: $BE
     jr   z, jr_007_6347                           ; $633F: $28 $06
 
@@ -7633,9 +7633,9 @@ jr_007_70E0:
 
     ld   a, $28                                   ; $70ED: $3E $28
     call GetVectorTowardsLink_trampoline          ; $70EF: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $70F2: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $70F2: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $70F4: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $70F6: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $70F6: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $70F8: $E0 $9A
     ld   a, $02                                   ; $70FA: $3E $02
     ld   [wIsLinkInTheAir], a                     ; $70FC: $EA $46 $C1
@@ -7720,11 +7720,11 @@ jr_007_7168:
     call SpawnNewEntity_trampoline                ; $716F: $CD $86 $3B
     jr   c, jr_007_7197                           ; $7172: $38 $23
 
-    ldh  a, [hMultiPurpose0]                           ; $7174: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7174: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7176: $21 $00 $C2
     add  hl, de                                   ; $7179: $19
     ld   [hl], a                                  ; $717A: $77
-    ldh  a, [hMultiPurpose1]                           ; $717B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $717B: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $717D: $21 $10 $C2
     add  hl, de                                   ; $7180: $19
     ld   [hl], a                                  ; $7181: $77
@@ -7787,11 +7787,11 @@ jr_007_71B4:
     ld   hl, wEntitiesDroppedItemTable            ; $71D1: $21 $E0 $C4
     add  hl, de                                   ; $71D4: $19
     ld   [hl], a                                  ; $71D5: $77
-    ldh  a, [hMultiPurpose0]                           ; $71D6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $71D6: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $71D8: $21 $00 $C2
     add  hl, de                                   ; $71DB: $19
     ld   [hl], a                                  ; $71DC: $77
-    ldh  a, [hMultiPurpose1]                           ; $71DD: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $71DD: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $71DF: $21 $10 $C2
     add  hl, de                                   ; $71E2: $19
     add  $08                                      ; $71E3: $C6 $08
@@ -9201,9 +9201,9 @@ jr_007_7ACB:
 jr_007_7AD1:
     push bc                                       ; $7AD1: $C5
     ldh  a, [hActiveEntityVisualPosY]             ; $7AD2: $F0 $EC
-    ldh  [hMultiPurpose0], a                           ; $7AD4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7AD4: $E0 $D7
     ldh  a, [hActiveEntityPosX]                   ; $7AD6: $F0 $EE
-    ldh  [hMultiPurpose1], a                           ; $7AD8: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7AD8: $E0 $D8
     ldh  a, [hActiveEntitySpriteVariant]          ; $7ADA: $F0 $F1
     ld   e, a                                     ; $7ADC: $5F
     ld   d, b                                     ; $7ADD: $50
@@ -9221,7 +9221,7 @@ jr_007_7AD1:
     ld   hl, Data_007_7A7D                        ; $7AF6: $21 $7D $7A
     add  hl, de                                   ; $7AF9: $19
     ld   a, [hl]                                  ; $7AFA: $7E
-    ldh  [hMultiPurpose2], a                           ; $7AFB: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $7AFB: $E0 $D9
     ld   hl, Data_007_7A75                        ; $7AFD: $21 $75 $7A
     add  hl, de                                   ; $7B00: $19
     ld   a, [hl]                                  ; $7B01: $7E
@@ -9238,7 +9238,7 @@ jr_007_7AD1:
     ld   c, l                                     ; $7B13: $4D
     ld   b, h                                     ; $7B14: $44
     xor  a                                        ; $7B15: $AF
-    ldh  [hMultiPurpose3], a                           ; $7B16: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $7B16: $E0 $DA
     pop  hl                                       ; $7B18: $E1
     call func_1819                               ; $7B19: $CD $19 $18
     ld   a, $02                                   ; $7B1C: $3E $02
@@ -9594,7 +9594,7 @@ jr_007_7E7B:
 func_007_7E7D::
     call func_007_7E5D                            ; $7E7D: $CD $5D $7E
     ld   a, e                                     ; $7E80: $7B
-    ldh  [hMultiPurpose0], a                           ; $7E81: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7E81: $E0 $D7
     ld   a, d                                     ; $7E83: $7A
     bit  7, a                                     ; $7E84: $CB $7F
     jr   z, jr_007_7E8A                           ; $7E86: $28 $02
@@ -9606,7 +9606,7 @@ jr_007_7E8A:
     push af                                       ; $7E8A: $F5
     call func_007_7E6D                            ; $7E8B: $CD $6D $7E
     ld   a, e                                     ; $7E8E: $7B
-    ldh  [hMultiPurpose1], a                           ; $7E8F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7E8F: $E0 $D8
     ld   a, d                                     ; $7E91: $7A
     bit  7, a                                     ; $7E92: $CB $7F
     jr   z, jr_007_7E98                           ; $7E94: $28 $02
@@ -9619,11 +9619,11 @@ jr_007_7E98:
     cp   d                                        ; $7E99: $BA
     jr   nc, jr_007_7EA0                          ; $7E9A: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $7E9C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7E9C: $F0 $D7
     jr   jr_007_7EA2                              ; $7E9E: $18 $02
 
 jr_007_7EA0:
-    ldh  a, [hMultiPurpose1]                           ; $7EA0: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7EA0: $F0 $D8
 
 jr_007_7EA2:
     ld   e, a                                     ; $7EA2: $5F
@@ -9677,11 +9677,11 @@ func_007_7ED6::
 
     ld   a, ENTITY_KEY_DROP_POINT                 ; $7EE1: $3E $30
     call SpawnNewEntity_trampoline                ; $7EE3: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7EE6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7EE6: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7EE8: $21 $00 $C2
     add  hl, de                                   ; $7EEB: $19
     ld   [hl], a                                  ; $7EEC: $77
-    ldh  a, [hMultiPurpose1]                           ; $7EED: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7EED: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7EEF: $21 $10 $C2
     add  hl, de                                   ; $7EF2: $19
     ld   [hl], a                                  ; $7EF3: $77
@@ -9728,9 +9728,9 @@ label_007_7F16:
 label_007_7F36:
     call func_007_7D9C                            ; $7F36: $CD $9C $7D
     ldh  a, [hActiveEntityPosX]                   ; $7F39: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $7F3B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7F3B: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7F3D: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7F3F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7F3F: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $7F41: $3E $02
     call AddTranscientVfx                         ; $7F43: $CD $C7 $0C
     ld   a, $13                                   ; $7F46: $3E $13
@@ -9739,11 +9739,11 @@ label_007_7F36:
 
     ld   a, $36                                   ; $7F4B: $3E $36
     call SpawnNewEntity_trampoline                ; $7F4D: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7F50: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7F50: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7F52: $21 $00 $C2
     add  hl, de                                   ; $7F55: $19
     ld   [hl], a                                  ; $7F56: $77
-    ldh  a, [hMultiPurpose1]                           ; $7F57: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7F57: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7F59: $21 $10 $C2
     add  hl, de                                   ; $7F5C: $19
     ld   [hl], a                                  ; $7F5D: $77

--- a/src/code/entities/big_fairy.asm
+++ b/src/code/entities/big_fairy.asm
@@ -209,12 +209,12 @@ jr_006_71BA:
     ld   hl, wEntitiesUnknownTableD               ; $71D2: $21 $D0 $C2
     add  hl, de                                   ; $71D5: $19
     ld   [hl], $01                                ; $71D6: $36 $01
-    ldh  a, [hMultiPurpose0]                           ; $71D8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $71D8: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $71DA: $21 $00 $C2
     add  hl, de                                   ; $71DD: $19
     add  $00                                      ; $71DE: $C6 $00
     ld   [hl], a                                  ; $71E0: $77
-    ldh  a, [hMultiPurpose1]                           ; $71E1: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $71E1: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $71E3: $21 $10 $C2
     add  hl, de                                   ; $71E6: $19
     sub  $0E                                      ; $71E7: $D6 $0E

--- a/src/code/entities/boo_buddy.asm
+++ b/src/code/entities/boo_buddy.asm
@@ -34,10 +34,10 @@ BooBuddyState0Handler::
     and  $07                                      ; $79DE: $E6 $07
     add  $06                                      ; $79E0: $C6 $06
     call GetVectorTowardsLink_trampoline          ; $79E2: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $79E5: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $79E5: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $79E7: $21 $50 $C2
     call func_006_7A79                            ; $79EA: $CD $79 $7A
-    ldh  a, [hMultiPurpose1]                           ; $79ED: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $79ED: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $79EF: $21 $40 $C2
 
 jr_006_79F2:
@@ -104,13 +104,13 @@ BooBuddyState1Handler::
     call label_3B39                               ; $7A4A: $CD $39 $3B
     ld   a, $04                                   ; $7A4D: $3E $04
     call GetVectorTowardsLink_trampoline          ; $7A4F: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7A52: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7A52: $F0 $D7
     cpl                                           ; $7A54: $2F
     inc  a                                        ; $7A55: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $7A56: $21 $50 $C2
     add  hl, bc                                   ; $7A59: $09
     ld   [hl], a                                  ; $7A5A: $77
-    ldh  a, [hMultiPurpose1]                           ; $7A5B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7A5B: $F0 $D8
     cpl                                           ; $7A5D: $2F
     inc  a                                        ; $7A5E: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $7A5F: $21 $40 $C2

--- a/src/code/entities/boomerang.asm
+++ b/src/code/entities/boomerang.asm
@@ -97,10 +97,10 @@ jr_019_44DA:
     call func_014_5526_trampoline                 ; $44E3: $CD $78 $21
     ldh  a, [hSwordIntersectedAreaX]              ; $44E6: $F0 $CE
     add  $08                                      ; $44E8: $C6 $08
-    ldh  [hMultiPurpose0], a                           ; $44EA: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $44EA: $E0 $D7
     ldh  a, [hSwordIntersectedAreaY]              ; $44EC: $F0 $CD
     add  $10                                      ; $44EE: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $44F0: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $44F0: $E0 $D8
     ld   a, TRANSCIENT_VFX_SMOKE                  ; $44F2: $3E $08
     call AddTranscientVfx                         ; $44F4: $CD $C7 $0C
     ld   a, $13                                   ; $44F7: $3E $13

--- a/src/code/entities/bow_wow.asm
+++ b/src/code/entities/bow_wow.asm
@@ -134,9 +134,9 @@ func_005_40E6::
     jr   z, jr_005_40FA                           ; $40EE: $28 $0A
 
     ldh  a, [hLinkPositionX]                      ; $40F0: $F0 $98
-    ldh  [hMultiPurpose0], a                           ; $40F2: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $40F2: $E0 $D7
     ldh  a, [hFFB3]                               ; $40F4: $F0 $B3
-    ldh  [hMultiPurpose1], a                           ; $40F6: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $40F6: $E0 $D8
     jr   jr_005_4129                              ; $40F8: $18 $2F
 
 jr_005_40FA:
@@ -169,11 +169,11 @@ jr_005_4127:
     jr   jr_005_4137                              ; $4127: $18 $0E
 
 jr_005_4129:
-    ldh  a, [hMultiPurpose0]                           ; $4129: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4129: $F0 $D7
     ld   hl, wEntitiesPrivateState1Table          ; $412B: $21 $B0 $C2
     add  hl, bc                                   ; $412E: $09
     ld   [hl], a                                  ; $412F: $77
-    ldh  a, [hMultiPurpose1]                           ; $4130: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4130: $F0 $D8
     ld   hl, wEntitiesPrivateState2Table          ; $4132: $21 $C0 $C2
     add  hl, bc                                   ; $4135: $09
     ld   [hl], a                                  ; $4136: $77
@@ -434,17 +434,17 @@ label_005_4297:
 
     ld   e, $0F                                   ; $42A7: $1E $0F
     ld   a, $FF                                   ; $42A9: $3E $FF
-    ldh  [hMultiPurpose0], a                           ; $42AB: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $42AB: $E0 $D7
     jr   jr_005_42B7                              ; $42AD: $18 $08
 
 jr_005_42AF:
     ld   e, $00                                   ; $42AF: $1E $00
     ld   a, $01                                   ; $42B1: $3E $01
-    ldh  [hMultiPurpose0], a                           ; $42B3: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $42B3: $E0 $D7
     ld   a, $10                                   ; $42B5: $3E $10
 
 jr_005_42B7:
-    ldh  [hMultiPurpose1], a                           ; $42B7: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $42B7: $E0 $D8
 
 jr_005_42B9:
     ld   a, e                                     ; $42B9: $7B
@@ -789,7 +789,7 @@ jr_005_4473:
     jr   nz, jr_005_4455                          ; $4476: $20 $DD
 
     ld   a, b                                     ; $4478: $78
-    ldh  [hMultiPurpose0], a                           ; $4479: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4479: $E0 $D7
     pop  bc                                       ; $447B: $C1
     and  $01                                      ; $447C: $E6 $01
     jr   z, jr_005_4499                           ; $447E: $28 $19
@@ -819,7 +819,7 @@ jr_005_4492:
     call func_005_44B5                            ; $4496: $CD $B5 $44
 
 jr_005_4499:
-    ldh  a, [hMultiPurpose0]                           ; $4499: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4499: $F0 $D7
     and  $02                                      ; $449B: $E6 $02
     jr   z, jr_005_44CA                           ; $449D: $28 $2B
 

--- a/src/code/entities/butterfly.asm
+++ b/src/code/entities/butterfly.asm
@@ -122,12 +122,12 @@ ButterflyEntityHandler::
     pop  af                                       ; $6C5B: $F1
     ldh  [hLinkPositionX], a                      ; $6C5C: $E0 $98
     ; wEntitiesPrivateState2Table[c] = [hMultiPurpose0]
-    ldh  a, [hMultiPurpose0]                           ; $6C5E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6C5E: $F0 $D7
     ld   hl, wEntitiesPrivateState2Table          ; $6C60: $21 $C0 $C2
     add  hl, bc                                   ; $6C63: $09
     ld   [hl], a                                  ; $6C64: $77
     ; wEntitiesPrivateState1Table[c] = [hMultiPurpose1]
-    ldh  a, [hMultiPurpose1]                           ; $6C65: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6C65: $F0 $D8
     ld   hl, wEntitiesPrivateState1Table          ; $6C67: $21 $B0 $C2
     add  hl, bc                                   ; $6C6A: $09
     ld   [hl], a                                  ; $6C6B: $77

--- a/src/code/entities/chest_with_item.asm
+++ b/src/code/entities/chest_with_item.asm
@@ -72,11 +72,11 @@ ChestWithItemEntityHandler::
     call SpawnNewEntity_trampoline                ; $7BF0: $CD $86 $3B
     jp   c, func_007_7EA4                         ; $7BF3: $DA $A4 $7E
 
-    ldh  a, [hMultiPurpose0]                           ; $7BF6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7BF6: $F0 $D7
     ld   hl, wEntitiesPosXTable                         ; $7BF8: $21 $00 $C2
     add  hl, de                                   ; $7BFB: $19
     ld   [hl], a                                  ; $7BFC: $77
-    ldh  a, [hMultiPurpose1]                           ; $7BFD: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7BFD: $F0 $D8
     ld   hl, wEntitiesPosYTable                         ; $7BFF: $21 $10 $C2
     add  hl, de                                   ; $7C02: $19
     ld   [hl], a                                  ; $7C03: $77

--- a/src/code/entities/crow.asm
+++ b/src/code/entities/crow.asm
@@ -77,11 +77,11 @@ CrowState0Handler::
     ld   hl, wEntitiesPosXTable                   ; $5CFE: $21 $00 $C2
     add  hl, bc                                   ; $5D01: $09
     ld   a, [hl]                                  ; $5D02: $7E
-    ldh  [hMultiPurpose0], a                           ; $5D03: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5D03: $E0 $D7
     ld   hl, wEntitiesPosYTable                   ; $5D05: $21 $10 $C2
     add  hl, bc                                   ; $5D08: $09
     ld   a, [hl]                                  ; $5D09: $7E
-    ldh  [hMultiPurpose1], a                           ; $5D0A: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5D0A: $E0 $D8
     ld   de, $00                                  ; $5D0C: $11 $00 $00
 
 jr_006_5D0F:
@@ -106,7 +106,7 @@ jr_006_5D0F:
     ld   hl, wEntitiesPosXTable                   ; $5D29: $21 $00 $C2
     add  hl, de                                   ; $5D2C: $19
     ld   l, [hl]                                  ; $5D2D: $6E
-    ldh  a, [hMultiPurpose0]                           ; $5D2E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5D2E: $F0 $D7
     sub  l                                        ; $5D30: $95
     bit  7, a                                     ; $5D31: $CB $7F
     jr   z, jr_006_5D37                           ; $5D33: $28 $02
@@ -121,7 +121,7 @@ jr_006_5D37:
     ld   hl, wEntitiesPosYTable                   ; $5D3B: $21 $10 $C2
     add  hl, de                                   ; $5D3E: $19
     ld   l, [hl]                                  ; $5D3F: $6E
-    ldh  a, [hMultiPurpose1]                           ; $5D40: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5D40: $F0 $D8
     sub  l                                        ; $5D42: $95
     bit  7, a                                     ; $5D43: $CB $7F
     jr   z, jr_006_5D49                           ; $5D45: $28 $02
@@ -228,7 +228,7 @@ CrowState2Handler::
 
     ld   a, $20                                   ; $5DD5: $3E $20
     call GetVectorTowardsLink_trampoline          ; $5DD7: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $5DDA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5DDA: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $5DDC: $21 $50 $C2
     add  hl, bc                                   ; $5DDF: $09
     sub  [hl]                                     ; $5DE0: $96
@@ -240,7 +240,7 @@ CrowState2Handler::
 
 jr_006_5DE7:
     dec  [hl]                                     ; $5DE7: $35
-    ldh  a, [hMultiPurpose1]                           ; $5DE8: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5DE8: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $5DEA: $21 $40 $C2
     add  hl, bc                                   ; $5DED: $09
     sub  [hl]                                     ; $5DEE: $96
@@ -284,7 +284,7 @@ CrowState3Handler::
 
     ld   a, $20                                   ; $5E20: $3E $20
     call GetVectorTowardsLink_trampoline          ; $5E22: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $5E25: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5E25: $F0 $D7
     cpl                                           ; $5E27: $2F
     inc  a                                        ; $5E28: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $5E29: $21 $50 $C2
@@ -298,7 +298,7 @@ CrowState3Handler::
 
 jr_006_5E34:
     dec  [hl]                                     ; $5E34: $35
-    ldh  a, [hMultiPurpose1]                           ; $5E35: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5E35: $F0 $D8
     cpl                                           ; $5E37: $2F
     inc  a                                        ; $5E38: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $5E39: $21 $40 $C2

--- a/src/code/entities/cucco.asm
+++ b/src/code/entities/cucco.asm
@@ -253,13 +253,13 @@ func_005_46AF::
 
     ld   a, $0C                                   ; $46BB: $3E $0C
     call GetVectorTowardsLink_trampoline          ; $46BD: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $46C0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $46C0: $F0 $D7
     cpl                                           ; $46C2: $2F
     inc  a                                        ; $46C3: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $46C4: $21 $50 $C2
     add  hl, bc                                   ; $46C7: $09
     ld   [hl], a                                  ; $46C8: $77
-    ldh  a, [hMultiPurpose1]                           ; $46C9: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $46C9: $F0 $D8
     cpl                                           ; $46CB: $2F
     inc  a                                        ; $46CC: $3C
 

--- a/src/code/entities/cue_ball.asm
+++ b/src/code/entities/cue_ball.asm
@@ -237,14 +237,14 @@ jr_006_4CCE:
     ld   c, a                                     ; $4CE3: $4F
     ld   hl, Data_006_4BF8                        ; $4CE4: $21 $F8 $4B
     add  hl, bc                                   ; $4CE7: $09
-    ldh  a, [hMultiPurpose0]                           ; $4CE8: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4CE8: $F0 $D7
     add  [hl]                                     ; $4CEA: $86
     ld   hl, wEntitiesPosXTable                   ; $4CEB: $21 $00 $C2
     add  hl, de                                   ; $4CEE: $19
     ld   [hl], a                                  ; $4CEF: $77
     ld   hl, Data_006_4C00                        ; $4CF0: $21 $00 $4C
     add  hl, bc                                   ; $4CF3: $09
-    ldh  a, [hMultiPurpose1]                           ; $4CF4: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4CF4: $F0 $D8
     add  [hl]                                     ; $4CF6: $86
     ld   hl, wEntitiesPosYTable                   ; $4CF7: $21 $10 $C2
     add  hl, de                                   ; $4CFA: $19

--- a/src/code/entities/desert_lanmola.asm
+++ b/src/code/entities/desert_lanmola.asm
@@ -79,15 +79,15 @@ func_006_564B::
     call label_27DD                               ; $5650: $CD $DD $27
     ld   a, $30                                   ; $5653: $3E $30
     call SpawnNewEntity_trampoline                ; $5655: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $5658: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5658: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $565A: $21 $00 $C2
     add  hl, de                                   ; $565D: $19
     ld   [hl], a                                  ; $565E: $77
-    ldh  a, [hMultiPurpose1]                           ; $565F: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $565F: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5661: $21 $10 $C2
     add  hl, de                                   ; $5664: $19
     ld   [hl], a                                  ; $5665: $77
-    ldh  a, [hMultiPurpose3]                           ; $5666: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $5666: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $5668: $21 $10 $C3
     add  hl, de                                   ; $566B: $19
     ld   [hl], a                                  ; $566C: $77
@@ -102,7 +102,7 @@ func_006_564B::
     ld   [hl], $10                                ; $567D: $36 $10
     call ClearEntityStatus_06                     ; $567F: $CD $DB $65
     ldh  a, [hActiveEntityPosX]                   ; $5682: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $5684: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5684: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $5686: $F0 $EC
     jr   jr_006_56BB                              ; $5688: $18 $31
 
@@ -126,7 +126,7 @@ jr_006_568A:
     ld   hl, wIsFileSelectionArrowShifted         ; $56A1: $21 $00 $D0
     add  hl, de                                   ; $56A4: $19
     ld   a, [hl]                                  ; $56A5: $7E
-    ldh  [hMultiPurpose0], a                           ; $56A6: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $56A6: $E0 $D7
     ld   hl, $D200                                ; $56A8: $21 $00 $D2
     add  hl, de                                   ; $56AB: $19
     ld   a, [hl]                                  ; $56AC: $7E
@@ -142,7 +142,7 @@ jr_006_568A:
     ld   [hl], $FF                                ; $56B9: $36 $FF
 
 jr_006_56BB:
-    ldh  [hMultiPurpose1], a                           ; $56BB: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $56BB: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $56BD: $3E $02
     call AddTranscientVfx                         ; $56BF: $CD $C7 $0C
     ld   a, $13                                   ; $56C2: $3E $13
@@ -487,7 +487,7 @@ jr_006_58D8:
     ld   hl, wEntitiesUnknowTableY                ; $58D8: $21 $D0 $C3
     add  hl, bc                                   ; $58DB: $09
     ld   a, [hl]                                  ; $58DC: $7E
-    ldh  [hMultiPurpose0], a                           ; $58DD: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $58DD: $E0 $D7
     ldh  a, [hFrameCounter]                       ; $58DF: $F0 $E7
     and  $01                                      ; $58E1: $E6 $01
     jr   z, jr_006_58ED                           ; $58E3: $28 $08
@@ -508,7 +508,7 @@ jr_006_58F3:
     ld   d, b                                     ; $58F6: $50
     ld   hl, Data_006_58C3                        ; $58F7: $21 $C3 $58
     add  hl, de                                   ; $58FA: $19
-    ldh  a, [hMultiPurpose0]                           ; $58FB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $58FB: $F0 $D7
     sub  [hl]                                     ; $58FD: $96
     and  $FF                                      ; $58FE: $E6 $FF
     ld   e, a                                     ; $5900: $5F

--- a/src/code/entities/dodongo_snake.asm
+++ b/src/code/entities/dodongo_snake.asm
@@ -95,7 +95,7 @@ jr_005_689B:
     inc  a                                        ; $68A0: $3C
     and  $3F                                      ; $68A1: $E6 $3F
     ld   [hl], a                                  ; $68A3: $77
-    ldh  [hMultiPurpose0], a                           ; $68A4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $68A4: $E0 $D7
     rra                                           ; $68A6: $1F
     rra                                           ; $68A7: $1F
     nop                                           ; $68A8: $00
@@ -127,7 +127,7 @@ jr_005_689B:
     push de                                       ; $68D5: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $68D6: $21 $00 $D0
     add  hl, de                                   ; $68D9: $19
-    ldh  a, [hMultiPurpose0]                           ; $68DA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $68DA: $F0 $D7
     ld   e, a                                     ; $68DC: $5F
     add  hl, de                                   ; $68DD: $19
     ldh  a, [hActiveEntityPosX]                   ; $68DE: $F0 $EE
@@ -135,7 +135,7 @@ jr_005_689B:
     pop  de                                       ; $68E1: $D1
     ld   hl, wD100                                ; $68E2: $21 $00 $D1
     add  hl, de                                   ; $68E5: $19
-    ldh  a, [hMultiPurpose0]                           ; $68E6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $68E6: $F0 $D7
     ld   e, a                                     ; $68E8: $5F
     add  hl, de                                   ; $68E9: $19
     ldh  a, [hActiveEntityVisualPosY]             ; $68EA: $F0 $EC
@@ -304,12 +304,12 @@ jr_005_69CB:
     add  hl, de                                   ; $69D6: $19
     ldh  a, [hActiveEntityPosX]                   ; $69D7: $F0 $EE
     add  [hl]                                     ; $69D9: $86
-    ldh  [hMultiPurpose0], a                           ; $69DA: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $69DA: $E0 $D7
     ld   hl, Data_005_69AD                        ; $69DC: $21 $AD $69
     add  hl, de                                   ; $69DF: $19
     ldh  a, [hActiveEntityVisualPosY]             ; $69E0: $F0 $EC
     add  [hl]                                     ; $69E2: $86
-    ldh  [hMultiPurpose1], a                           ; $69E3: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $69E3: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $69E5: $3E $02
     call AddTranscientVfx                         ; $69E7: $CD $C7 $0C
     xor  a                                        ; $69EA: $AF
@@ -337,14 +337,14 @@ jr_005_69EB:
     ld   c, [hl]                                  ; $6A07: $4E
     ld   hl, Data_005_69A1                        ; $6A08: $21 $A1 $69
     add  hl, bc                                   ; $6A0B: $09
-    ldh  a, [hMultiPurpose0]                           ; $6A0C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A0C: $F0 $D7
     add  [hl]                                     ; $6A0E: $86
     ld   hl, wEntitiesPosXTable                   ; $6A0F: $21 $00 $C2
     add  hl, de                                   ; $6A12: $19
     ld   [hl], a                                  ; $6A13: $77
     ld   hl, Data_005_69A5                        ; $6A14: $21 $A5 $69
     add  hl, bc                                   ; $6A17: $09
-    ldh  a, [hMultiPurpose1]                           ; $6A18: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6A18: $F0 $D8
     add  [hl]                                     ; $6A1A: $86
     ld   hl, wEntitiesPosYTable                   ; $6A1B: $21 $10 $C2
     add  hl, de                                   ; $6A1E: $19
@@ -382,7 +382,7 @@ func_005_6A5F::
     ld   hl, wEntitiesUnknowTableY                ; $6A5F: $21 $D0 $C3
     add  hl, bc                                   ; $6A62: $09
     ld   a, [hl]                                  ; $6A63: $7E
-    ldh  [hMultiPurpose0], a                           ; $6A64: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6A64: $E0 $D7
     push bc                                       ; $6A66: $C5
     ld   hl, wEntitiesLoadOrderTable              ; $6A67: $21 $60 $C4
     add  hl, bc                                   ; $6A6A: $09
@@ -400,7 +400,7 @@ func_005_6A5F::
     push de                                       ; $6A7E: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $6A7F: $21 $00 $D0
     add  hl, de                                   ; $6A82: $19
-    ldh  a, [hMultiPurpose0]                           ; $6A83: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A83: $F0 $D7
     sub  c                                        ; $6A85: $91
     and  $3F                                      ; $6A86: $E6 $3F
     ld   e, a                                     ; $6A88: $5F
@@ -411,7 +411,7 @@ func_005_6A5F::
     pop  de                                       ; $6A8E: $D1
     ld   hl, wD100                                ; $6A8F: $21 $00 $D1
     add  hl, de                                   ; $6A92: $19
-    ldh  a, [hMultiPurpose0]                           ; $6A93: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A93: $F0 $D7
     sub  c                                        ; $6A95: $91
     and  $3F                                      ; $6A96: $E6 $3F
     ld   e, a                                     ; $6A98: $5F
@@ -427,7 +427,7 @@ func_005_6AA5::
     ld   hl, wEntitiesUnknowTableY                ; $6AA5: $21 $D0 $C3
     add  hl, bc                                   ; $6AA8: $09
     ld   a, [hl]                                  ; $6AA9: $7E
-    ldh  [hMultiPurpose0], a                           ; $6AAA: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6AAA: $E0 $D7
     push bc                                       ; $6AAC: $C5
     ld   hl, wEntitiesLoadOrderTable              ; $6AAD: $21 $60 $C4
     add  hl, bc                                   ; $6AB0: $09
@@ -445,7 +445,7 @@ func_005_6AA5::
     push de                                       ; $6AC4: $D5
     ld   hl, wIsFileSelectionArrowShifted         ; $6AC5: $21 $00 $D0
     add  hl, de                                   ; $6AC8: $19
-    ldh  a, [hMultiPurpose0]                           ; $6AC9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6AC9: $F0 $D7
     sub  c                                        ; $6ACB: $91
     and  $3F                                      ; $6ACC: $E6 $3F
     ld   e, a                                     ; $6ACE: $5F
@@ -456,7 +456,7 @@ func_005_6AA5::
     pop  de                                       ; $6AD4: $D1
     ld   hl, wD100                                ; $6AD5: $21 $00 $D1
     add  hl, de                                   ; $6AD8: $19
-    ldh  a, [hMultiPurpose0]                           ; $6AD9: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6AD9: $F0 $D7
     sub  c                                        ; $6ADB: $91
     and  $3F                                      ; $6ADC: $E6 $3F
     ld   e, a                                     ; $6ADE: $5F

--- a/src/code/entities/entities_8c_8d.asm
+++ b/src/code/entities/entities_8c_8d.asm
@@ -76,9 +76,9 @@ jr_006_4EF2:
     ld   [wC13E], a                               ; $4EFD: $EA $3E $C1
     ld   a, $10                                   ; $4F00: $3E $10
     call GetVectorTowardsLink_trampoline          ; $4F02: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4F05: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4F05: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $4F07: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $4F09: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4F09: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $4F0B: $E0 $9A
 
 jr_006_4F0D:

--- a/src/code/entities/evil_eagle.asm
+++ b/src/code/entities/evil_eagle.asm
@@ -113,12 +113,12 @@ jr_005_5AA7:
     ld   c, a                                     ; $5AB1: $4F
     ld   hl, Data_005_5A7D                        ; $5AB2: $21 $7D $5A
     add  hl, bc                                   ; $5AB5: $09
-    ldh  a, [hMultiPurpose0]                           ; $5AB6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5AB6: $F0 $D7
     add  [hl]                                     ; $5AB8: $86
     ld   hl, wEntitiesPosXTable                   ; $5AB9: $21 $00 $C2
     add  hl, de                                   ; $5ABC: $19
     ld   [hl], a                                  ; $5ABD: $77
-    ldh  a, [hMultiPurpose1]                           ; $5ABE: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5ABE: $F0 $D8
     sub  $10                                      ; $5AC0: $D6 $10
     ld   hl, wEntitiesPosYTable                   ; $5AC2: $21 $10 $C2
     add  hl, de                                   ; $5AC5: $19
@@ -848,12 +848,12 @@ jr_005_5EB0:
     srl  c                                        ; $5ED7: $CB $39
     ld   hl, Data_005_5E1B                        ; $5ED9: $21 $1B $5E
     add  hl, bc                                   ; $5EDC: $09
-    ldh  a, [hMultiPurpose0]                           ; $5EDD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $5EDD: $F0 $D7
     add  [hl]                                     ; $5EDF: $86
     ld   hl, wEntitiesPosXTable                   ; $5EE0: $21 $00 $C2
     add  hl, de                                   ; $5EE3: $19
     ld   [hl], a                                  ; $5EE4: $77
-    ldh  a, [hMultiPurpose1]                           ; $5EE5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5EE5: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $5EE7: $21 $10 $C2
     add  hl, de                                   ; $5EEA: $19
     add  $0C                                      ; $5EEB: $C6 $0C

--- a/src/code/entities/gel.asm
+++ b/src/code/entities/gel.asm
@@ -97,16 +97,16 @@ jr_006_7C6A:
     ld   hl, wEntitiesLoadOrderTable              ; $7C95: $21 $60 $C4
     add  hl, de                                   ; $7C98: $19
     ld   [hl], a                                  ; $7C99: $77
-    ldh  a, [hMultiPurpose0]                           ; $7C9A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7C9A: $F0 $D7
     add  $08                                      ; $7C9C: $C6 $08
     ld   hl, wEntitiesPosXTable                   ; $7C9E: $21 $00 $C2
     add  hl, de                                   ; $7CA1: $19
     ld   [hl], a                                  ; $7CA2: $77
-    ldh  a, [hMultiPurpose1]                           ; $7CA3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7CA3: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7CA5: $21 $10 $C2
     add  hl, de                                   ; $7CA8: $19
     ld   [hl], a                                  ; $7CA9: $77
-    ldh  a, [hMultiPurpose3]                           ; $7CAA: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $7CAA: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $7CAC: $21 $10 $C3
     add  hl, de                                   ; $7CAF: $19
     ld   [hl], a                                  ; $7CB0: $77

--- a/src/code/entities/genie.asm
+++ b/src/code/entities/genie.asm
@@ -29,11 +29,11 @@ GenieState0Handler::
     ld   a, ENTITY_GENIE                          ; $401F: $3E $5C
     call SpawnNewEntity_trampoline                ; $4021: $CD $86 $3B
 
-    ldh  a, [hMultiPurpose0]                           ; $4024: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4024: $F0 $D7
     ld   hl, wEntitiesPosXTable                         ; $4026: $21 $00 $C2
     add  hl, de                                   ; $4029: $19
     ld   [hl], a                                  ; $402A: $77
-    ldh  a, [hMultiPurpose1]                           ; $402B: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $402B: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $402D: $21 $10 $C2
     add  hl, de                                   ; $4030: $19
     sub  $18                                      ; $4031: $D6 $18

--- a/src/code/entities/ghoma.asm
+++ b/src/code/entities/ghoma.asm
@@ -426,11 +426,11 @@ jr_005_7E3A:
     call SpawnNewEntity_trampoline                ; $7E40: $CD $86 $3B
     jr   c, jr_005_7E61                           ; $7E43: $38 $1C
 
-    ldh  a, [hMultiPurpose0]                           ; $7E45: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7E45: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $7E47: $21 $00 $C2
     add  hl, de                                   ; $7E4A: $19
     ld   [hl], a                                  ; $7E4B: $77
-    ldh  a, [hMultiPurpose1]                           ; $7E4C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7E4C: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7E4E: $21 $10 $C2
     add  hl, de                                   ; $7E51: $19
     ld   [hl], a                                  ; $7E52: $77

--- a/src/code/entities/giant_goponga_flower.asm
+++ b/src/code/entities/giant_goponga_flower.asm
@@ -45,11 +45,11 @@ jr_006_62EF:
     call SpawnNewEntity_trampoline                ; $62F5: $CD $86 $3B
     jr   c, jr_006_6311                           ; $62F8: $38 $17
 
-    ldh  a, [hMultiPurpose0]                           ; $62FA: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $62FA: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $62FC: $21 $00 $C2
     add  hl, de                                   ; $62FF: $19
     ld   [hl], a                                  ; $6300: $77
-    ldh  a, [hMultiPurpose1]                           ; $6301: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6301: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $6303: $21 $10 $C2
     add  hl, de                                   ; $6306: $19
     ld   [hl], a                                  ; $6307: $77

--- a/src/code/entities/hard_hat_beetle.asm
+++ b/src/code/entities/hard_hat_beetle.asm
@@ -35,7 +35,7 @@ jr_006_4F48:
     and  $07                                      ; $4F6F: $E6 $07
     add  $04                                      ; $4F71: $C6 $04
     call GetVectorTowardsLink_trampoline          ; $4F73: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4F76: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4F76: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $4F78: $21 $50 $C2
     call func_006_4FA3                            ; $4F7B: $CD $A3 $4F
     ld   hl, wEntitiesCollisionsTable             ; $4F7E: $21 $A0 $C2
@@ -49,7 +49,7 @@ jr_006_4F48:
     ld   [hl], b                                  ; $4F8B: $70
 
 jr_006_4F8C:
-    ldh  a, [hMultiPurpose1]                           ; $4F8C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4F8C: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $4F8E: $21 $40 $C2
     call func_006_4FA3                            ; $4F91: $CD $A3 $4F
     ld   hl, wEntitiesCollisionsTable             ; $4F94: $21 $A0 $C2

--- a/src/code/entities/hinox.asm
+++ b/src/code/entities/hinox.asm
@@ -220,10 +220,10 @@ jr_006_5102:
     jr   nz, jr_006_5117                          ; $5106: $20 $0F
 
     ldh  a, [hActiveEntityPosX]                   ; $5108: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $510A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $510A: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $510C: $F0 $EC
     add  $0A                                      ; $510E: $C6 $0A
-    ldh  [hMultiPurpose1], a                           ; $5110: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5110: $E0 $D8
     ld   a, TRANSCIENT_VFX_PEGASUS_DUST           ; $5112: $3E $0B
     call AddTranscientVfx                         ; $5114: $CD $C7 $0C
 
@@ -347,12 +347,12 @@ jr_006_51D0:
     call SpawnNewEntity_trampoline                ; $51D6: $CD $86 $3B
     jr   c, jr_006_51F6                           ; $51D9: $38 $1B
 
-    ldh  a, [hMultiPurpose0]                           ; $51DB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $51DB: $F0 $D7
     sub  $0C                                      ; $51DD: $D6 $0C
     ld   hl, wEntitiesPosXTable                   ; $51DF: $21 $00 $C2
     add  hl, de                                   ; $51E2: $19
     ld   [hl], a                                  ; $51E3: $77
-    ldh  a, [hMultiPurpose1]                           ; $51E4: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $51E4: $F0 $D8
     sub  $00                                      ; $51E6: $D6 $00
     ld   hl, wEntitiesPosYTable                   ; $51E8: $21 $10 $C2
     add  hl, de                                   ; $51EB: $19

--- a/src/code/entities/hookshot_chain.asm
+++ b/src/code/entities/hookshot_chain.asm
@@ -57,11 +57,11 @@ ENDC
 jr_018_7C21:
     ld   a, $30                                   ; $7C21: $3E $30
     call GetVectorTowardsLink_trampoline          ; $7C23: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7C26: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7C26: $F0 $D7
     cpl                                           ; $7C28: $2F
     inc  a                                        ; $7C29: $3C
     ldh  [hLinkPositionYIncrement], a             ; $7C2A: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $7C2C: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7C2C: $F0 $D8
     cpl                                           ; $7C2E: $2F
     inc  a                                        ; $7C2F: $3C
     ldh  [hLinkPositionXIncrement], a             ; $7C30: $E0 $9A
@@ -155,8 +155,8 @@ jr_018_7CAF:
     ld   a, JINGLE_SWORD_POKING                   ; $7CB3: $3E $07
     ldh  [hJingle], a                             ; $7CB5: $E0 $F2
     ldh  a, [hActiveEntityPosX]                   ; $7CB7: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $7CB9: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7CB9: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7CBB: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7CBD: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7CBD: $E0 $D8
     ld   a, TRANSCIENT_VFX_SWORD_POKE             ; $7CBF: $3E $05
     jp   AddTranscientVfx                         ; $7CC1: $C3 $C7 $0C

--- a/src/code/entities/hookshot_hit.asm
+++ b/src/code/entities/hookshot_hit.asm
@@ -57,10 +57,10 @@ jr_003_69F8:
     call func_014_5526_trampoline                 ; $6A05: $CD $78 $21
     ldh  a, [hSwordIntersectedAreaX]              ; $6A08: $F0 $CE
     add  $08                                      ; $6A0A: $C6 $08
-    ldh  [hMultiPurpose0], a                           ; $6A0C: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6A0C: $E0 $D7
     ldh  a, [hSwordIntersectedAreaY]              ; $6A0E: $F0 $CD
     add  $10                                      ; $6A10: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $6A12: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6A12: $E0 $D8
     ld   a, $08                                   ; $6A14: $3E $08
     call AddTranscientVfx                         ; $6A16: $CD $C7 $0C
     ld   a, $13                                   ; $6A19: $3E $13

--- a/src/code/entities/hot_head.asm
+++ b/src/code/entities/hot_head.asm
@@ -183,16 +183,16 @@ func_005_63EB::
     ld   [hl], $40                                ; $6421: $36 $40
     ldh  a, [hActiveEntityPosX]                   ; $6423: $F0 $EE
     add  $F8                                      ; $6425: $C6 $F8
-    ldh  [hMultiPurpose0], a                           ; $6427: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6427: $E0 $D7
     call func_005_6432                            ; $6429: $CD $32 $64
     ldh  a, [hActiveEntityPosX]                   ; $642C: $F0 $EE
     add  $08                                      ; $642E: $C6 $08
-    ldh  [hMultiPurpose0], a                           ; $6430: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6430: $E0 $D7
 
 func_005_6432::
     ldh  a, [hActiveEntityVisualPosY]             ; $6432: $F0 $EC
     sub  $10                                      ; $6434: $D6 $10
-    ldh  [hMultiPurpose1], a                           ; $6436: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6436: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $6438: $3E $02
     call AddTranscientVfx                         ; $643A: $CD $C7 $0C
     ld   hl, wTranscientVfxCountdownTable                                ; $643D: $21 $20 $C5
@@ -367,9 +367,9 @@ jr_005_6522:
     ret  nz                                       ; $6526: $C0
 
     ldh  a, [hActiveEntityPosX]                   ; $6527: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6529: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6529: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $652B: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $652D: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $652D: $E0 $D8
     ld   a, TRANSCIENT_VFX_LAVA_SPLASH            ; $652F: $3E $0A
     jp   AddTranscientVfx                         ; $6531: $C3 $C7 $0C
 
@@ -451,16 +451,16 @@ jr_005_6581:
     ld   c, a                                     ; $6593: $4F
     ld   hl, Data_005_657A                        ; $6594: $21 $7A $65
     add  hl, bc                                   ; $6597: $09
-    ldh  a, [hMultiPurpose0]                           ; $6598: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6598: $F0 $D7
     add  [hl]                                     ; $659A: $86
     ld   hl, wEntitiesPosXTable                   ; $659B: $21 $00 $C2
     add  hl, de                                   ; $659E: $19
     ld   [hl], a                                  ; $659F: $77
-    ldh  a, [hMultiPurpose1]                           ; $65A0: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $65A0: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $65A2: $21 $10 $C2
     add  hl, de                                   ; $65A5: $19
     ld   [hl], a                                  ; $65A6: $77
-    ldh  a, [hMultiPurpose3]                           ; $65A7: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $65A7: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $65A9: $21 $10 $C3
     add  hl, de                                   ; $65AC: $19
     ld   [hl], a                                  ; $65AD: $77
@@ -501,11 +501,11 @@ func_005_65D9::
     ld   hl, wEntitiesPrivateState1Table          ; $65E0: $21 $B0 $C2
     add  hl, de                                   ; $65E3: $19
     ld   [hl], $01                                ; $65E4: $36 $01
-    ldh  a, [hMultiPurpose0]                           ; $65E6: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $65E6: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $65E8: $21 $00 $C2
     add  hl, de                                   ; $65EB: $19
     ld   [hl], a                                  ; $65EC: $77
-    ldh  a, [hMultiPurpose1]                           ; $65ED: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $65ED: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $65EF: $21 $10 $C2
     add  hl, de                                   ; $65F2: $19
     ld   [hl], a                                  ; $65F3: $77
@@ -545,14 +545,14 @@ jr_005_6613:
     ld   c, a                                     ; $6625: $4F
     ld   hl, Data_005_6600                        ; $6626: $21 $00 $66
     add  hl, bc                                   ; $6629: $09
-    ldh  a, [hMultiPurpose0]                           ; $662A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $662A: $F0 $D7
     add  [hl]                                     ; $662C: $86
     ld   hl, wEntitiesPosXTable                   ; $662D: $21 $00 $C2
     add  hl, de                                   ; $6630: $19
     ld   [hl], a                                  ; $6631: $77
     ld   hl, Data_005_6604                        ; $6632: $21 $04 $66
     add  hl, bc                                   ; $6635: $09
-    ldh  a, [hMultiPurpose1]                           ; $6636: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6636: $F0 $D8
     add  [hl]                                     ; $6638: $86
     ld   hl, wEntitiesPosYTable                   ; $6639: $21 $10 $C2
     add  hl, de                                   ; $663C: $19

--- a/src/code/entities/kid_71_72.asm
+++ b/src/code/entities/kid_71_72.asm
@@ -219,11 +219,11 @@ func_006_61A6::
     call SpawnNewEntity_trampoline                ; $61B7: $CD $86 $3B
     jr   c, jr_006_61EB                           ; $61BA: $38 $2F
 
-    ldh  a, [hMultiPurpose0]                           ; $61BC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $61BC: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $61BE: $21 $00 $C2
     add  hl, de                                   ; $61C1: $19
     ld   [hl], a                                  ; $61C2: $77
-    ldh  a, [hMultiPurpose1]                           ; $61C3: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $61C3: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $61C5: $21 $10 $C2
     add  hl, de                                   ; $61C8: $19
     ld   [hl], a                                  ; $61C9: $77

--- a/src/code/entities/liftable_rock.asm
+++ b/src/code/entities/liftable_rock.asm
@@ -2,7 +2,7 @@ LiftableRockEntityHandler::
     ld   a, c                                     ; $5328: $79
     ld   [wC50C], a                               ; $5329: $EA $0C $C5
     call GetEntityPrivateCountdown1                                      ; $532C: $CD $00 $0C
-    ldh  [hMultiPurpose0], a                           ; $532F: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $532F: $E0 $D7
     jp   z, jp_003_53A8                           ; $5331: $CA $A8 $53
 
     cp   $01                                      ; $5334: $FE $01
@@ -22,15 +22,15 @@ LiftableRockEntityHandler::
     call SpawnNewEntity                           ; $5349: $CD $CA $64
     jr   c, jr_003_5369                           ; $534C: $38 $1B
 
-    ldh  a, [hMultiPurpose0]                           ; $534E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $534E: $F0 $D7
     ld   hl, wEntitiesPosXTable                         ; $5350: $21 $00 $C2
     add  hl, de                                   ; $5353: $19
     ld   [hl], a                                  ; $5354: $77
-    ldh  a, [hMultiPurpose1]                           ; $5355: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $5355: $F0 $D8
     ld   hl, wEntitiesPosYTable                         ; $5357: $21 $10 $C2
     add  hl, de                                   ; $535A: $19
     ld   [hl], a                                  ; $535B: $77
-    ldh  a, [hMultiPurpose3]                           ; $535C: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $535C: $F0 $DA
     ld   hl, wEntitiesPosZTable                                ; $535E: $21 $10 $C3
     add  hl, de                                   ; $5361: $19
     ld   [hl], a                                  ; $5362: $77

--- a/src/code/entities/mad_bomber.asm
+++ b/src/code/entities/mad_bomber.asm
@@ -107,11 +107,11 @@ MadBomberState3Handler::
 
     ld   a, $02                                   ; $41DF: $3E $02
     call SpawnNewEntity_trampoline                ; $41E1: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $41E4: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $41E4: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $41E6: $21 $00 $C2
     add  hl, de                                   ; $41E9: $19
     ld   [hl], a                                  ; $41EA: $77
-    ldh  a, [hMultiPurpose1]                           ; $41EB: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $41EB: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $41ED: $21 $10 $C2
     add  hl, de                                   ; $41F0: $19
     ld   [hl], a                                  ; $41F1: $77

--- a/src/code/entities/marin.asm
+++ b/src/code/entities/marin.asm
@@ -115,7 +115,7 @@ MarinCreditsHandler:
     call SpawnNewEntity_trampoline                ; $4EFB: $CD $86 $3B
     jr   c, jr_005_4F39                           ; $4EFE: $38 $39
 
-    ldh  a, [hMultiPurpose1]                           ; $4F00: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4F00: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4F02: $21 $10 $C2
     add  hl, de                                   ; $4F05: $19
     sub  $08                                      ; $4F06: $D6 $08
@@ -132,7 +132,7 @@ MarinCreditsHandler:
     ld   c, a                                     ; $4F15: $4F
     ld   hl, Data_005_4E5E                        ; $4F16: $21 $5E $4E
     add  hl, bc                                   ; $4F19: $09
-    ldh  a, [hMultiPurpose0]                           ; $4F1A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4F1A: $F0 $D7
     add  [hl]                                     ; $4F1C: $86
     ld   hl, wEntitiesPosXTable                   ; $4F1D: $21 $00 $C2
     add  hl, de                                   ; $4F20: $19

--- a/src/code/entities/mr_write_bird.asm
+++ b/src/code/entities/mr_write_bird.asm
@@ -190,13 +190,13 @@ func_006_7335::
     ld   [hl], $02                                ; $7351: $36 $02
     ld   a, $10                                   ; $7353: $3E $10
     call GetVectorTowardsLink_trampoline          ; $7355: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $7358: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7358: $F0 $D7
     cpl                                           ; $735A: $2F
     inc  a                                        ; $735B: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $735C: $21 $50 $C2
     add  hl, bc                                   ; $735F: $09
     ld   [hl], a                                  ; $7360: $77
-    ldh  a, [hMultiPurpose1]                           ; $7361: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7361: $F0 $D8
     cpl                                           ; $7363: $2F
     inc  a                                        ; $7364: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $7365: $21 $40 $C2

--- a/src/code/entities/owl_event.asm
+++ b/src/code/entities/owl_event.asm
@@ -371,12 +371,12 @@ jr_006_6A0F:
 
     ld   a, $20                                   ; $6A15: $3E $20
     call GetVectorTowardsLink_trampoline          ; $6A17: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $6A1A: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $6A1A: $F0 $D7
     cpl                                           ; $6A1C: $2F
     inc  a                                        ; $6A1D: $3C
     ld   hl, wEntitiesSpeedYTable                 ; $6A1E: $21 $50 $C2
     call func_006_6A2B                            ; $6A21: $CD $2B $6A
-    ldh  a, [hMultiPurpose1]                           ; $6A24: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $6A24: $F0 $D8
     cpl                                           ; $6A26: $2F
     inc  a                                        ; $6A27: $3C
     ld   hl, wEntitiesSpeedXTable                 ; $6A28: $21 $40 $C2

--- a/src/code/entities/racoon.asm
+++ b/src/code/entities/racoon.asm
@@ -182,15 +182,15 @@ jr_005_4A46:
     ld   a, ENTITY_BOMB                           ; $4A59: $3E $02
     call SpawnNewEntity_trampoline                ; $4A5B: $CD $86 $3B
 
-    ldh  a, [hMultiPurpose0]                           ; $4A5E: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4A5E: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $4A60: $21 $00 $C2
     add  hl, de                                   ; $4A63: $19
     ld   [hl], a                                  ; $4A64: $77
-    ldh  a, [hMultiPurpose1]                           ; $4A65: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4A65: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $4A67: $21 $10 $C2
     add  hl, de                                   ; $4A6A: $19
     ld   [hl], a                                  ; $4A6B: $77
-    ldh  a, [hMultiPurpose3]                           ; $4A6C: $F0 $DA
+    ldh  a, [hMultiPurpose3]                      ; $4A6C: $F0 $DA
     ld   hl, wEntitiesPosZTable                   ; $4A6E: $21 $10 $C3
     add  hl, de                                   ; $4A71: $19
     ld   [hl], a                                  ; $4A72: $77
@@ -723,12 +723,12 @@ jr_005_4D5D:
 
     ld   a, $3F                                   ; $4D67: $3E $3F
     call SpawnNewEntity_trampoline                ; $4D69: $CD $86 $3B
-    ldh  a, [hMultiPurpose0]                           ; $4D6C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4D6C: $F0 $D7
     add  $06                                      ; $4D6E: $C6 $06
     ld   hl, wEntitiesPosXTable                   ; $4D70: $21 $00 $C2
     add  hl, de                                   ; $4D73: $19
     ld   [hl], a                                  ; $4D74: $77
-    ldh  a, [hMultiPurpose1]                           ; $4D75: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4D75: $F0 $D8
     sub  $03                                      ; $4D77: $D6 $03
     ld   hl, wEntitiesPosYTable                   ; $4D79: $21 $10 $C2
     add  hl, de                                   ; $4D7C: $19

--- a/src/code/entities/rolling_bones_bar.asm
+++ b/src/code/entities/rolling_bones_bar.asm
@@ -42,7 +42,7 @@ jr_006_6F03:
     ld   hl, wEntitiesPrivateState1Table          ; $6F15: $21 $B0 $C2
     add  hl, bc                                   ; $6F18: $09
     ldh  a, [hActiveEntityPosX]                   ; $6F19: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $6F1B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $6F1B: $E0 $D7
     ld   e, [hl]                                  ; $6F1D: $5E
     inc  [hl]                                     ; $6F1E: $34
     ld   a, [hl]                                  ; $6F1F: $7E
@@ -70,7 +70,7 @@ jr_006_6F3C:
     ld   hl, Data_006_6EDD                        ; $6F3D: $21 $DD $6E
     add  hl, de                                   ; $6F40: $19
     ld   a, [hl]                                  ; $6F41: $7E
-    ldh  [hMultiPurpose1], a                           ; $6F42: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $6F42: $E0 $D8
     jp   label_006_7035                           ; $6F44: $C3 $35 $70
 
 jr_006_6F47:

--- a/src/code/entities/slime_eel.asm
+++ b/src/code/entities/slime_eel.asm
@@ -789,9 +789,9 @@ func_005_7283::
     call label_3B18                               ; $72B9: $CD $18 $3B
     ld   a, $18                                   ; $72BC: $3E $18
     call GetVectorTowardsLink_trampoline          ; $72BE: $CD $B5 $3B
-    ldh  a, [hMultiPurpose0]                           ; $72C1: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $72C1: $F0 $D7
     ldh  [hLinkPositionYIncrement], a             ; $72C3: $E0 $9B
-    ldh  a, [hMultiPurpose1]                           ; $72C5: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $72C5: $F0 $D8
     ldh  [hLinkPositionXIncrement], a             ; $72C7: $E0 $9A
 
 jr_005_72C9:
@@ -1112,11 +1112,11 @@ jr_005_74C5:
     add  hl, de                                   ; $74E8: $19
     ld   a, [hl]                                  ; $74E9: $7E
     call GetVectorTowardsLink_trampoline          ; $74EA: $CD $B5 $3B
-    ldh  a, [hMultiPurpose1]                           ; $74ED: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $74ED: $F0 $D8
     ld   hl, wEntitiesSpeedXTable                 ; $74EF: $21 $40 $C2
     add  hl, bc                                   ; $74F2: $09
     ld   [hl], a                                  ; $74F3: $77
-    ldh  a, [hMultiPurpose0]                           ; $74F4: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $74F4: $F0 $D7
     ld   hl, wEntitiesSpeedYTable                 ; $74F6: $21 $50 $C2
     add  hl, bc                                   ; $74F9: $09
     ld   [hl], a                                  ; $74FA: $77
@@ -1202,9 +1202,9 @@ label_005_7550:
 label_005_7570:
     call func_005_7A40                            ; $7570: $CD $40 $7A
     ldh  a, [hActiveEntityPosX]                   ; $7573: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $7575: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7575: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $7577: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $7579: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7579: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $757B: $3E $02
     call AddTranscientVfx                         ; $757D: $CD $C7 $0C
     ld   a, $13                                   ; $7580: $3E $13
@@ -1220,16 +1220,16 @@ label_005_758C:
     ld   a, ENTITY_HEART_CONTAINER                ; $758C: $3E $36
     call SpawnNewEntity_trampoline                ; $758E: $CD $86 $3B
     ld   a, $48                                   ; $7591: $3E $48
-    ldh  [hMultiPurpose0], a                           ; $7593: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7593: $E0 $D7
     ld   a, $10                                   ; $7595: $3E $10
-    ldh  [hMultiPurpose1], a                           ; $7597: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7597: $E0 $D8
 
 jr_005_7599:
-    ldh  a, [hMultiPurpose1]                           ; $7599: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7599: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $759B: $21 $10 $C2
     add  hl, de                                   ; $759E: $19
     ld   [hl], a                                  ; $759F: $77
-    ldh  a, [hMultiPurpose0]                           ; $75A0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $75A0: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $75A2: $21 $00 $C2
     add  hl, de                                   ; $75A5: $19
     ld   [hl], a                                  ; $75A6: $77
@@ -1283,11 +1283,11 @@ func_005_75D1::
     ld   a, ENTITY_BOMB                           ; $75F4: $3E $02
     call SpawnNewEntity_trampoline                ; $75F6: $CD $86 $3B
     call PlayBombExplosionSfx                     ; $75F9: $CD $4B $0C
-    ldh  a, [hMultiPurpose0]                           ; $75FC: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $75FC: $F0 $D7
     ld   hl, wEntitiesPosXTable                   ; $75FE: $21 $00 $C2
     add  hl, de                                   ; $7601: $19
     ld   [hl], a                                  ; $7602: $77
-    ldh  a, [hMultiPurpose1]                           ; $7603: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7603: $F0 $D8
     ld   hl, wEntitiesPosYTable                   ; $7605: $21 $10 $C2
     add  hl, de                                   ; $7608: $19
     ld   [hl], a                                  ; $7609: $77
@@ -1381,8 +1381,8 @@ func_005_766E::
     ld   hl, wEntitiesUnknowTableY                ; $7687: $21 $D0 $C3
     add  hl, bc                                   ; $768A: $09
     ld   a, [hl]                                  ; $768B: $7E
-    ldh  [hMultiPurpose0], a                           ; $768C: $E0 $D7
-    ldh  a, [hMultiPurpose0]                           ; $768E: $F0 $D7
+    ldh  [hMultiPurpose0], a                      ; $768C: $E0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $768E: $F0 $D7
     sub  $0C                                      ; $7690: $D6 $0C
     and  $7F                                      ; $7692: $E6 $7F
     ld   e, a                                     ; $7694: $5F
@@ -1399,7 +1399,7 @@ func_005_766E::
     ldh  [hActiveEntitySpriteVariant], a          ; $76A6: $E0 $F1
     ld   de, Data_005_72CC                        ; $76A8: $11 $CC $72
     call RenderActiveEntitySpritesPair            ; $76AB: $CD $C0 $3B
-    ldh  a, [hMultiPurpose0]                           ; $76AE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $76AE: $F0 $D7
     sub  $18                                      ; $76B0: $D6 $18
     and  $7F                                      ; $76B2: $E6 $7F
     ld   e, a                                     ; $76B4: $5F
@@ -1416,7 +1416,7 @@ func_005_766E::
     ldh  [hActiveEntitySpriteVariant], a          ; $76C6: $E0 $F1
     ld   de, Data_005_72CC                        ; $76C8: $11 $CC $72
     call RenderActiveEntitySpritesPair            ; $76CB: $CD $C0 $3B
-    ldh  a, [hMultiPurpose0]                           ; $76CE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $76CE: $F0 $D7
     sub  $24                                      ; $76D0: $D6 $24
     and  $7F                                      ; $76D2: $E6 $7F
     ld   e, a                                     ; $76D4: $5F
@@ -1886,7 +1886,7 @@ jr_005_7B22:
 func_005_7B24::
     call func_005_7B04                            ; $7B24: $CD $04 $7B
     ld   a, e                                     ; $7B27: $7B
-    ldh  [hMultiPurpose0], a                           ; $7B28: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7B28: $E0 $D7
     ld   a, d                                     ; $7B2A: $7A
     bit  7, a                                     ; $7B2B: $CB $7F
     jr   z, jr_005_7B31                           ; $7B2D: $28 $02
@@ -1898,7 +1898,7 @@ jr_005_7B31:
     push af                                       ; $7B31: $F5
     call func_005_7B14                            ; $7B32: $CD $14 $7B
     ld   a, e                                     ; $7B35: $7B
-    ldh  [hMultiPurpose1], a                           ; $7B36: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $7B36: $E0 $D8
     ld   a, d                                     ; $7B38: $7A
     bit  7, a                                     ; $7B39: $CB $7F
     jr   z, jr_005_7B3F                           ; $7B3B: $28 $02
@@ -1911,11 +1911,11 @@ jr_005_7B3F:
     cp   d                                        ; $7B40: $BA
     jr   nc, jr_005_7B47                          ; $7B41: $30 $04
 
-    ldh  a, [hMultiPurpose0]                           ; $7B43: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7B43: $F0 $D7
     jr   jr_005_7B49                              ; $7B45: $18 $02
 
 jr_005_7B47:
-    ldh  a, [hMultiPurpose1]                           ; $7B47: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7B47: $F0 $D8
 
 jr_005_7B49:
     ld   e, a                                     ; $7B49: $5F

--- a/src/code/entities/smasher.asm
+++ b/src/code/entities/smasher.asm
@@ -18,12 +18,12 @@ SmasherEntityHandler::
     call SpawnNewEntity_trampoline                ; $4521: $CD $86 $3B
     ld   a, e                                     ; $4524: $7B
     ld   [$D201], a                               ; $4525: $EA $01 $D2
-    ldh  a, [hMultiPurpose1]                           ; $4528: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4528: $F0 $D8
     add  $10                                      ; $452A: $C6 $10
     ld   hl, wEntitiesPosYTable                   ; $452C: $21 $10 $C2
     add  hl, de                                   ; $452F: $19
     ld   [hl], a                                  ; $4530: $77
-    ldh  a, [hMultiPurpose0]                           ; $4531: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4531: $F0 $D7
     add  $30                                      ; $4533: $C6 $30
     ld   hl, wEntitiesPosXTable                   ; $4535: $21 $00 $C2
     add  hl, de                                   ; $4538: $19

--- a/src/code/entities/stalfos_aggressive.asm
+++ b/src/code/entities/stalfos_aggressive.asm
@@ -118,8 +118,8 @@ jr_006_4B53:
     ret  nc                                       ; $4B68: $D0
 
     ldh  a, [hActiveEntityPosX]                   ; $4B69: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $4B6B: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4B6B: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $4B6D: $F0 $EC
     add  $0C                                      ; $4B6F: $C6 $0C
-    ldh  [hMultiPurpose1], a                           ; $4B71: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4B71: $E0 $D8
     jp   label_D15                                ; $4B73: $C3 $15 $0D

--- a/src/code/entities/three_of_a_kind.asm
+++ b/src/code/entities/three_of_a_kind.asm
@@ -114,7 +114,7 @@ ThreeOfAKindState2Handler::
     and  a                                        ; $49D9: $A7
     jp   nz, label_006_4AA7                       ; $49DA: $C2 $A7 $4A
 
-    ldh  [hMultiPurpose0], a                           ; $49DD: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $49DD: $E0 $D7
     ld   e, $0F                                   ; $49DF: $1E $0F
     ld   d, b                                     ; $49E1: $50
 
@@ -143,9 +143,9 @@ jr_006_49E2:
     and  a                                        ; $4A01: $A7
     jr   nz, jr_006_4A09                          ; $4A02: $20 $05
 
-    ldh  a, [hMultiPurpose0]                           ; $4A04: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4A04: $F0 $D7
     inc  a                                        ; $4A06: $3C
-    ldh  [hMultiPurpose0], a                           ; $4A07: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4A07: $E0 $D7
 
 jr_006_4A09:
     dec  e                                        ; $4A09: $1D
@@ -153,7 +153,7 @@ jr_006_4A09:
     cp   $FF                                      ; $4A0B: $FE $FF
     jr   nz, jr_006_49E2                          ; $4A0D: $20 $D3
 
-    ldh  a, [hMultiPurpose0]                           ; $4A0F: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4A0F: $F0 $D7
     cp   $03                                      ; $4A11: $FE $03
     jp   nz, label_006_4AA7                       ; $4A13: $C2 $A7 $4A
 
@@ -192,7 +192,7 @@ jr_006_4A37:
     pop  bc                                       ; $4A3D: $C1
     call PlayWrongAnswerJingle                    ; $4A3E: $CD $20 $0C
     ld   e, $00                                   ; $4A41: $1E $00
-    ldh  a, [hMultiPurpose2]                           ; $4A43: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $4A43: $F0 $D9
     ld   hl, hMultiPurpose3                            ; $4A45: $21 $DA $FF
     cp   [hl]                                     ; $4A48: $BE
     jr   nz, jr_006_4A62                          ; $4A49: $20 $17

--- a/src/code/entities/wizrobe.asm
+++ b/src/code/entities/wizrobe.asm
@@ -150,14 +150,14 @@ jr_006_76E9:
     jr   c, jr_006_772D                           ; $76EE: $38 $3D
 
     push bc                                       ; $76F0: $C5
-    ldh  a, [hMultiPurpose2]                           ; $76F1: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $76F1: $F0 $D9
     ld   hl, wEntitiesDirectionTable              ; $76F3: $21 $80 $C3
     add  hl, de                                   ; $76F6: $19
     ld   [hl], a                                  ; $76F7: $77
     ld   c, a                                     ; $76F8: $4F
     ld   hl, Data_006_7618                        ; $76F9: $21 $18 $76
     add  hl, bc                                   ; $76FC: $09
-    ldh  a, [hMultiPurpose0]                           ; $76FD: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $76FD: $F0 $D7
     add  [hl]                                     ; $76FF: $86
     ld   hl, wEntitiesPosXTable                   ; $7700: $21 $00 $C2
     add  hl, de                                   ; $7703: $19
@@ -166,7 +166,7 @@ jr_006_76E9:
     add  hl, bc                                   ; $7708: $09
 
 label_006_7709:
-    ldh  a, [hMultiPurpose1]                           ; $7709: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7709: $F0 $D8
     add  [hl]                                     ; $770B: $86
     ld   hl, wEntitiesPosYTable                   ; $770C: $21 $10 $C2
     add  hl, de                                   ; $770F: $19
@@ -186,7 +186,7 @@ label_006_7709:
 
 jr_006_7725:
     pop  bc                                       ; $7725: $C1
-    ldh  a, [hMultiPurpose2]                           ; $7726: $F0 $D9
+    ldh  a, [hMultiPurpose2]                      ; $7726: $F0 $D9
     ld   hl, wEntitiesSpriteVariantTable          ; $7728: $21 $B0 $C3
     add  hl, de                                   ; $772B: $19
     ld   [hl], a                                  ; $772C: $77

--- a/src/code/events.asm
+++ b/src/code/events.asm
@@ -119,9 +119,9 @@ DropFairyEffectHandler::
     ld   [hl], $80                                ; $5DDA: $36 $80
 
     ld   a, $88                                   ; $5DDC: $3E $88
-    ldh  [hMultiPurpose0], a                           ; $5DDE: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5DDE: $E0 $D7
     ld   a, $30                                   ; $5DE0: $3E $30
-    ldh  [hMultiPurpose1], a                           ; $5DE2: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5DE2: $E0 $D8
     ld   a, TRANSCIENT_VFX_POOF                   ; $5DE4: $3E $02
     jp   MakeEffectObjectAppear                   ; $5DE6: $C3 $F6 $5D
 
@@ -129,9 +129,9 @@ RevealStairwayEffectHandler::
     call EventEffectGuard                         ; $5DE9: $CD $AF $5D
 
     ld   a, $88                                   ; $5DEC: $3E $88
-    ldh  [hMultiPurpose0], a                           ; $5DEE: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5DEE: $E0 $D7
     ld   a, $20                                   ; $5DF0: $3E $20
-    ldh  [hMultiPurpose1], a                           ; $5DF2: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5DF2: $E0 $D8
     ld   a, TRANSCIENT_VFX_STAIRS_APPEARS         ; $5DF4: $3E $04
 
 MakeEffectObjectAppear::
@@ -273,7 +273,7 @@ Data_002_5EA7::
 RevealChestEffectHandler::
     call EventEffectGuard                         ; $5EAB: $CD $AF $5D
     ld   a, $88                                   ; $5EAE: $3E $88
-    ldh  [hMultiPurpose0], a                           ; $5EB0: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5EB0: $E0 $D7
     ldh  a, [hLinkPositionY]                      ; $5EB2: $F0 $99
     sub  $30                                      ; $5EB4: $D6 $30
     add  $08                                      ; $5EB6: $C6 $08
@@ -293,7 +293,7 @@ jr_002_5ECA:
     ld   a, $30                                   ; $5ECA: $3E $30
 
 jr_002_5ECC:
-    ldh  [hMultiPurpose1], a                           ; $5ECC: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5ECC: $E0 $D8
     ld   a, TRANSCIENT_VFX_CHEST_APPEARS          ; $5ECE: $3E $03
     jp   AddTranscientVfx                         ; $5ED0: $C3 $C7 $0C
 
@@ -432,7 +432,7 @@ func_002_5F5C::
 CheckTriggersResolution::
     ; hMultiPurpose0 = event trigger
     and  EVENT_TRIGGER_MASK                       ; $5F9F: $E6 $1F
-    ldh  [hMultiPurpose0], a                           ; $5FA1: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5FA1: $E0 $D7
     dec  a                                        ; $5FA3: $3D
     JP_TABLE                                      ; $5FA4: $C7
 ._01 dw CheckKillEnemiesTrigger
@@ -660,7 +660,7 @@ jr_002_60BD:
     and  $0F                                      ; $60BF: $E6 $0F
     jr   nz, jr_002_609B                          ; $60C1: $20 $D8
 
-    ldh  a, [hMultiPurpose0]                           ; $60C3: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $60C3: $F0 $D7
     cp   $02                                      ; $60C5: $FE $02
     ret  nz                                       ; $60C7: $C0
 

--- a/src/code/file_menus.asm
+++ b/src/code/file_menus.asm
@@ -116,7 +116,7 @@ func_4852::
     ld   a, $05                                   ; $486B: $3E $05
 
 .loop
-    ldh  [hMultiPurpose0], a                           ; $486D: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $486D: $E0 $D7
     ld   a, [de]                                  ; $486F: $1A
     and  a                                        ; $4870: $A7
     ld   a, $7E                                   ; $4871: $3E $7E
@@ -134,7 +134,7 @@ func_4852::
 
     ldi  [hl], a                                  ; $4881: $22
     inc  de                                       ; $4882: $13
-    ldh  a, [hMultiPurpose0]                           ; $4883: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4883: $F0 $D7
     dec  a                                        ; $4885: $3D
     jr   nz, .loop                                ; $4886: $20 $E5
     ld   a, b                                     ; $4888: $78
@@ -148,7 +148,7 @@ func_4852::
     ld   a, $05                                   ; $4892: $3E $05
 
 jr_001_4894::
-    ldh  [hMultiPurpose0], a                           ; $4894: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4894: $E0 $D7
     ld   a, [de]                                  ; $4896: $1A
     and  a                                        ; $4897: $A7
 
@@ -198,7 +198,7 @@ ENDC
 jr_001_48A9::
     ldi  [hl], a                                  ; $48A9: $22
     inc  de                                       ; $48AA: $13
-    ldh  a, [hMultiPurpose0]                           ; $48AB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $48AB: $F0 $D7
     dec  a                                        ; $48AD: $3D
     jr   nz, jr_001_4894                          ; $48AE: $20 $E4
     xor  a                                        ; $48B0: $AF
@@ -743,11 +743,11 @@ func_001_4BF5::
     ldh  a, [hJoypadState]                        ; $4BF5: $F0 $CC
 
 jr_001_4BF7::
-    ldh  [hMultiPurpose0], a                           ; $4BF7: $E0 $D7
-    ldh  a, [hMultiPurpose0]                           ; $4BF9: $F0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4BF7: $E0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4BF9: $F0 $D7
     and  $0C                                      ; $4BFB: $E6 $0C
     jr   nz, jr_001_4C41                          ; $4BFD: $20 $42
-    ldh  a, [hMultiPurpose0]                           ; $4BFF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4BFF: $F0 $D7
     and  $03                                      ; $4C01: $E6 $03
     jr   nz, jr_001_4C21                          ; $4C03: $20 $1C
     ldh  a, [hPressedButtonsMask]                 ; $4C05: $F0 $CB
@@ -1037,11 +1037,11 @@ ELSE
     jr   z, jr_001_4DBD                            ; $4DAB: $28 $10 ; $4DAB: $28 $10
 
     xor  a                                        ; $4DAD: $AF ; $4DAD: $AF
-    ldh  [hMultiPurpose4], a                           ; $4DAE: $E0 $DB ; $4DAE: $E0 $DB
+    ldh  [hMultiPurpose4], a                      ; $4DAE: $E0 $DB ; $4DAE: $E0 $DB
     ld   a, [wDC06]                               ; $4DB0: $FA $06 $DC ; $4DB0: $FA $06 $DC
-    ldh  [hMultiPurpose2], a                           ; $4DB3: $E0 $D9 ; $4DB3: $E0 $D9
+    ldh  [hMultiPurpose2], a                      ; $4DB3: $E0 $D9 ; $4DB3: $E0 $D9
     ld   a, [wDC09]                               ; $4DB5: $FA $09 $DC ; $4DB5: $FA $09 $DC
-    ldh  [hMultiPurpose3], a                           ; $4DB8: $E0 $DA ; $4DB8: $E0 $DA
+    ldh  [hMultiPurpose3], a                      ; $4DB8: $E0 $DA ; $4DB8: $E0 $DA
     jp   label_001_5D53                               ; $4DBA: $C3 $53 $5D ; $4DBA: $C3 $53 $5D
 ENDC
 

--- a/src/code/home/animated_tiles.asm
+++ b/src/code/home/animated_tiles.asm
@@ -36,7 +36,7 @@ AnimateMarinBeachTiles::
     jp   CopyData                                 ; $1B02: $C3 $14 $29
     jr   nz, AnimateTiles.doWorldAnimations       ; $1B05: $20 $60
     and  b                                        ; $1B07: $A0
-    ldh  [hMultiPurpose9], a                           ; $1B08: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $1B08: $E0 $E0
     ldh  [hLinkFinalPositionY], a                 ; $1B0A: $E0 $A0
     ld   h, b                                     ; $1B0C: $60
 

--- a/src/code/home/dialog.asm
+++ b/src/code/home/dialog.asm
@@ -171,13 +171,13 @@ label_23EF::
     ld   a, [wBGOriginLow]                        ; $2403: $FA $2F $C1
     add  a, [hl]                                  ; $2406: $86
     ld   l, a                                     ; $2407: $6F
-    ldh  [hMultiPurpose0], a                           ; $2408: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $2408: $E0 $D7
     ld   hl, data_23D6                            ; $240A: $21 $D6 $23
     add  hl, de                                   ; $240D: $19
     ld   a, [wBGOriginHigh]                       ; $240E: $FA $2E $C1
     add  a, [hl]                                  ; $2411: $86
     ld   h, a                                     ; $2412: $67
-    ldh  a, [hMultiPurpose0]                           ; $2413: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $2413: $F0 $D7
     ld   l, a                                     ; $2415: $6F
     xor  a                                        ; $2416: $AF
     ld   e, a                                     ; $2417: $5F
@@ -204,9 +204,9 @@ label_242B::
     cp   $12                                      ; $242D: $FE $12
     jr   nz, label_241E                           ; $242F: $20 $ED
     ld   e, $00                                   ; $2431: $1E $00
-    ldh  a, [hMultiPurpose0]                           ; $2433: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $2433: $F0 $D7
     add  a, $20                                   ; $2435: $C6 $20
-    ldh  [hMultiPurpose0], a                           ; $2437: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $2437: $E0 $D7
     jr   nc, label_243C                           ; $2439: $30 $01
     inc  h                                        ; $243B: $24
 
@@ -251,9 +251,9 @@ label_2464::
     cp   $12                                      ; $2466: $FE $12
     jr   nz, label_2444                           ; $2468: $20 $DA
     ld   e, $00                                   ; $246A: $1E $00
-    ldh  a, [hMultiPurpose0]                           ; $246C: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $246C: $F0 $D7
     add  a, $20                                   ; $246E: $C6 $20
-    ldh  [hMultiPurpose0], a                           ; $2470: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $2470: $E0 $D7
     jr   nc, label_2475                           ; $2472: $30 $01
     inc  h                                        ; $2474: $24
 
@@ -462,7 +462,7 @@ ENDC
     ld   [wC3C3], a ; upcoming character, used in code for the arrow ; $2583: $EA $C3 $C3
     call ReloadSavedBank                          ; $2586: $CD $1D $08
     ld   a, e                                     ; $2589: $7B
-    ldh  [hMultiPurpose0], a                           ; $258A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $258A: $E0 $D7
     cp   "<ask>" ; $fe                            ; $258C: $FE $FE
     jr   nz, .notChoice                           ; $258E: $20 $14
     pop  hl                                       ; $2590: $E1
@@ -555,7 +555,7 @@ ENDR
 .handleNameChar
 
 .notName
-    ldh  [hMultiPurpose1], a                           ; $2608: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $2608: $E0 $D8
     ld   e, a                                     ; $260A: $5F
     ld   a, BANK(AsciiToTileMap)                  ; $260B: $3E $1C
     ld   [MBC3SelectBank], a                      ; $260D: $EA $00 $21
@@ -590,7 +590,7 @@ ENDR
 
     ld   a, BANK(DakutenTable)                    ; $263C: $3E $1C
     ld   [MBC3SelectBank], a ; current character  ; $263E: $EA $00 $21
-    ldh  a, [hMultiPurpose1]                           ; $2641: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $2641: $F0 $D8
     ld   e, a                                     ; $2643: $5F
     ld   d, $00                                   ; $2644: $16 $00
 IF __DO_CHECK_DAKUTEN__
@@ -835,7 +835,7 @@ label_278B::
     jp   UpdateDialogState                        ; $2790: $C3 $96 $24
 
 DialogChoiceHandler::
-    ; Was A pushed? 
+    ; Was A pushed?
     ldh  a, [hJoypadState]                        ; $2793: $F0 $CC
     bit  J_BIT_A, a                               ; $2795: $CB $67
     jp   nz, .jp_27B7                             ; $2797: $C2 $B7 $27

--- a/src/code/home/entities.asm
+++ b/src/code/home/entities.asm
@@ -753,14 +753,14 @@ RenderActiveEntitySpritesRect::
 
     ; Save counter to hMultiPurpose0
     ld   a, c                                     ; $3CF9: $79
-    ldh  [hMultiPurpose0], a                           ; $3CFA: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $3CFA: $E0 $D7
 
     ld   a, [wActiveEntityIndex]                  ; $3CFC: $FA $23 $C1
     ld   c, a                                     ; $3CFF: $4F
     call SkipDisabledEntityDuringRoomTransition   ; $3D00: $CD $57 $3D
 
     ; Restore counter from hMultiPurpose0
-    ldh  a, [hMultiPurpose0]                           ; $3D03: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $3D03: $F0 $D7
     ld   c, a                                     ; $3D05: $4F
 
 .loop
@@ -1024,9 +1024,9 @@ label_3E8E::
     ret  nz                                       ; $3E9A: $C0
 
     ldh  a, [hActiveEntityPosX]                   ; $3E9B: $F0 $EE
-    ldh  [hMultiPurpose0], a                           ; $3E9D: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $3E9D: $E0 $D7
     ldh  a, [hActiveEntityVisualPosY]             ; $3E9F: $F0 $EC
-    ldh  [hMultiPurpose1], a                           ; $3EA1: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $3EA1: $E0 $D8
     ld   a, TRANSCIENT_VFX_SMOKE                  ; $3EA3: $3E $08
     call AddTranscientVfx                         ; $3EA5: $CD $C7 $0C
     ld   hl, wTranscientVfxCountdownTable         ; $3EA8: $21 $20 $C5
@@ -1044,7 +1044,7 @@ label_3EAF::
     inc  a                                        ; $3EB9: $3C
 
 .jr_3EBA
-    ldh  [hMultiPurpose0], a                           ; $3EBA: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $3EBA: $E0 $D7
     ld   hl, wEntitiesUnknowTableS                ; $3EBC: $21 $00 $C4
     add  hl, bc                                   ; $3EBF: $09
     ld   a, [hl]                                  ; $3EC0: $7E

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -496,8 +496,8 @@ Data_001_7148::
     db 0, 0, 0, 0, $40, $40, $40, $40, $90, $90, $90, $90 ; $7148
 
 label_7154::
-    ldh  [hMultiPurpose9], a                           ; $7154: $E0 $E0
-    ldh  [hMultiPurpose9], a                           ; $7156: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $7154: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $7156: $E0 $E0
 
 IntroStage6Handler::
     call func_001_71C7                            ; $7158: $CD $C7 $71
@@ -921,11 +921,11 @@ RenderRain::
     call GetRandomByte                            ; $7466: $CD $0D $28
     and  $18                                      ; $7469: $E6 $18
     add  a, $10                                   ; $746B: $C6 $10
-    ldh  [hMultiPurpose1], a                           ; $746D: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $746D: $E0 $D8
     call GetRandomByte                            ; $746F: $CD $0D $28
     and  $18                                      ; $7472: $E6 $18
     add  a, $10                                   ; $7474: $C6 $10
-    ldh  [hMultiPurpose0], a                           ; $7476: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $7476: $E0 $D7
     ld   hl, wDynamicOAMBuffer+$1C                                ; $7478: $21 $4C $C0
     ; On the sea, limit the rain to the top section of the screen ($10)
     ld   c, $10                                   ; $747B: $0E $10
@@ -936,9 +936,9 @@ RenderRain::
     ld   c, $15                                   ; $7484: $0E $15
 
 .loop
-    ldh  a, [hMultiPurpose1]                           ; $7486: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $7486: $F0 $D8
     ldi  [hl], a                                  ; $7488: $22
-    ldh  a, [hMultiPurpose0]                           ; $7489: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $7489: $F0 $D7
     ldi  [hl], a                                  ; $748B: $22
     call GetRandomByte                            ; $748C: $CD $0D $28
     and  $01       ; if random(0,1) == 0          ; $748F: $E6 $01
@@ -952,16 +952,16 @@ RenderRain::
     ldi  [hl], a                                  ; $749C: $22
     ld   a, $00                                   ; $749D: $3E $00
     ldi  [hl], a                                  ; $749F: $22
-    ldh  a, [hMultiPurpose0]                           ; $74A0: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $74A0: $F0 $D7
     add  a, $1C                                   ; $74A2: $C6 $1C
-    ldh  [hMultiPurpose0], a                           ; $74A4: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $74A4: $E0 $D7
     cp   $A0                                      ; $74A6: $FE $A0
     jr   c, .continue                             ; $74A8: $38 $0A
     sub  a, $98                                   ; $74AA: $D6 $98
-    ldh  [hMultiPurpose0], a                           ; $74AC: $E0 $D7
-    ldh  a, [hMultiPurpose1]                           ; $74AE: $F0 $D8
+    ldh  [hMultiPurpose0], a                      ; $74AC: $E0 $D7
+    ldh  a, [hMultiPurpose1]                      ; $74AE: $F0 $D8
     add  a, $25                                   ; $74B0: $C6 $25
-    ldh  [hMultiPurpose1], a                           ; $74B2: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $74B2: $E0 $D8
 
 .continue
     dec  c                                        ; $74B4: $0D

--- a/src/code/map_loading.asm
+++ b/src/code/map_loading.asm
@@ -33,7 +33,7 @@ GetBGAttributesAddressForObject::
     ld   hl, OverworldBGAttributesBanks           ; $6584: $21 $76 $64
     add  hl, bc                                   ; $6587: $09
     ld   a, [hl]                                  ; $6588: $7E
-    ldh  [hMultiPurpose8], a                           ; $6589: $E0 $DF
+    ldh  [hMultiPurpose8], a                      ; $6589: $E0 $DF
 .overworldPaletteBankEnd
 
     ; bc = [hMapRoom] * 2
@@ -56,7 +56,7 @@ GetBGAttributesAddressForObject::
 
 
     ld   a, BANK(IndoorsBGAttributesA)            ; $659E: $3E $23
-    ldh  [hMultiPurpose8], a                           ; $65A0: $E0 $DF
+    ldh  [hMultiPurpose8], a                      ; $65A0: $E0 $DF
 
     ; hl += $200
     ; Assertions were introduced in rgbds 0.4.0
@@ -172,7 +172,7 @@ GetBGAttributesAddressForObject::
 
 .useSecondaryIndoorsPaletteBank
     ld   a, BANK(IndoorsBGAttributesB)            ; $662A: $3E $24
-    ldh  [hMultiPurpose8], a                           ; $662C: $E0 $DF
+    ldh  [hMultiPurpose8], a                      ; $662C: $E0 $DF
 
 .jr_01A_662E
     inc  h                                        ; $662E: $24
@@ -196,7 +196,7 @@ GetBGAttributesAddressForObject::
     add  hl, bc                                   ; $6637: $09
     ; hMultiPurpose9, hMultiPurposeA = PalettesTable[ObjectAttributeValue * 4]
     ld   a, h                                     ; $6638: $7C
-    ldh  [hMultiPurpose9], a                           ; $6639: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $6639: $E0 $E0
     ld   a, l                                     ; $663B: $7D
     ldh  [hMultiPurposeA], a                           ; $663C: $E0 $E1
     pop  hl                                       ; $663E: $E1
@@ -271,13 +271,13 @@ jr_01A_6736:
     ld   b, $00                                   ; $6737: $06 $00
     ld   a, [hl]                                  ; $6739: $7E
     ld   c, a                                     ; $673A: $4F
-    ldh  a, [hMultiPurpose9]                           ; $673B: $F0 $E0
+    ldh  a, [hMultiPurpose9]                      ; $673B: $F0 $E0
     ld   h, a                                     ; $673D: $67
     ldh  a, [hMultiPurposeA]                           ; $673E: $F0 $E1
     ld   l, a                                     ; $6740: $6F
     add  hl, bc                                   ; $6741: $09
     ld   a, h                                     ; $6742: $7C
-    ldh  [hMultiPurpose9], a                           ; $6743: $E0 $E0
+    ldh  [hMultiPurpose9], a                      ; $6743: $E0 $E0
     ld   a, l                                     ; $6745: $7D
     ldh  [hMultiPurposeA], a                           ; $6746: $E0 $E1
     ret                                           ; $6748: $C9

--- a/src/code/overworld_macros.asm
+++ b/src/code/overworld_macros.asm
@@ -40,7 +40,7 @@ jr_024_75A9:
     ld   d, $00                                   ; $75A9: $16 $00
     ld   hl, wRoomObjectsArea                     ; $75AB: $21 $00 $D7
     add  hl, de                                   ; $75AE: $19
-    ldh  a, [hMultiPurpose0]                           ; $75AF: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $75AF: $F0 $D7
     and  a                                        ; $75B1: $A7
     jr   z, jr_024_75CD                           ; $75B2: $28 $19
 
@@ -50,7 +50,7 @@ jr_024_75A9:
 jr_024_75B7:
     call func_024_75CD                            ; $75B7: $CD $CD $75
     dec  bc                                       ; $75BA: $0B
-    ldh  a, [hMultiPurpose0]                           ; $75BB: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $75BB: $F0 $D7
     and  $40                                      ; $75BD: $E6 $40
     ld   d, $F1                                   ; $75BF: $16 $F1
     jr   z, jr_024_75C5                           ; $75C1: $28 $02

--- a/src/code/palettes.asm
+++ b/src/code/palettes.asm
@@ -1396,7 +1396,7 @@ jr_021_5491:
     ld   a, e                                     ; $5491: $7B
     and  $1F                                      ; $5492: $E6 $1F
     call func_021_54F9                            ; $5494: $CD $F9 $54
-    ldh  [hMultiPurpose8], a                           ; $5497: $E0 $DF
+    ldh  [hMultiPurpose8], a                      ; $5497: $E0 $DF
     ld   a, e                                     ; $5499: $7B
     and  $E0                                      ; $549A: $E6 $E0
     swap a                                        ; $549C: $CB $37

--- a/src/code/photos.asm
+++ b/src/code/photos.asm
@@ -1464,9 +1464,9 @@ func_037_4972::
     ld   h, [hl]                                  ; $4984: $66
     ld   l, a                                     ; $4985: $6F
     ld   a, [wEntitiesPosYTable+2]                               ; $4986: $FA $12 $C2
-    ldh  [hMultiPurpose0], a                           ; $4989: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4989: $E0 $D7
     ld   a, [wEntitiesPosYTable+1]                               ; $498B: $FA $11 $C2
-    ldh  [hMultiPurpose1], a                           ; $498E: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $498E: $E0 $D8
     call func_037_4AB8                            ; $4990: $CD $B8 $4A
     ret                                           ; $4993: $C9
 
@@ -1534,9 +1534,9 @@ func_037_49E1::
     ld   h, [hl]                                  ; $49EB: $66
     ld   l, a                                     ; $49EC: $6F
     ld   a, [wEntitiesPosXTable+3]                               ; $49ED: $FA $03 $C2
-    ldh  [hMultiPurpose0], a                           ; $49F0: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $49F0: $E0 $D7
     ld   a, [wEntitiesPosXTable+2]                               ; $49F2: $FA $02 $C2
-    ldh  [hMultiPurpose1], a                           ; $49F5: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $49F5: $E0 $D8
     call func_037_4AB8                            ; $49F7: $CD $B8 $4A
     ret                                           ; $49FA: $C9
 
@@ -1598,9 +1598,9 @@ func_037_4A45::
     ld   h, [hl]                                  ; $4A4F: $66
     ld   l, a                                     ; $4A50: $6F
     ld   a, [wEntitiesPosXTable+9]                               ; $4A51: $FA $09 $C2
-    ldh  [hMultiPurpose0], a                           ; $4A54: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4A54: $E0 $D7
     ld   a, [wEntitiesPosXTable+8]                               ; $4A56: $FA $08 $C2
-    ldh  [hMultiPurpose1], a                           ; $4A59: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4A59: $E0 $D8
     call func_037_4AB8                            ; $4A5B: $CD $B8 $4A
     ret                                           ; $4A5E: $C9
 
@@ -1617,9 +1617,9 @@ func_037_4A64::
     ld   h, [hl]                                  ; $4A6E: $66
     ld   l, a                                     ; $4A6F: $6F
     ld   a, [wEntitiesPosYTable+13]                               ; $4A70: $FA $1D $C2
-    ldh  [hMultiPurpose0], a                           ; $4A73: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4A73: $E0 $D7
     ld   a, [wEntitiesPosYTable+12]                               ; $4A75: $FA $1C $C2
-    ldh  [hMultiPurpose1], a                           ; $4A78: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4A78: $E0 $D8
     call func_037_4AB8                            ; $4A7A: $CD $B8 $4A
     ret                                           ; $4A7D: $C9
 
@@ -1652,8 +1652,8 @@ func_037_4A8E::
 
 .else_4AAD_37:
     xor  a                                        ; $4AAD: $AF
-    ldh  [hMultiPurpose0], a                           ; $4AAE: $E0 $D7
-    ldh  [hMultiPurpose1], a                           ; $4AB0: $E0 $D8
+    ldh  [hMultiPurpose0], a                      ; $4AAE: $E0 $D7
+    ldh  [hMultiPurpose1], a                      ; $4AB0: $E0 $D8
     ld   c, $08                                   ; $4AB2: $0E $08
     call func_037_4AB8                            ; $4AB4: $CD $B8 $4A
     ret                                           ; $4AB7: $C9
@@ -1674,12 +1674,12 @@ func_037_4AB8::
     srl  c                                        ; $4ACC: $CB $39
 
 .loop_4ACE_37:
-    ldh  a, [hMultiPurpose0]                           ; $4ACE: $F0 $D7
+    ldh  a, [hMultiPurpose0]                      ; $4ACE: $F0 $D7
     add  [hl]                                     ; $4AD0: $86
     ld   [de], a                                  ; $4AD1: $12
     inc  de                                       ; $4AD2: $13
     inc  hl                                       ; $4AD3: $23
-    ldh  a, [hMultiPurpose1]                           ; $4AD4: $F0 $D8
+    ldh  a, [hMultiPurpose1]                      ; $4AD4: $F0 $D8
     add  [hl]                                     ; $4AD6: $86
     ld   [de], a                                  ; $4AD7: $12
     inc  de                                       ; $4AD8: $13
@@ -1757,9 +1757,9 @@ func_037_4B31::
     ld   h, [hl]                                  ; $4B45: $66
     ld   l, a                                     ; $4B46: $6F
     ld   a, [wEntitiesPosXTable+3]                               ; $4B47: $FA $03 $C2
-    ldh  [hMultiPurpose0], a                           ; $4B4A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4B4A: $E0 $D7
     ld   a, [wEntitiesPosXTable+2]                               ; $4B4C: $FA $02 $C2
-    ldh  [hMultiPurpose1], a                           ; $4B4F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4B4F: $E0 $D8
     call func_037_4AB8                            ; $4B51: $CD $B8 $4A
     ret                                           ; $4B54: $C9
 
@@ -2379,9 +2379,9 @@ func_037_4F1B::
     ld   [wEntitiesPosXSignTable+5], a                               ; $4F21: $EA $25 $C2
     ld   hl, Data_037_4F13                        ; $4F24: $21 $13 $4F
     ld   a, [wEntitiesSpeedYAccTable+9]                               ; $4F27: $FA $79 $C2
-    ldh  [hMultiPurpose0], a                           ; $4F2A: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4F2A: $E0 $D7
     ld   a, [wEntitiesSpeedYAccTable+8]                               ; $4F2C: $FA $78 $C2
-    ldh  [hMultiPurpose1], a                           ; $4F2F: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4F2F: $E0 $D8
     ld   c, $08                                   ; $4F31: $0E $08
     call func_037_4AB8                            ; $4F33: $CD $B8 $4A
     ret                                           ; $4F36: $C9
@@ -2401,9 +2401,9 @@ func_037_4F37::
     ld   h, [hl]                                  ; $4F4B: $66
     ld   l, a                                     ; $4F4C: $6F
     ld   a, [wEntitiesPosXSignTable+2]                               ; $4F4D: $FA $22 $C2
-    ldh  [hMultiPurpose0], a                           ; $4F50: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4F50: $E0 $D7
     ld   a, [wEntitiesPosXSignTable+3]                               ; $4F52: $FA $23 $C2
-    ldh  [hMultiPurpose1], a                           ; $4F55: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4F55: $E0 $D8
     call func_037_4AB8                            ; $4F57: $CD $B8 $4A
     ret                                           ; $4F5A: $C9
 
@@ -2498,9 +2498,9 @@ JumpTable_037_4FD0::
     ld   h, [hl]                                  ; $4FE2: $66
     ld   l, a                                     ; $4FE3: $6F
     ld   a, [wEntitiesPosYTable+6]                               ; $4FE4: $FA $16 $C2
-    ldh  [hMultiPurpose0], a                           ; $4FE7: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $4FE7: $E0 $D7
     ld   a, [wEntitiesPosYTable+7]                               ; $4FE9: $FA $17 $C2
-    ldh  [hMultiPurpose1], a                           ; $4FEC: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $4FEC: $E0 $D8
     call func_037_4AB8                            ; $4FEE: $CD $B8 $4A
     ld   hl, Data_037_5941                        ; $4FF1: $21 $41 $59
     ld   a, [wEntitiesPosXTable+1]                               ; $4FF4: $FA $01 $C2
@@ -3038,9 +3038,9 @@ func_037_533F::
     ld   h, [hl]                                  ; $534E: $66
     ld   l, a                                     ; $534F: $6F
     ld   a, [wEntitiesSpeedXTable+15]                               ; $5350: $FA $4F $C2
-    ldh  [hMultiPurpose0], a                           ; $5353: $E0 $D7
+    ldh  [hMultiPurpose0], a                      ; $5353: $E0 $D7
     ld   a, [wEntitiesSpeedYTable]                ; $5355: $FA $50 $C2
-    ldh  [hMultiPurpose1], a                           ; $5358: $E0 $D8
+    ldh  [hMultiPurpose1], a                      ; $5358: $E0 $D8
     call func_037_4AB8                            ; $535A: $CD $B8 $4A
     ret                                           ; $535D: $C9
 


### PR DESCRIPTION
This is a cosmetic code update: now all statements using the multi-purpose registers have comments aligned properly.