### PR TITLE
Fix and improve Backgrounds decoding and encoding

### DIFF
--- a/src/data/backgrounds/README.md
+++ b/src/data/backgrounds/README.md
@@ -19,3 +19,25 @@ To make change to a tilemap:
     ```
     tools/convert_background.py encode src/data/backgrounds/marin_beach.tilemap --output src/data/backgrounds/marin_beach.tilemap.encoded
     ```
+
+## Background color
+
+Some tilemaps take advantage of the backround being pre-filled with an initial color.
+For instance, the file menu tilemaps assume that the background has been filled with black tiles
+(7E) beforehand.
+
+When decoding a tilemap, this initial color can be specified using the `--filler` command line argument.
+
+And when encoding a tilemap, if an initial color is specified, long repeated sequences of this
+color will be ignored (which will reduce both the encoded tilemap size and the overdraw)
+
+For instance:
+
+```
+# Decode a tilemap using an initial color
+tools/convert_background.py decode src/data/backgrounds/menu_file_creation.tilemap.encoded --filler 0x7E --outfile src/data/backgrounds/menu_file_creation.tilemap
+# Edit using an external tool
+# …
+# Re-encode the tilemap without storing the initial color
+tools/convert_background.py encode src/data/backgrounds/menu_file_creation.tilemap --filler 0x7E --outfile src/data/backgrounds/menu_file_creation.tilemap.encoded
+```

--- a/tools/convert_background.py
+++ b/tools/convert_background.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         write_result(result, outfile, wrap_count=args.wrap)
 
     elif args.command == 'encode':
-        result = BackgroundCoder.encode(data, args.location, args.width)
+        result = BackgroundCoder.encode(data, args.location, args.width, args.filler)
         write_result(result, outfile)
 
     outfile.close()


### PR DESCRIPTION
## Summary

- Fix the decoding of BG maps with repeated commands
- Improve the BG map encoder to have a better compression ratio
- Allow configuring the BG map initial value ("filler") before decoding a BG map, to make the tilemap easier to edit
- Allow configuring the BG map initial value ("filler") before encoding a BG map, to reduce the file size and ensure tiles written manually won't get overwritten

## The issue

User @Javs on Discord reported an issue occurring when editing the Background tilemap of the File creation menu. When decoding, editing and then re-encoding this specific tilemap, the tile indicating the save slot number would disappear.

![file creation screenshots](https://user-images.githubusercontent.com/179923/142762738-8fc751e2-5c83-49a6-b4f1-05671a6ad1e3.png)
_On the left, the original version. On the right, the edited version, lacking the save slot number._

Now why did that happen? Turns out a combination of different issues.

## Investigating

The first thing we tried was to disassemble the relevant code.

When displaying this specific screen, there are two loading stages before the screen becomes interactive:

1. The game requests the BG map to be filled with black tiles during the next vblank,
2. Then the game simultaneously:
   2.1 requests the file creation tilemap (and attrmap) to be loaded during the next vblank,
   2.2 and requests a specific tile to be written to the BG map during the next vblank: the save slot index.

So far, so good. Now why doesn't this work anymore when the tilemap has been edited?

A possible cause of troubles is that Link's Awakening tilemaps use a custom compression format, where repeated tiles can be "painted" over the screen. And most of the time, these compressed tilemaps were handwritten. So when we decode and re-encode a tilemap, there's always a difference in how the compression is expressed (because the automatic encoding program doesn't make the same choices than the original artists). In the end, the re-encoded tilemap is supposed to be functionaly equivalent.

But could the different encoding trigger some underlying issues, like a race condition? What if the original encoding wrote to the top of the screen first, but the new re-encoding wrote to the top of the screen last, overwriting the changes made manually to the BG map?

Turns out the issue was simpler than that.

To save space, the original tilemaps often don't encode the bytes for the background color. Instead they first fill the whole BG map with black (or white) tiles, then "paint" the tilemap over this background color. This is precisely what the File creation BG tilemap does: it only paints the bricks and letters, not the black areas.

![File creation screen + overlay](https://user-images.githubusercontent.com/179923/142764095-67a11309-a831-48d0-a20b-93584a9a31f9.png)
_The original tilemap only draws the tiles different from the background color._

When decoding the tilemap, we want the result to be editable using an external tool. So the decoder does the same steps: filling the background with a default color, and then painting over. Which means the background color gets included into the decoded tilemap.

But when re-encoding the tilemap, the background color was also imported into the file. Which resulted in the tilemap containing draw commands for all the black background areas.

![File creation screen edited + overlay](https://user-images.githubusercontent.com/179923/142764119-b02c7db1-6389-4ecc-b061-d3594ecc00cd.png)
_But an edited tilemap used to define draw commands for the whole screen._

This is not only wasteful, it also means that the game paints the tilemap bytes twice: once when filling the Background with the default color, and once again when reading the tilemap.

And that was our issue: the game filled the background with black, then wrote the tile for the save slot number and painted the tilemap. As the save slot number is written over a black tile, it wasn't overwritten by the original tilemap. But it was by the re-encoded version.

## The fix

In theory, fixing the issue was easy: we just had to ignore the background color when re-encoding the BG map.

That said, the actual fix took some evenings. The encoder didn't had any proper compression scheme implemented (all bytes were always written sequentially), but to allow some bytes to be skipped, a proper implementation of writing only to certain regions was needed. This also uncovered several bugs in the decoder part, which had to be solved.

## Conclusion

In the end:
- Decoding an original BG tilemap or attrmap is more reliable, and produces better results;
- Encoding a decoded tilemap ignores filler bytes, which fixes the issue with the File creation screen;
- The encoded tilemaps are now even smaller than the original hand-tuned ones.

And there's our fixed version in-game:

![unknown-1](https://user-images.githubusercontent.com/179923/142763825-2281b1ef-199f-4588-85d8-fe2ac1fbe90d.png)
_The edited File creation tilemap, with the save slot number correctly displayed._ 

A remaining caveat is that, for now, the background color has to be specified manually, both when decoding and encoding the tilemap. For instance:

```shell
# Decoding
tools/convert_background.py decode src/data/backgrounds/menu_file_creation.tilemap.encoded --filler 0x7E --outfile src/data/backgrounds/menu_file_creation.tilemap
# Editing using an external tool
# …
# Re-encoding
tools/convert_background.py encode src/data/backgrounds/menu_file_creation.tilemap --filler 0x7E --outfile src/data/backgrounds/menu_file_creation.tilemap.encoded
```

But hopefully this is something that can be defined by the file name at some point.