### PR TITLE
Fix shiftability issues when loading a room object attributes

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -552,6 +552,9 @@ CopyObjectsAttributesToWRAM2::
     ret                                           ; $0B2E: $C9
 
 ; On GBC, copy some overworld objects to ram bank 2
+; Inputs:
+;   a  data bank?
+;   hl destination in RAM bank 2
 func_2BF::
     ldh  [hMultiPurpose2], a                      ; $0B2F: $E0 $D9
     ldh  a, [hIsGBC]                              ; $0B31: $F0 $FE
@@ -5873,10 +5876,12 @@ LoadRoomTilemap:
     pop  hl                                       ; $30C5: $E1
     pop  de                                       ; $30C6: $D1
 
+    ; Increment the object pointer in wRoomObjects
     inc  hl                                       ; $30C7: $23
+    ; When the end of a objects line is reached, move to the next one.
     ld   a, l                                     ; $30C8: $7D
     and  $0F                                      ; $30C9: $E6 $0F
-    cp   $0B                                      ; $30CB: $FE $0B
+    cp   OBJECTS_PER_ROW + 1                      ; $30CB: $FE $0B
     jr   nz, .lEnd                                ; $30CD: $20 $06
     ld   a, l                                     ; $30CF: $7D
     and  $F0                                      ; $30D0: $E6 $F0
@@ -5884,12 +5889,14 @@ LoadRoomTilemap:
     ld   l, a                                     ; $30D4: $6F
 .lEnd
 
+    ; Increment the tiles pointer in vBGMap0
     ld   a, e                                     ; $30D5: $7B
     add  a, $02                                   ; $30D6: $C6 $02
     ld   e, a                                     ; $30D8: $5F
+    ; When the end of a tiles line is reached, move to the next one.
     and  $1F                                      ; $30D9: $E6 $1F
-    cp   $14                                      ; $30DB: $FE $14
-    jr   nz, .aEnd                                ; $30DD: $20 $0A
+    cp   (DISPLAY_WIDTH / TILE_WIDTH)             ; $30DB: $FE $14
+    jr   nz, .eEnd                                ; $30DD: $20 $0A
     ld   a, e                                     ; $30DF: $7B
     and  $E0                                      ; $30E0: $E6 $E0
     add  a, $40                                   ; $30E2: $C6 $40
@@ -5897,7 +5904,7 @@ LoadRoomTilemap:
     ld   a, d                                     ; $30E5: $7A
     adc  a, $00                                   ; $30E6: $CE $00
     ld   d, a                                     ; $30E8: $57
-.aEnd
+.eEnd
 
     ; Loop until all objects of the room are copied to the BG
     dec  c                                        ; $30E9: $0D

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -5879,6 +5879,8 @@ LoadRoomTilemap:
     ; Increment the object pointer in wRoomObjects
     inc  hl                                       ; $30C7: $23
     ; When the end of a objects line is reached, move to the next one.
+    ; (NB: this assumes that wRoomObjectsArea is $10-bytes aligned)
+ASSERT LOW(wRoomObjectsArea) & $0F == 0, "wRoomObjectsArea must be aligned on $10 addresses"
     ld   a, l                                     ; $30C8: $7D
     and  $0F                                      ; $30C9: $E6 $0F
     cp   OBJECTS_PER_ROW + 1                      ; $30CB: $FE $0B

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5468,14 +5468,14 @@ LoadRoomObjectsAttributes::
     ; Copy the objects attributes to the room objects attributes in WRAM 2
     ld   de, wRoomObjects                         ; $6E3C: $11 $11 $D7
 .loop
-    ld   bc, $0A                                  ; $6E3F: $01 $0A $00
+    ld   bc, OBJECTS_PER_ROW                      ; $6E3F: $01 $0A $00
     push de                                       ; $6E42: $D5
-    call CopyObjectsAttributesToWRAM2                  ; $6E43: $CD $1A $0B
+    call CopyObjectsAttributesToWRAM2             ; $6E43: $CD $1A $0B
     pop  de                                       ; $6E46: $D1
     ld   a, e                                     ; $6E47: $7B
     add  $10                                      ; $6E48: $C6 $10
     ld   e, a                                     ; $6E4A: $5F
-    cp   $91                                      ; $6E4B: $FE $91
+    cp   OBJECTS_PER_COLUMN * $10                 ; $6E4B: $FE $91
     jr   nz, .loop                                ; $6E4D: $20 $F0
 
     ret                                           ; $6E4F: $C9
@@ -5486,22 +5486,22 @@ func_020_6E50::
     ld   b, $0E                                   ; $6E52: $06 $0E
     ld   hl, Data_020_6E65                        ; $6E54: $21 $65 $6E
 
-jr_020_6E57:
+.loop
     ld   a, [hl+]                                 ; $6E57: $2A
     cp   c                                        ; $6E58: $B9
-    jr   nz, jr_020_6E5F                          ; $6E59: $20 $04
+    jr   nz, .jr_020_6E5F                         ; $6E59: $20 $04
 
     scf                                           ; $6E5B: $37
     ccf                                           ; $6E5C: $3F
-    jr   jr_020_6E63                              ; $6E5D: $18 $04
+    jr   .done                                    ; $6E5D: $18 $04
 
-jr_020_6E5F:
+.jr_020_6E5F
     dec  b                                        ; $6E5F: $05
-    jr   nz, jr_020_6E57                          ; $6E60: $20 $F5
+    jr   nz, .loop                                ; $6E60: $20 $F5
 
     scf                                           ; $6E62: $37
 
-jr_020_6E63:
+.done
     pop  hl                                       ; $6E63: $E1
     ret                                           ; $6E64: $C9
 

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5466,6 +5466,8 @@ LoadRoomObjectsAttributes::
 
 .copyAttributes
     ; Copy the objects attributes to the room objects attributes in WRAM 2
+    ; (NB: this assumes that wRoomObjectsArea is $10-bytes aligned)
+ASSERT LOW(wRoomObjectsArea) & $0F == 0, "wRoomObjectsArea must be aligned on $10 addresses"
     ld   de, wRoomObjects                         ; $6E3C: $11 $11 $D7
 .loop
     ld   bc, OBJECTS_PER_ROW                      ; $6E3F: $01 $0A $00

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5475,7 +5475,7 @@ LoadRoomObjectsAttributes::
     ld   a, e                                     ; $6E47: $7B
     add  $10                                      ; $6E48: $C6 $10
     ld   e, a                                     ; $6E4A: $5F
-    cp   OBJECTS_PER_COLUMN * $10                 ; $6E4B: $FE $91
+    cp   LOW(wRoomObjects) + OBJECTS_PER_COLUMN * $10 ; $6E4B: $FE $91
     jr   nz, .loop                                ; $6E4D: $20 $F0
 
     ret                                           ; $6E4F: $C9

--- a/src/constants/constants.asm
+++ b/src/constants/constants.asm
@@ -1,6 +1,7 @@
 ;
 ; Useful definitions
 ;
+include "constants/gbhw.asm"
 include "constants/defines.asm"
 
 ;
@@ -32,9 +33,8 @@ include "constants/charmaps/main.asm"
 include "constants/charmaps/name_entry.asm"
 
 ;
-; GameBoy hardware and memory setup
+; Memory layout
 ;
-include "constants/gbhw.asm"
 include "constants/memory/hram.asm"
 include "constants/memory/sram.asm"
 include "constants/memory/vram.asm"

--- a/src/constants/gfx.asm
+++ b/src/constants/gfx.asm
@@ -1,4 +1,11 @@
-; constants for graphic constants
+; constants for graphics
+
+; Number of game objects in one BG map row
+OBJECTS_PER_ROW    equ DISPLAY_WIDTH/(TILE_WIDTH*2)
+; Number of game objects in one BG map column
+OBJECTS_PER_COLUMN equ DISPLAY_HEIGHT/(TILE_HEIGHT*2) - 1
+; Number of game objects in a whole room BG map
+OBJECTS_PER_ROOM   equ OBJECTS_PER_ROW * OBJECTS_PER_COLUMN
 
 ; Values for wTilesetToLoad
 TILESET_ROOM_TILEMAP                  equ $01

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -2629,8 +2629,9 @@ wBGMapToLoad::
 ; When loading a new room, room data is read and decoded into this
 ; area.
 ;
-; NB: this area is also used in RAM bank 2, where it contains
-; the object attributes.
+; Notes on wram hiftability:
+; - This area is also used in RAM bank 2, where it contains the object attributes.
+; - wRoomObjectsArea must be $10-bytes aligned (otherwise various copy loops break)
 ;
 ; First section is FF values padding…
 wRoomObjectsArea::


### PR DESCRIPTION
Currently, when shifting WRAM $D000 by 16 bytes, loading of object attributes in the Overworld rooms breaks.

<img width="160" alt="Capture d’écran 2022-03-07 à 09 17 19" src="https://user-images.githubusercontent.com/179923/156993608-5e3dffd4-57ed-4d86-9a64-2575dbae2f19.png">

This PR :
- Documents that wRoomObjectsArea must be aligned on $10 addresses, and assert for this in the code
- Fixes the shiftability issue when shifting $D000 by a multiple of $10 (which works now!)

<img width="161" alt="Capture d’écran 2022-03-07 à 09 16 53" src="https://user-images.githubusercontent.com/179923/156993787-15b55d4e-b9d0-4a2d-a5e4-4988b435004c.png">

See #409