### PR TITLE
Improve project statistics

### DIFF
--- a/src/code/file_menus.asm
+++ b/src/code/file_menus.asm
@@ -60,7 +60,7 @@ CopyDeathCountsToBG::
     ld   h, a                                     ; $4816: $67
     ld   a, [wFile1DeathCountLow]                 ; $4817: $FA $01 $DC
     ld   l, a                                     ; $481A: $6F
-    ld   de, vBGMap0 + $00E7                      ; $481B: $11 $E7 $98
+    ld   de, vBGMap0 + $0E7                       ; $481B: $11 $E7 $98
     call CopyDigitsToFileScreenBG                 ; $481E: $CD $45 $4F
 
 .file2
@@ -72,7 +72,7 @@ CopyDeathCountsToBG::
     ld   h, a                                     ; $482B: $67
     ld   a, [wFile2DeathCountLow]                 ; $482C: $FA $03 $DC
     ld   l, a                                     ; $482F: $6F
-    ld   de, vBGMap0 + $0147                      ; $4830: $11 $47 $99
+    ld   de, vBGMap0 + $147                       ; $4830: $11 $47 $99
     call CopyDigitsToFileScreenBG                 ; $4833: $CD $45 $4F
 
 .file3
@@ -84,7 +84,7 @@ CopyDeathCountsToBG::
     ld   h, a                                     ; $4840: $67
     ld   a, [wFile3DeathCountLow]                 ; $4841: $FA $05 $DC
     ld   l, a                                     ; $4844: $6F
-    ld   de, vBGMap0 + $01A7                      ; $4845: $11 $A7 $99
+    ld   de, vBGMap0 + $1A7                       ; $4845: $11 $A7 $99
     call CopyDigitsToFileScreenBG                 ; $4848: $CD $45 $4F
 
 .return

--- a/src/code/overworld_macros.asm
+++ b/src/code/overworld_macros.asm
@@ -479,7 +479,7 @@ func_024_7B77::
     add  hl, bc                                   ; $7B8D: $09
 .jr_024_7B8E
 
-    ld   bc, $0040                                ; $7B8E: $01 $40 $00
+    ld   bc, $40                                  ; $7B8E: $01 $40 $00
     ld   de, wBGPal1                              ; $7B91: $11 $10 $DC
     call CopyData                                 ; $7B94: $CD $14 $29
 

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -44,7 +44,8 @@ EXCLUDED_FILES="\
 --exclude */home/init.asm \
 --exclude */home/clear_memory.asm \
 --exclude */audio/sfx.asm \
---exclude */audio/music_1.asm"
+--exclude */audio/music_1.asm \
+--exclude */palettes.asm"
 count_matches '[^;] \$[0-3][0-9A-F]{3}' "$EXCLUDED_FILES"
 
 echo "   Referencing non-Home ROM banks (4000-7FFF):"

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -6,6 +6,7 @@
 
 VERBOSE=${1:-"disabled"}
 SOURCE_DIR="src/code"
+SYM_FILE="azle.sym"
 
 count_matches()
 {
@@ -57,9 +58,11 @@ echo "   Referencing RAM (8000-FFFF):"
 count_matches '(, | \[|call |jp   )\$[89A-Z][A-Z0-9]{3}'
 
 echo ""
-echo "Number of unlabeled functions:"
-count_matches '^[Ff]unc'
-
-echo ""
-echo "Number of unlabeled jumps:"
-count_matches '^label_|^jr_|^\.jr_|^\.loop_|^\.else_'
+echo "Documented labels:"
+UNDOCUMENTED_LABEL='[A-Za-z0-9_\.]*[0-9A-F]{4}[A-Za-z0-9_]*'
+ANY_LABEL='[A-Za-z0-9_\.]*'
+undocumented_labels=$(grep -E --only-matching " $UNDOCUMENTED_LABEL" "$SYM_FILE" | sort -u | wc -l)
+documented_labels=$(grep -E -v " $UNDOCUMENTED_LABEL" "$SYM_FILE" | grep --only-matching " $ANY_LABEL" | sort -u | wc -l)
+all_labels=$(expr $documented_labels + $undocumented_labels)
+completion_percentage=$(awk "BEGIN {print $documented_labels / $all_labels * 100}")
+echo "$documented_labels / $all_labels ($completion_percentage %)"


### PR DESCRIPTION
tools/stats.sh: improve labels computation, and add a completion percentage

```
$ tools/stats.sh
Number of remaining raw addresses:
   Referencing Home (0000-3FFF):
       0
   Referencing non-Home ROM banks (4000-7FFF):
       0
   Referencing RAM (8000-FFFF):
    1153

Documented labels:
   11193 / 23351 (47,9337 %)
```