### PR TITLE
Fix tilemap encoding

### DIFF
--- a/src/data/backgrounds/README.md
+++ b/src/data/backgrounds/README.md
@@ -12,10 +12,10 @@ To make change to a tilemap:
 
 1. Decode the tilemap:
     ```
-    tools/convert_background.py --decode src/data/backgrounds/marin_beach.tilemap.encoded --output src/data/backgrounds/marin_beach.tilemap
+    tools/convert_background.py decode src/data/backgrounds/marin_beach.tilemap.encoded --output src/data/backgrounds/marin_beach.tilemap
     ```
 2. Edit the tilemap, using your favorite editor.
 3. Re-encode the modified tilemap:
     ```
-    tools/convert_background.py --encode src/data/backgrounds/marin_beach.tilemap --output src/data/backgrounds/marin_beach.tilemap.encoded
+    tools/convert_background.py encode src/data/backgrounds/marin_beach.tilemap --output src/data/backgrounds/marin_beach.tilemap.encoded
     ```

--- a/tools/convert_background.py
+++ b/tools/convert_background.py
@@ -29,13 +29,16 @@ if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
     options_parser = argparse.ArgumentParser(add_help=False)
     options_parser.add_argument('--output', '-o', type=str, metavar='outfile', action='store', help='file to write the output to')
-    options_parser.add_argument('--wrap', '-w', type=int, metavar='char_count', default=40, action='store', help='wrap the stdout output to a number of characters (40 by default; 0 to disable)')
 
     operations_subparser = arg_parser.add_subparsers(title='commands', dest='command', required=True)
     decoding_parser = operations_subparser.add_parser('decode',  parents=[options_parser], help='convert a tilemap encoded with the ZLADX format to a raw tilemap')
     decoding_parser.add_argument('infile', type=str, help='encoded tilemap file to decode')
+    decoding_parser.add_argument('--wrap', '-w', type=int, metavar='char_count', default=40, action='store', help='wrap the stdout output to a number of characters (40 by default; 0 to disable)')
+
     encoding_parser = operations_subparser.add_parser('encode',  parents=[options_parser], help='convert a raw tilemap to the encoded ZLADX format')
     encoding_parser.add_argument('infile', type=str, help='raw tilemap file to encode')
+    encoding_parser.add_argument('--width', type=int, metavar="tiles_count", default=20, action='store', help='number of tiles in the tilemap width')
+    encoding_parser.add_argument('--location', type=int, metavar="VRAM_address", default=0x9800, action='store', help='start address of the tilemap in VRAM')
 
     args = arg_parser.parse_args()
 
@@ -52,11 +55,8 @@ if __name__ == "__main__":
             result.append(tilemap_bytes[address])
         write_result(result, outfile, wrap_count=args.wrap)
 
-    elif args.encode:
-        # TODO: allow to specify the tilemap location and width from command-line argument
-        # (For now defaults of location=0x9800 and width=20 are assumed.)
-        result = BackgroundCoder.encode(data)
-        write_result(result, outfile, wrap_count=args.wrap)
+    elif args.command == 'encode':
+        result = BackgroundCoder.encode(data, args.location, args.width)
+        write_result(result, outfile)
 
     outfile.close()
-

--- a/tools/convert_background.py
+++ b/tools/convert_background.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 #
-# Decode or encode BG tilemap data
+# Decode or encode BG tilemap data using the ZLADX encoding format
 #
 # Usage:
-#  tools/convert_background.py --decode marin_beach.tilemap.compressed
-#  tools/convert_background.py --decode marin_beach.tilemap.compressed -o marin_beach.tilemap
-#  tools/convert_background.py --encode marin_beach-modified.tilemap -o marin_beach.tilemap.compressed
+#  tools/convert_background.py decode marin_beach.tilemap.encoded
+#  tools/convert_background.py decode marin_beach.tilemap.encoded --output marin_beach.tilemap
+#  tools/convert_background.py encode marin_beach-modified.tilemap --output marin_beach.tilemap.encoded
 
 import sys
 import argparse
@@ -13,6 +13,10 @@ from textwrap import wrap
 from lib.background_coder import BackgroundCoder
 
 def write_result(bytes, outfile, wrap_count=None):
+    """
+    Write as a sequence of bytes if the outfile is binary,
+    but as wrapped hexadecimal values if printing on stdout.
+    """
     if 'b' in outfile.mode:
         outfile.write(bytes)
     else:
@@ -23,36 +27,36 @@ def write_result(bytes, outfile, wrap_count=None):
 
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
-    operation_args = arg_parser.add_argument_group('Operation').add_mutually_exclusive_group()
-    operation_args.add_argument('--decode', '-d', nargs=1, type=str, metavar='encoded tilemap', help='encoded binary tilemap file to decode')
-    operation_args.add_argument('--encode', '-e', nargs=1, type=str, metavar='tilemap', help='raw binary tilemap file to encode')
-    arg_parser.add_argument('--wrap', '-w', nargs=1, type=int, metavar='char_count', default=[40], help='wrap the stdout output to a number of characters (40 by default; 0 to disable)')
-    arg_parser.add_argument('--output', '-o', nargs=1, type=str, metavar='outfile', help='file to write the output to')
+    options_parser = argparse.ArgumentParser(add_help=False)
+    options_parser.add_argument('--output', '-o', type=str, metavar='outfile', action='store', help='file to write the output to')
+    options_parser.add_argument('--wrap', '-w', type=int, metavar='char_count', default=40, action='store', help='wrap the stdout output to a number of characters (40 by default; 0 to disable)')
+
+    operations_subparser = arg_parser.add_subparsers(title='commands', dest='command', required=True)
+    decoding_parser = operations_subparser.add_parser('decode',  parents=[options_parser], help='convert a tilemap encoded with the ZLADX format to a raw tilemap')
+    decoding_parser.add_argument('infile', type=str, help='encoded tilemap file to decode')
+    encoding_parser = operations_subparser.add_parser('encode',  parents=[options_parser], help='convert a raw tilemap to the encoded ZLADX format')
+    encoding_parser.add_argument('infile', type=str, help='raw tilemap file to encode')
 
     args = arg_parser.parse_args()
 
-    if args.decode is None and args.encode is None:
-        arg_parser.print_help()
-        sys.exit(-1)
-
-    infile = open((args.decode and args.decode[0]) or args.encode[0], 'rb')
+    infile = open(args.infile, 'rb')
     data = infile.read()
     infile.close()
 
-    outfile = (args.output and open(args.output[0], 'wb')) or sys.stdout
+    outfile = (args.output and open(args.output, 'wb')) or sys.stdout
     result = bytearray()
 
-    if args.decode:
+    if args.command == 'decode':
         tilemap_bytes = BackgroundCoder.decode(data)
         for address in sorted(tilemap_bytes):
             result.append(tilemap_bytes[address])
-        write_result(result, outfile, wrap_count=args.wrap[0])
+        write_result(result, outfile, wrap_count=args.wrap)
 
     elif args.encode:
         # TODO: allow to specify the tilemap location and width from command-line argument
         # (For now defaults of location=0x9800 and width=20 are assumed.)
         result = BackgroundCoder.encode(data)
-        write_result(result, outfile, wrap_count=args.wrap[0])
+        write_result(result, outfile, wrap_count=args.wrap)
 
     outfile.close()
 

--- a/tools/convert_background.py
+++ b/tools/convert_background.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     operation_args = arg_parser.add_argument_group('Operation').add_mutually_exclusive_group()
     operation_args.add_argument('--decode', '-d', nargs=1, type=str, metavar='encoded tilemap', help='encoded binary tilemap file to decode')
     operation_args.add_argument('--encode', '-e', nargs=1, type=str, metavar='tilemap', help='raw binary tilemap file to encode')
-    arg_parser.add_argument('--wrap', '-w', nargs=1, type=int, metavar='char_count', default=40, help='wrap the stdout output to a number of characters (40 by default; 0 to disable)')
+    arg_parser.add_argument('--wrap', '-w', nargs=1, type=int, metavar='char_count', default=[40], help='wrap the stdout output to a number of characters (40 by default; 0 to disable)')
     arg_parser.add_argument('--output', '-o', nargs=1, type=str, metavar='outfile', help='file to write the output to')
 
     args = arg_parser.parse_args()
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         arg_parser.print_help()
         sys.exit(-1)
 
-    infile = open(args.decode[0] or args.encode[0], 'rb')
+    infile = open((args.decode and args.decode[0]) or args.encode[0], 'rb')
     data = infile.read()
     infile.close()
 
@@ -49,6 +49,8 @@ if __name__ == "__main__":
         write_result(result, outfile, wrap_count=args.wrap[0])
 
     elif args.encode:
+        # TODO: allow to specify the tilemap location and width from command-line argument
+        # (For now defaults of location=0x9800 and width=20 are assumed.)
         result = BackgroundCoder.encode(data)
         write_result(result, outfile, wrap_count=args.wrap[0])
 

--- a/tools/lib/background_coder.py
+++ b/tools/lib/background_coder.py
@@ -30,7 +30,8 @@ class BackgroundCoder:
 
         return tilemap_bytes
 
-    def encode(tilemap_bytes):
+    @staticmethod
+    def encode(tilemap_bytes, tilemap_location=0x9800, tilemap_width=20):
         """
         Encode a raw BG tilemap to the LADX commands format.
 
@@ -43,24 +44,21 @@ class BackgroundCoder:
           compressed tilemap. Original tilemaps were probably hand-coded, and so cannot
           be reproduced byte-for-byte by this encoder.
         """
-        result = bytearray()
-        low = min(self.tiles.keys())
-        high = max(self.tiles.keys()) + 1
-        while low < high:
-            if low not in self.tiles:
-                low += 1
-                continue
-            count = 1
-            while low + count in self.tiles and count < 255:
-                count += 1
-            result.append(low >> 8)
-            result.append(low & 0xFF)
-            result.append(count - 1)
-            for n in range(count):
-                result.append(self.tiles[low + n])
-            low += count
-        result.append(0x00)
-        if self.__is_attributes:
-            rom.background_attributes[self.__index] = result
-        else:
-            rom.background_tiles[self.__index] = result
+
+        # Split the tilemap into chunks
+        chunk_size = tilemap_width
+        chunks = [tilemap_bytes[i:i + chunk_size] for i in range(0, len(tilemap_bytes), chunk_size)]
+
+        encoded_bytes = bytearray()
+        address = tilemap_location
+
+        for i, chunk in enumerate(chunks):
+            count = len(chunk)
+            encoded_bytes.append(address >> 8)
+            encoded_bytes.append(address & 0xFF)
+            encoded_bytes.append(count - 1)
+            encoded_bytes.extend(chunk)
+            address += 0x20
+
+        encoded_bytes.append(0x00)
+        return encoded_bytes

--- a/tools/lib/background_coder.py
+++ b/tools/lib/background_coder.py
@@ -31,7 +31,7 @@ class BackgroundCoder:
         return tilemap_bytes
 
     @staticmethod
-    def encode(tilemap_bytes, tilemap_location=0x9800, tilemap_width=20):
+    def encode(bytes, tilemap_location=0x9800, tilemap_width=20):
         """
         Encode a raw BG tilemap to the LADX commands format.
 
@@ -47,16 +47,15 @@ class BackgroundCoder:
 
         # Split the tilemap into chunks
         chunk_size = tilemap_width
-        chunks = [tilemap_bytes[i:i + chunk_size] for i in range(0, len(tilemap_bytes), chunk_size)]
+        chunks = [bytes[i:i + chunk_size] for i in range(0, len(bytes), chunk_size)]
 
         encoded_bytes = bytearray()
         address = tilemap_location
 
-        for i, chunk in enumerate(chunks):
-            count = len(chunk)
+        for chunk in chunks:
             encoded_bytes.append(address >> 8)
             encoded_bytes.append(address & 0xFF)
-            encoded_bytes.append(count - 1)
+            encoded_bytes.append(len(chunk) - 1)
             encoded_bytes.extend(chunk)
             address += 0x20
 

--- a/tools/resize_tiles.py
+++ b/tools/resize_tiles.py
@@ -6,7 +6,7 @@ import argparse
 import os
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-gfx_py = "python2 " + os.path.join(dir_path, 'pokemontools', 'gfx.py')
+gfx_py = "python3 " + os.path.join(dir_path, 'gfx', 'gfx.py')
 
 parser = argparse.ArgumentParser(description='Resize a PNG file containing tiles to the given width or height')
 parser.add_argument('--width', type=lambda x: int(x, 10), metavar='target_width', default=32, help='Target width of the png')


### PR DESCRIPTION
The python tool to decode tilemaps was working, but broke when attempting to encode a tilemap.

This is now fixed.

~~TODO: for now this only works for width=20 tilemaps, starting at 0x9800.~~

Which means… We can now actually edit tilemaps and re-insert them into the game!

<img width="946" alt="Capture d’écran 2021-01-09 à 00 39 06" src="https://user-images.githubusercontent.com/179923/104075620-a28df280-5213-11eb-9cc8-e0896c1f11fa.png">
