### PR TITLE
wram: document wLinkAttackStepAnimationCountdown

### DIFF
--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -1320,8 +1320,9 @@ jr_014_541B:
     ld   hl, wEntitiesSpeedZTable                 ; $5439: $21 $20 $C3
     add  hl, bc                                   ; $543C: $09
     ld   [hl], a                                  ; $543D: $77
-    ld   a, $0C                                   ; $543E: $3E $0C
-    ld   [wC19B], a                               ; $5440: $EA $9B $C1
+
+    ld   a, $0C | ATTACK_STEP_ITEM_ANY            ; $543E: $3E $0C
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $5440: $EA $9B $C1
 
 label_014_5443:
     ret                                           ; $5443: $C9

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -301,14 +301,15 @@ DirectionToLinkAnimationState::
 .down:  db  LINK_ANIMATION_STATE_HOOKSHOT_CHAIN_DOWN     ; $4346 $0E
 
 func_002_434A::
-    ld   a, [wC19B]                               ; $434A: $FA $9B $C1
-    and  $7F                                      ; $434D: $E6 $7F
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $434A: $FA $9B $C1
+    and  ATTACK_STEP_DURATION_MASK                ; $434D: $E6 $7F
     jr   z, jr_002_4367                           ; $434F: $28 $16
 
-    ld   a, [wC19B]                               ; $4351: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $4351: $FA $9B $C1
     dec  a                                        ; $4354: $3D
-    ld   [wC19B], a                               ; $4355: $EA $9B $C1
-    and  $7F                                      ; $4358: $E6 $7F
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $4355: $EA $9B $C1
+    and  ATTACK_STEP_DURATION_MASK                ; $4358: $E6 $7F
+
     ldh  a, [hLinkDirection]                      ; $435A: $F0 $9E
     ld   e, a                                     ; $435C: $5F
     ld   d, $00                                   ; $435D: $16 $00
@@ -320,7 +321,7 @@ func_002_434A::
 
 jr_002_4367:
     xor  a                                        ; $4367: $AF
-    ld   [wC19B], a                               ; $4368: $EA $9B $C1
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $4368: $EA $9B $C1
     ret                                           ; $436B: $C9
 
 func_002_436C::
@@ -2264,7 +2265,7 @@ jr_002_4F3C:
     ; reset all states after spin attack
     ldh  [hLinkPositionZ], a                      ; $4F3F: $E0 $A2
     ld   [wIsLinkInTheAir], a                     ; $4F41: $EA $46 $C1
-    ld   [wC19B], a                               ; $4F44: $EA $9B $C1
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $4F44: $EA $9B $C1
     ld   [wSwordAnimationState], a                ; $4F47: $EA $37 $C1
     ld   [wC16A], a                               ; $4F4A: $EA $6A $C1
     ld   [wC16D], a                               ; $4F4D: $EA $6D $C1
@@ -2918,15 +2919,15 @@ LinkDirectionTohMultiPurpose4_5::
 
 label_002_5310::
     ; TODO label and also add row comment for data above
-    ld   a, [wC19B]                               ; $5310: $FA $9B $C1
-    and  $7F                                      ; $5313: $E6 $7F
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $5310: $FA $9B $C1
+    and  ATTACK_STEP_DURATION_MASK                ; $5313: $E6 $7F
     cp   $08                                      ; $5315: $FE $08
     ldh  a, [hLinkDirection]                      ; $5317: $F0 $9E
     jr   c, .skipOffset                           ; $5319: $38 $02
 
     add  $04                                      ; $531B: $C6 $04
 
-.skipOffset::
+.skipOffset
     ld   e, a                                     ; $531D: $5F
     ld   d, $00                                   ; $531E: $16 $00
     ld   hl, LinkDirectionTohMultiPurpose0        ; $5320: $21 $E8 $52

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -1189,8 +1189,10 @@ ENDC
     ld   [wBombArrowCooldown], a                  ; $4BA0: $EA $C0 $C1
     ld   a, e                                     ; $4BA3: $7B
     ld   [wLatestDroppedBombEntityIndex], a       ; $4BA4: $EA $C1 $C1
-    ld   a, $0C                                   ; $4BA7: $3E $0C
-    ld   [wC19B], a                               ; $4BA9: $EA $9B $C1
+
+    ld   a, $0C | ATTACK_STEP_ITEM_ANY            ; $4BA7: $3E $0C
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $4BA9: $EA $9B $C1
+
     ld   hl, wEntitiesTransitionCountdownTable    ; $4BAC: $21 $E0 $C2
     add  hl, de                                   ; $4BAF: $19
     ld   [hl], $A0                                ; $4BB0: $36 $A0
@@ -1314,8 +1316,10 @@ SprinkleMagicPowder::
     ; play powder jingle
     ld   a, JINGLE_POWDER                         ; $4C47: $3E $05
     ldh  [hJingle], a                             ; $4C49: $E0 $F2
-    ld   a, $0E                                   ; $4C4B: $3E $0E
-    ld   [wC19B], a                               ; $4C4D: $EA $9B $C1
+
+    ld   a, $0E | ATTACK_STEP_ITEM_ANY            ; $4C4B: $3E $0E
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $4C4D: $EA $9B $C1
+
     ; reduce wMagicPowderCount
     ld   a, [wMagicPowderCount]                   ; $4C50: $FA $4C $DB
     sub  $01                                      ; $4C53: $D6 $01

--- a/src/code/entities/bank18.asm
+++ b/src/code/entities/bank18.asm
@@ -2209,8 +2209,10 @@ func_018_50D2::
     ld   [wC167], a                               ; $50D6: $EA $67 $C1
     ld   a, LINK_ANIMATION_STATE_STANDING_UP      ; $50D9: $3E $04
     ldh  [hLinkAnimationState], a                 ; $50DB: $E0 $9D
+
     xor  a                                        ; $50DD: $AF
-    ld   [wC19B], a                               ; $50DE: $EA $9B $C1
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $50DE: $EA $9B $C1
+
     ret                                           ; $50E1: $C9
 
 label_018_50E2:
@@ -4414,7 +4416,8 @@ MarinAtTalTalHeightsState3Handler::
 
 jr_018_5FBF:
     xor  a                                        ; $5FBF: $AF
-    ld   [wC19B], a                               ; $5FC0: $EA $9B $C1
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $5FC0: $EA $9B $C1
+
     call GetEntityTransitionCountdown             ; $5FC3: $CD $05 $0C
     ld   [hl], $10                                ; $5FC6: $36 $10
     jp   IncrementEntityState                     ; $5FC8: $C3 $12 $3B

--- a/src/code/entities/bank19.asm
+++ b/src/code/entities/bank19.asm
@@ -69,7 +69,7 @@ LiftableStatueState0Handler::
     cp   $30                                      ; $4085: $FE $30
     jp   nc, label_019_411C                       ; $4087: $D2 $1C $41
 
-    ld   a, [wC19B]                               ; $408A: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $408A: $FA $9B $C1
     and  a                                        ; $408D: $A7
     jp   nz, label_019_411C                       ; $408E: $C2 $1C $41
 
@@ -3593,7 +3593,7 @@ jr_019_5922:
     cp   $24                                      ; $592F: $FE $24
     ret  nc                                       ; $5931: $D0
 
-    ld   a, [wC19B]                               ; $5932: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $5932: $FA $9B $C1
     and  a                                        ; $5935: $A7
     ret  nz                                       ; $5936: $C0
 
@@ -3834,7 +3834,7 @@ jr_019_5A9F:
     call CheckLinkCollisionWithEnemy_trampoline   ; $5AA2: $CD $5A $3B
     ret  nc                                       ; $5AA5: $D0
 
-    ld   a, [wC19B]                               ; $5AA6: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $5AA6: $FA $9B $C1
     and  a                                        ; $5AA9: $A7
     ret  nz                                       ; $5AAA: $C0
 

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -5633,7 +5633,8 @@ func_003_68F8::
     jr   c, .return                               ; $696C: $38 $32
 
     xor  a                                        ; $696E: $AF
-    ld   [wC19B], a                               ; $696F: $EA $9B $C1
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $696F: $EA $9B $C1
+
     ld   hl, wEntitiesPosXTable                         ; $6972: $21 $00 $C2
     add  hl, de                                   ; $6975: $19
     ldh  a, [hSwordIntersectedAreaX]              ; $6976: $F0 $CE

--- a/src/code/entities/bank7.asm
+++ b/src/code/entities/bank7.asm
@@ -195,7 +195,7 @@ jr_007_4128:
     call CheckLinkCollisionWithEnemy_trampoline   ; $4137: $CD $5A $3B
     ret  nc                                       ; $413A: $D0
 
-    ld   a, [wC19B]                               ; $413B: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $413B: $FA $9B $C1
     and  a                                        ; $413E: $A7
     ret  nz                                       ; $413F: $C0
 
@@ -5015,7 +5015,7 @@ jr_007_60DD:
     call CheckLinkCollisionWithEnemy_trampoline   ; $60DD: $CD $5A $3B
     jr   nc, jr_007_6133                          ; $60E0: $30 $51
 
-    ld   a, [wC19B]                               ; $60E2: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $60E2: $FA $9B $C1
     and  a                                        ; $60E5: $A7
     jr   nz, jr_007_6133                          ; $60E6: $20 $4B
 
@@ -8595,7 +8595,7 @@ label_007_7733:
     call CheckLinkCollisionWithEnemy_trampoline   ; $7733: $CD $5A $3B
     jr   nc, jr_007_7783                          ; $7736: $30 $4B
 
-    ld   a, [wC19B]                               ; $7738: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $7738: $FA $9B $C1
     and  a                                        ; $773B: $A7
     jr   nz, jr_007_7783                          ; $773C: $20 $45
 

--- a/src/code/entities/cucco.asm
+++ b/src/code/entities/cucco.asm
@@ -113,7 +113,7 @@ jr_005_45BF:
     cp   $03                                      ; $45C6: $FE $03
     jr   z, jr_005_4611                           ; $45C8: $28 $47
 
-    ld   a, [wC19B]                               ; $45CA: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $45CA: $FA $9B $C1
     and  a                                        ; $45CD: $A7
     jr   nz, jr_005_4611                          ; $45CE: $20 $41
 

--- a/src/code/entities/smasher.asm
+++ b/src/code/entities/smasher.asm
@@ -449,7 +449,7 @@ jr_006_4806:
     call CheckLinkCollisionWithEnemy_trampoline   ; $4806: $CD $5A $3B
     jr   nc, jr_006_4852                          ; $4809: $30 $47
 
-    ld   a, [wC19B]                               ; $480B: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $480B: $FA $9B $C1
     and  a                                        ; $480E: $A7
     jr   nz, jr_006_4852                          ; $480F: $20 $41
 

--- a/src/code/entities/tarin.asm
+++ b/src/code/entities/tarin.asm
@@ -119,7 +119,7 @@ jr_005_49FD:
     call ShouldLinkTalkToEntity_05                ; $49FD: $CD $06 $55
     jr   nc, jr_005_4A0C                          ; $4A00: $30 $0A
 
-    ld   a, [wC19B]                               ; $4A02: $FA $9B $C1
+    ld   a, [wLinkAttackStepAnimationCountdown]   ; $4A02: $FA $9B $C1
     and  a                                        ; $4A05: $A7
     ret  nz                                       ; $4A06: $C0
 
@@ -136,8 +136,10 @@ Data_005_4A11::
 func_005_4A17::
     ld   a, $02                                   ; $4A17: $3E $02
     ldh  [hLinkInteractiveMotionBlocked], a       ; $4A19: $E0 $A1
+
     xor  a                                        ; $4A1B: $AF
-    ld   [wC19B], a                               ; $4A1C: $EA $9B $C1
+    ld   [wLinkAttackStepAnimationCountdown], a   ; $4A1C: $EA $9B $C1
+
     call func_005_7B24                            ; $4A1F: $CD $24 $7B
     ld   a, e                                     ; $4A22: $7B
     xor  $01                                      ; $4A23: $EE $01

--- a/src/constants/gfx.asm
+++ b/src/constants/gfx.asm
@@ -160,5 +160,10 @@ ROOM_SWITCHABLE_OBJECT_NONE          equ $0
 ROOM_SWITCHABLE_OBJECT_SWITCH_BUTTON equ $1
 ROOM_SWITCHABLE_OBJECT_MOBILE_BLOCK  equ $2
 
+; Values for the highest bit of wLinkAttackStepAnimationCountdown
+ATTACK_STEP_ITEM_ANY                 equ $00
+ATTACK_STEP_ITEM_MAGIC_ROD           equ $80
+ATTACK_STEP_DURATION_MASK            equ $7F ; extract the duration value, without the item type part
+
 ; height of the window on the top of the screen
 WINDOW_HEIGHT equ 2 ; number in tiles

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -698,8 +698,16 @@ wC198::
 wC199::
   ds 2 ; C199 - C19A
 
-; Unlabeled
-wC19B::
+; Link attack-step animation timer.
+;
+; When the timer is non-zero, display an attack-step animation for Link –
+; for instance when slashing the sword, or when throwing a projectile.
+;
+; Bit 7: is the attack step triggered by the magic rod
+; Bits 6-0: countdown until the animation ends
+;
+; See ATTACK_STEP_ITEM constants
+wLinkAttackStepAnimationCountdown::
   ds 1 ; C19B
 
 ; Unlabeled


### PR DESCRIPTION
Weird stuff: the magic rod fireball isn't fired when using the item, but on the second frame of the attack step animation instead.

I wonder what kind of weird bug led to this…