### PR TITLE
Render loop improvements

### DIFF
--- a/src/code/background_colors.asm
+++ b/src/code/background_colors.asm
@@ -33,7 +33,7 @@ func_024_5C1A::
     ld   a, $01                                   ; $5C1E: $3E $01
     ldh  [rVBK], a                                ; $5C20: $E0 $4F
     ld   de, wDC91                                ; $5C22: $11 $91 $DC
-    call ExecuteBackgroundCopyRequest             ; $5C25: $CD $27 $29
+    call ExecuteBGCopyRequest                     ; $5C25: $CD $27 $29
     xor  a                                        ; $5C28: $AF
     ldh  [rVBK], a                                ; $5C29: $E0 $4F
     ret                                           ; $5C2B: $C9
@@ -56,7 +56,7 @@ LoadBGMapAttributes::
     ld   e, a                                     ; $5C41: $5F
     ld   a, [hl]                                  ; $5C42: $7E
     ld   d, a                                     ; $5C43: $57
-    call ExecuteBackgroundCopyRequest.noMapTransition; $5C44: $CD $2D $29
+    call ExecuteBGCopyRequest.noMapTransition     ; $5C44: $CD $2D $29
     xor  a                                        ; $5C47: $AF
     ldh  [rVBK], a                                ; $5C48: $E0 $4F
     ret                                           ; $5C4A: $C9

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -5616,7 +5616,7 @@ doCopyObjectToBG:
 ;
 ; This is used when loading a map in one go (instead
 ; of having a sliding screen transition.)
-; (called by LoadMapData)
+; (called by LoadRequestedGfx)
 LoadRoomTilemap:
     call SwitchToMapDataBank                      ; $309B: $CD $05 $39
     call SwitchBank                               ; $309E: $CD $0C $08

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -473,7 +473,7 @@ func_AB5::
     push af                                       ; $0AB5: $F5
     callsb func_024_5C1A                          ; $0AB6: $3E $24 $EA $00 $21 $CD $1A $5C
     ld   de, wRequest                             ; $0ABE: $11 $01 $D6
-    call ExecuteBackgroundCopyRequest             ; $0AC1: $CD $27 $29
+    call ExecuteBGCopyRequest                     ; $0AC1: $CD $27 $29
     jr   RestoreStackedBank                       ; $0AC4: $18 $EA
 
 func_036_703E_trampoline::

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -251,9 +251,9 @@ TilesetLoadHandlersTable::
 ._07 dw LoadBaseOverworldTiles ; same as command $05
 ._08 dw FillBGMapWith7E
 ._09 dw LoadRoomSpecificTiles
-._0A dw LoadMapData.return
+._0A dw LoadRequestedGfx.return
 ._0B dw LoadWorldMapTiles
-._0C dw LoadMapData.return
+._0C dw LoadRequestedGfx.return
 ._0D dw LoadSaveMenuTiles
 ._0E dw LoadWorldMapBGMap_trampoline
 ._0F dw LoadTileset0F_trampoline ; fade from white? used in menus

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -8398,9 +8398,11 @@ func_036_72BA::
     ld   [wDE00], a                               ; $72D5: $EA $00 $DE
 
     ld   hl, wOAMBuffer                           ; $72D8: $21 $00 $C0
-    ld   de, wDynamicOAMBuffer+$6C                                ; $72DB: $11 $9C $C0
+    ld   de, wDynamicOAMBuffer+$6C                ; $72DB: $11 $9C $C0
     ld   b, $14                                   ; $72DE: $06 $14
 
+    ; Swap the content of HL and DE for $14 * 4 bytes
+    ; (the loop is partially unrolled)
 .loop
     ld   c, [hl]                                  ; $72E0: $4E
     ld   a, [de]                                  ; $72E1: $1A
@@ -8408,29 +8410,33 @@ func_036_72BA::
     ld   a, c                                     ; $72E3: $79
     ld   [de], a                                  ; $72E4: $12
     inc  de                                       ; $72E5: $13
+
     ld   c, [hl]                                  ; $72E6: $4E
     ld   a, [de]                                  ; $72E7: $1A
     ld   [hl+], a                                 ; $72E8: $22
     ld   a, c                                     ; $72E9: $79
     ld   [de], a                                  ; $72EA: $12
     inc  de                                       ; $72EB: $13
+
     ld   c, [hl]                                  ; $72EC: $4E
     ld   a, [de]                                  ; $72ED: $1A
     ld   [hl+], a                                 ; $72EE: $22
     ld   a, c                                     ; $72EF: $79
     ld   [de], a                                  ; $72F0: $12
     inc  de                                       ; $72F1: $13
+
     ld   c, [hl]                                  ; $72F2: $4E
     ld   a, [de]                                  ; $72F3: $1A
     ld   [hl+], a                                 ; $72F4: $22
     ld   a, c                                     ; $72F5: $79
     ld   [de], a                                  ; $72F6: $12
+
     ld   c, $07                                   ; $72F7: $0E $07
     ld   a, e                                     ; $72F9: $7B
     sub  c                                        ; $72FA: $91
     ld   e, a                                     ; $72FB: $5F
+
     dec  b                                        ; $72FC: $05
     jr   nz, .loop                                ; $72FD: $20 $E1
 
     ret                                           ; $72FF: $C9
-templabel:

--- a/src/code/home/copy_data.asm
+++ b/src/code/home/copy_data.asm
@@ -42,14 +42,14 @@ ExpandCopyRequestArgs::
     ld   a, [de]                                  ; $2922: $1A
     ; Move de to the data start
     inc  de                                       ; $2923: $13
-    call CopyBackgroundData                       ; $2924: $CD $41 $29
+    call CopyDataToBGMap                       ; $2924: $CD $41 $29
     ; fallthrough
 
-; Execute a data copy from a wRequest structure,
+; Copy data from a wRequest structure to the BG map,
 ; with optional handling during map transitions.
 ; Inputs:
-;   de: data copy request struct (see wRequest)
-ExecuteBackgroundCopyRequest::
+;   de: address of the data copy request struct (see wRequest)
+ExecuteBGCopyRequest::
     ld   a, [wRoomTransitionState]                ; $2927: $FA $24 $C1
     and  a                                        ; $292A: $A7
     jr   nz, .duringMapTransition                 ; $292B: $20 $0F
@@ -79,12 +79,14 @@ ExecuteBackgroundCopyRequest::
     jr   nz, .mapTransitionCopyLoop               ; $293E: $20 $F2
     ret                                           ; $2940: $C9
 
-; Copy map data to Background data
+; Copy data to the BG map, with support for copying a full row or column.
+; See BG_COPY_MODE_* for possible options.
+;
 ; Inputs:
 ;   de: data copy source address
 ;   hl: data copy destination address
 ;   a:  data length (bits 0-6) and copy mode (bits 7-8)
-CopyBackgroundData::
+CopyDataToBGMap::
     ; Save the six lowest bits (actual data length) of the data length to b
     push af                                       ; $2941: $F5
     and  $3F                                      ; $2942: $E6 $3F

--- a/src/code/home/init.asm
+++ b/src/code/home/init.asm
@@ -108,5 +108,5 @@ Init::
     ; On GBC, reset WRAM bank 5
     callsb ClearWRAMBank5                         ; $01CF: $3E $20 $EA $00 $21 $CD $54 $48
 
-    ; Start rendering
-    jp   WaitForNextFrame                         ; $01D7: $C3 $5F $03
+    ; Start the game loop
+    jp   RenderLoop.waitForNextFrame              ; $01D7: $C3 $5F $03

--- a/src/code/home/interrupts.asm
+++ b/src/code/home/interrupts.asm
@@ -141,7 +141,7 @@ InterruptSerial::
 ; Inputs:
 ;  - wTilesetToLoad: index of the tileset to load
 ;  - wBGMapToLoad:   index of the BG map to load
-LoadMapData::
+LoadRequestedGfx::
     ld   a, [wTilesetToLoad]                      ; $0419: $FA $FE $D6
     and  a                                        ; $041C: $A7
     jr   z, .loadBGMap                            ; $041D: $28 $1B

--- a/src/code/home/render_loop.asm
+++ b/src/code/home/render_loop.asm
@@ -12,11 +12,14 @@
 ;  - render window,
 ;  - wait for next frame.
 RenderLoop::
-    ; Set DidRenderFrame
+    ; Mark rendering of a new frame as being started
     ld   a, TRUE                                  ; $01DA: $3E $01
-    ldh  [hDidRenderFrame], a                     ; $01DC: $E0 $FD
+    ldh  [hIsRenderingFrame], a                   ; $01DC: $E0 $FD
 
-.RenderLoop_setScrollY:
+    ;
+    ; Set scroll Y
+    ;
+
     ; If wAlternateBackgroundEnabled == 1...
     ld   a, [wAlternateBackgroundEnabled]         ; $01DE: $FA $00 $C5
     and  a                                        ; $01E1: $A7
@@ -44,7 +47,10 @@ ENDC
 .setScrollY
     ld   [rSCY], a                                ; $01F8: $E0 $42
 
-.RenderLoop_setScrollX:
+    ;
+    ; Set scroll X
+    ;
+
     ; Add the base offset, the screen shake offset and an additionnal offset
     ldh  a, [hBaseScrollX]                        ; $01FA: $F0 $96
     ld   hl, wScreenShakeHorizontal               ; $01FC: $21 $55 $C1
@@ -53,17 +59,20 @@ ENDC
     add  a, [hl]                                  ; $0203: $86
     ld   [rSCX], a ; scrollX                      ; $0204: $E0 $43
 
-.RenderLoop_loadNewMap:
+    ;
+    ; Load requested GFX (if needed)
+    ;
+
     ; If wTilesetToLoad != 0 || wBGMapToLoad != 0,
-    ; load new map data and return.
+    ; load new graphics data and return.
     ld   a, [wTilesetToLoad]                      ; $0206: $FA $FE $D6
     and  a                                        ; $0209: $A7
-    jr   nz, .loadNewMap                          ; $020A: $20 $07
+    jr   nz, .loadRequestedGfx                    ; $020A: $20 $07
     ld   a, [wBGMapToLoad]                        ; $020C: $FA $FF $D6
     cp   $00                                      ; $020F: $FE $00
-    jr   z, .noNewMap                             ; $0211: $28 $2A
+    jr   z, .noGfxToLoad                          ; $0211: $28 $2A
 
-.loadNewMap
+.loadRequestedGfx
     ; Play audio samples before loading the map when:
     ; - in a menu (GameplayType <= GAMEPLAY_FILE_SAVE)
     ; - on the World in default mode (GAMEPLAY_WORLD_DEFAULT)
@@ -84,7 +93,7 @@ ENDC
     call PlayAudioStep                            ; $022C: $CD $A4 $08
 .skipAudio
 
-    ; Load new map tileset and BG map
+    ; Load the requested tileset or BG map
     di                                            ; $022F: $F3
     call LoadRequestedGfx                              ; $0230: $CD $19 $04
     ei                                            ; $0233: $FB
@@ -92,10 +101,14 @@ ENDC
     call PlayAudioStep                            ; $0234: $CD $A4 $08
     call PlayAudioStep                            ; $0237: $CD $A4 $08
     ; And we're done for this frame.
-    jp   WaitForNextFrame                         ; $023A: $C3 $5F $03
-.noNewMap
+    jp   .waitForNextFrame                        ; $023A: $C3 $5F $03
 
-.RenderLoop_renderFrame:
+.noGfxToLoad
+
+    ;
+    ; Start rendering the next frame
+    ;
+
     ; Apply LCD status flags
     ld   a, [wLCDControl]                         ; $023D: $FA $FD $D6
     and  $7F                                      ; $0240: $E6 $7F
@@ -121,11 +134,14 @@ ENDC
     callsb PositionTitleScreenSprites             ; $025C: $3E $20 $EA $00 $21 $CD $57 $52
 .titleScreenEnd
 
-.RenderLoop_TransitionSfx:
+    ;
+    ; Apply transition special effects
+    ;
+
     ; If no transition special effect is active, go to the next step.
     ld   a, [wTransitionGfx]                      ; $0264: $FA $7F $C1
     and  a                                        ; $0267: $A7
-    jp   z, RenderInteractiveFrame                ; $0268: $CA $D5 $02
+    jp   z, .renderInteractiveFrame               ; $0268: $CA $D5 $02
 
     ; There are two types of transition special effects:
     ;  - interactive: new gameplay frames are rendered while the effect is active ;
@@ -139,7 +155,7 @@ ENDC
     ; Apply the transition effect...
     callsb ApplyWindFishVfx                       ; $026E: $3E $17 $EA $00 $21 $CD $DD $48
     ; ... and continue rendering a new frame.
-    jp   RenderInteractiveFrame                   ; $0276: $C3 $D5 $02
+    jp   .renderInteractiveFrame                  ; $0276: $C3 $D5 $02
 .elsif
     ; If TransitionSfx == TRANSITION_GFX_FLOATING,
     ; use the interactive transition code too.
@@ -173,8 +189,8 @@ ENDC
     xor  a                                        ; $0296: $AF
     ld   [wTransitionGfx], a                      ; $0297: $EA $7F $C1
     ld   [wC3CA], a                               ; $029A: $EA $CA $C3
-    ; Resume rendering of interactive frames
-    jp   RenderInteractiveFrame                   ; $029D: $C3 $D5 $02
+    ; Resume rendering of an interactive frame
+    jp   .renderInteractiveFrame                  ; $029D: $C3 $D5 $02
 
 .renderTransitionSfx
 
@@ -213,9 +229,13 @@ ENDC
     ld   [rOBP1], a                               ; $02D0: $E0 $49
     ; This is a non-interactive transition: no new gameplay frame is rendered.
     ; Wait for the next V-Blank.
-    jp   WaitForNextFrame                         ; $02D2: $C3 $5F $03
+    jp   .waitForNextFrame                        ; $02D2: $C3 $5F $03
 
-RenderInteractiveFrame::
+    ;
+    ; Render an interactive frame
+    ;
+.renderInteractiveFrame
+
     ; Update graphics registers from game values
     ld   a, [wWindowY]                            ; $02D5: $FA $9A $DB
     ld   [rWY], a                                 ; $02D8: $E0 $4A
@@ -229,19 +249,22 @@ RenderInteractiveFrame::
     call PlayAudioStep                            ; $02E9: $CD $A4 $08
     call ReadJoypadState                          ; $02EC: $CD $1E $28
 
-    ; If NeedsUpdatingBGTiles or NeedsUpdatingEnnemiesTiles or NeedsUpdatingNPCTiles…
+    ; If NeedsUpdatingBGTiles || NeedsUpdatingEnnemiesTiles || NeedsUpdatingNPCTiles…
     ldh  a, [hNeedsUpdatingBGTiles]               ; $02EF: $F0 $90
     ld   hl, hNeedsUpdatingEnnemiesTiles          ; $02F1: $21 $91 $FF
     or   [hl]                                     ; $02F4: $B6
     ld   hl, wNeedsUpdatingNPCTiles               ; $02F5: $21 $0E $C1
     or   [hl]                                     ; $02F8: $B6
     ; skip further rendering: the vblank interrupt will load the required data
-    jr   nz, WaitForNextFrame                     ; $02F9: $20 $64
+    jr   nz, .waitForNextFrame                    ; $02F9: $20 $64
 
+    ;
     ; Debug functions
+    ;
+
     ld   a, [ROM_DebugTool1]                      ; $02FB: $FA $03 $00
     and  a  ; Is debug mode disabled?             ; $02FE: $A7
-    jr   z, ResetSprites                          ; $02FF: $28 $2C
+    jr   z, .debugEnd                             ; $02FF: $28 $2C
 
     ld   a, [wEnginePaused]                       ; $0301: $FA $FC $D6
     and  a  ; Is engine already paused?           ; $0304: $A7
@@ -263,22 +286,27 @@ RenderInteractiveFrame::
     ld   [wEnginePaused], a                       ; $0318: $EA $FC $D6
 
     ; If the engine was just paused, skip the rest of the render loop
-    jr   nz, WaitForNextFrame                     ; $031B: $20 $42
+    jr   nz, .waitForNextFrame                    ; $031B: $20 $42
 
     ; If the engine was just unpaused,
     ; toggle Free-movement mode.
     ld   a, [wFreeMovementMode]                   ; $031D: $FA $7B $C1
     xor  $10                                      ; $0320: $EE $10
     ld   [wFreeMovementMode], a                   ; $0322: $EA $7B $C1
-    jr   WaitForNextFrame                         ; $0325: $18 $38
+    jr   .waitForNextFrame                        ; $0325: $18 $38
 
 .saveEngineStatus
     ; If the engine is paused, skip the rest of the render loop
     ld   a, [wEnginePaused]                       ; $0327: $FA $FC $D6
     and  a                                        ; $032A: $A7
-    jr   nz, WaitForNextFrame                     ; $032B: $20 $32
+    jr   nz, .waitForNextFrame                    ; $032B: $20 $32
 
-ResetSprites::
+.debugEnd
+
+    ;
+    ; Reset sprites visibility
+    ;
+
     ; If not in Inventory, initially hide all sprites
     ld   a, [wGameplayType]                       ; $032D: $FA $95 $DB
     cp   GAMEPLAY_INVENTORY                       ; $0330: $FE $0C
@@ -287,15 +315,22 @@ ResetSprites::
     ; If Inventory is actually visible, leave sprites visible
     ld   a, [wGameplaySubtype]                    ; $0334: $FA $96 $DB
     cp   GAMEPLAY_INVENTORY_DELAY1                ; $0337: $FE $02
-    jr   c, RenderGameplay                        ; $0339: $38 $08
+    jr   c, .spritesEnd                           ; $0339: $38 $08
 
 .resetSpritesVisibility
     callsw HideAllSprites                         ; $033B: $3E $01 $CD $0C $08 $CD $2E $5F
+.spritesEnd
 
-RenderGameplay::
+    ;
+    ; Execute main gameplay code
+    ;
+
     call ExecuteGameplayHandler                   ; $0343: $CD $34 $0E
 
-RenderPalettes::
+    ;
+    ; Load color palettes
+    ;
+
     ; If isGBC…
     ldh  a, [hIsGBC]                              ; $0346: $F0 $FE
     and  a                                        ; $0348: $A7
@@ -308,10 +343,15 @@ RenderPalettes::
     xor  a                                        ; $0353: $AF
     ld   [wPaletteToLoadForTileMap], a            ; $0354: $EA $D2 $DD
 
-RenderWindow::
+    ;
+    ; Render Window
+    ;
     callsw UpdateWindowPosition                   ; $0357: $3E $01 $CD $0C $08 $CD $4B $5F
 
-WaitForNextFrame::
+    ;
+    ;
+    ;
+.waitForNextFrame
     ; Animate inventory window
     callsw func_01F_7F80                          ; $035F: $3E $1F $CD $0C $08 $CD $80 $7F
 
@@ -320,14 +360,15 @@ WaitForNextFrame::
     call AdjustBankNumberForGBC                   ; $0369: $CD $0B $0B
     call SwitchBank                               ; $036C: $CD $0C $08
 
-    ; Reset didRenderFrame flag
+    ; Mark the frame as being ready
     xor  a                                        ; $036F: $AF
-    ldh  [hDidRenderFrame], a                     ; $0370: $E0 $FD
+    ldh  [hIsRenderingFrame], a                   ; $0370: $E0 $FD
 
     ; Stop the CPU until the next interrupt
     halt                                          ; $0372: $76 $00
 
-    ; Loop until hNeedsRenderingFrame != 0
+    ; An interrupt occured; but maybe it wasn't the V-Blank interrupt.
+    ; Busy-loop until the V-Blank interrupt actually ran and finished.
 .pollNeedsRenderingFrame
     ldh  a, [hNeedsRenderingFrame]                ; $0374: $F0 $D1
     and  a                                        ; $0376: $A7
@@ -337,5 +378,5 @@ WaitForNextFrame::
     xor  a                                        ; $0379: $AF
     ldh  [hNeedsRenderingFrame], a                ; $037A: $E0 $D1
 
-    ; Jump to the top of the render loop
+    ; Start rendering the next frame
     jp   RenderLoop                               ; $037C: $C3 $DA $01

--- a/src/code/home/render_loop.asm
+++ b/src/code/home/render_loop.asm
@@ -86,7 +86,7 @@ ENDC
 
     ; Load new map tileset and BG map
     di                                            ; $022F: $F3
-    call LoadMapData                              ; $0230: $CD $19 $04
+    call LoadRequestedGfx                              ; $0230: $CD $19 $04
     ei                                            ; $0233: $FB
     ; Play more audio
     call PlayAudioStep                            ; $0234: $CD $A4 $08

--- a/src/code/home/render_loop.asm
+++ b/src/code/home/render_loop.asm
@@ -84,7 +84,7 @@ ENDC
     call PlayAudioStep                            ; $022C: $CD $A4 $08
 .skipAudio
 
-    ; Load new map tiles and background
+    ; Load new map tileset and BG map
     di                                            ; $022F: $F3
     call LoadMapData                              ; $0230: $CD $19 $04
     ei                                            ; $0233: $FB

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -471,11 +471,11 @@ IntroLinkFaceHandler::
 
 LoadTileMapZero_trampoline::
     ld   hl, wFarcallParams                       ; $7108: $21 $01 $DE
-    ld   a, BANK(LoadMapData.LoadTileMapZero)     ; $710B: $3E $00
+    ld   a, BANK(LoadMapData.loadBGMap)           ; $710B: $3E $00
     ldi  [hl], a                                  ; $710D: $22
-    ld   a, HIGH(LoadMapData.LoadTileMapZero)     ; $710E: $3E $04
+    ld   a, HIGH(LoadMapData.loadBGMap)           ; $710E: $3E $04
     ldi  [hl], a                                  ; $7110: $22
-    ld   a, LOW(LoadMapData.LoadTileMapZero)      ; $7111: $3E $3A
+    ld   a, LOW(LoadMapData.loadBGMap)            ; $7111: $3E $3A
     ldi  [hl], a                                  ; $7113: $22
     ld   a, BANK(@)                               ; $7114: $3E $01
     ld   [hl], a                                  ; $7116: $77

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -471,11 +471,11 @@ IntroLinkFaceHandler::
 
 LoadTileMapZero_trampoline::
     ld   hl, wFarcallParams                       ; $7108: $21 $01 $DE
-    ld   a, BANK(LoadMapData.loadBGMap)           ; $710B: $3E $00
+    ld   a, BANK(LoadRequestedGfx.loadBGMap)           ; $710B: $3E $00
     ldi  [hl], a                                  ; $710D: $22
-    ld   a, HIGH(LoadMapData.loadBGMap)           ; $710E: $3E $04
+    ld   a, HIGH(LoadRequestedGfx.loadBGMap)           ; $710E: $3E $04
     ldi  [hl], a                                  ; $7110: $22
-    ld   a, LOW(LoadMapData.loadBGMap)            ; $7111: $3E $3A
+    ld   a, LOW(LoadRequestedGfx.loadBGMap)            ; $7111: $3E $3A
     ldi  [hl], a                                  ; $7113: $22
     ld   a, BANK(@)                               ; $7114: $3E $01
     ld   [hl], a                                  ; $7116: $77

--- a/src/code/palettes.asm
+++ b/src/code/palettes.asm
@@ -3,7 +3,7 @@
 ; https://github.com/mattcurrie/mgbdis
 
 ; Copy object or background palettes to the hardware palette data
-CopyPalettesToHardware::
+CopyPalettesToVRAM::
     ld   a, [wPaletteDataFlags]                   ; $4000: $FA $D1 $DD
     and  a                                        ; $4003: $A7
     ret  z                                        ; $4004: $C8

--- a/src/constants/gameplay.asm
+++ b/src/constants/gameplay.asm
@@ -4,7 +4,7 @@
 
 NAME_LENGTH                EQU 5
 
-; Copy modes for CopyBackgroundData
+; Copy modes for CopyDataToBGMap
 ; Copy the data from source to dest, progressing horizontally
 BG_COPY_MODE_ROW                 equ $00
 ; Copy a single byte from source to dest, progressing horizontally

--- a/src/constants/memory/hram.asm
+++ b/src/constants/memory/hram.asm
@@ -515,10 +515,10 @@ hLinkFinalRoomPosition::
 hFFFC:
   ds 1 ; FFFC
 
-; bool value if rendering was done
-; 0 = rendering did not happened yet,
-; 1 = rendering happened
-hDidRenderFrame::
+; Is the engine currently rendering a frame.
+; 0 = rendering is done, a frame is ready to be copied to VRAM,
+; 1 = the engine is rendering a new frame
+hIsRenderingFrame::
  ds 1 ; FFFD
 
 ; Marker for the Hardware that the program is running on

--- a/src/main.asm
+++ b/src/main.asm
@@ -66,6 +66,7 @@ include "data/objects_tilemaps/indoor.cgb.asm"
 ColorDungeonObjectsTilemap::
 include "data/objects_tilemaps/color_dungeon.asm"
 include "data/objects/physics.asm"
+BGTilemaps::
 include "data/backgrounds/background_tile_commands.asm"
 
 ; Maps and dialogs


### PR DESCRIPTION
Improve labeling of the render loop and vblank interrupt handler:

- Make more labels local
- Improve naming
- Replace unused labels by documentation

Now the render_loop.asm and interrupts.asm code is much more enjoyable to read.
