### PR TITLE
Fix some issues with WRAM shiftability

### DIFF
--- a/src/code/audio/music_2.asm
+++ b/src/code/audio/music_2.asm
@@ -845,6 +845,7 @@ func_01E_4581::
     jp   nz, DontPlayAudio_1E                     ; $458B: $C2 $2B $40
 
     call func_01E_4387                            ; $458E: $CD $87 $43
+
     ld   a, $01                                   ; $4591: $3E $01
     ld   [wActiveChannelIndex], a                 ; $4593: $EA $50 $D3
     ld   hl, wD310                                ; $4596: $21 $10 $D3
@@ -1082,13 +1083,13 @@ label_01E_46BD:
     ld   hl, Data_01E_4A51                        ; $46C6: $21 $51 $4A
     add  hl, bc                                   ; $46C9: $09
 
-jr_01E_46CA:
+.loop
     ld   a, [hl+]                                 ; $46CA: $2A
     ld   [de], a                                  ; $46CB: $12
     inc  e                                        ; $46CC: $1C
     ld   a, e                                     ; $46CD: $7B
-    cp   $4B                                      ; $46CE: $FE $4B
-    jr   nz, jr_01E_46CA                          ; $46D0: $20 $F8
+    cp   LOW(wD346 + 5)                           ; $46CE: $FE $4B
+    jr   nz, .loop                                ; $46D0: $20 $F8
 
     ld   c, $20                                   ; $46D2: $0E $20
     ld   hl, wD344                                ; $46D4: $21 $44 $D3

--- a/src/code/audio/sfx_entry_point.asm
+++ b/src/code/audio/sfx_entry_point.asm
@@ -1,20 +1,20 @@
 ; Entry point for the Sfx sound system
 SoundSystemInit::
-    jp   label_01F_4009                           ; $4000: $C3 $09 $40
+    jp   _SoundSystemInit                         ; $4000: $C3 $09 $40
 
 func_01F_4003::
     jp   func_01F_7B5C                            ; $4003: $C3 $5C $7B
 
 PlaySfx::
-    jp   label_01F_401E                           ; $4006: $C3 $1E $40
+    jp   _PlaySfx                                 ; $4006: $C3 $1E $40
 
-label_01F_4009:
-    ld   hl, wMusicTranspose                      ; $4009: $21 $00 $D3
-
-jr_01F_400C:
+_SoundSystemInit::
+    ; Clear 16 bytes of memory, starting from wAudioSection
+    ld   hl, wAudioSection                        ; $4009: $21 $00 $D3
+.loop
     ld   [hl], $00                                ; $400C: $36 $00
     inc  l                                        ; $400E: $2C
-    jr   nz, jr_01F_400C                          ; $400F: $20 $FB
+    jr   nz, .loop                                ; $400F: $20 $FB
 
     ld   a, $80                                   ; $4011: $3E $80
     ldh  [rNR52], a                               ; $4013: $E0 $26
@@ -24,7 +24,7 @@ jr_01F_400C:
     ldh  [rNR51], a                               ; $401B: $E0 $25
     ret                                           ; $401D: $C9
 
-label_01F_401E:
+_PlaySfx::
     call PlayActiveJingle                         ; $401E: $CD $04 $42
     call PlayActiveWaveSfx                        ; $4021: $CD $ED $53
     call PlayActiveNoiseSfx                       ; $4024: $CD $EC $64

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -1346,7 +1346,7 @@ DialogOpenAnimationStart::
 
 jr_014_545A:
     ld   a, [wGameplayType]                       ; $545A: $FA $95 $DB
-    cp   $01                                      ; $545D: $FE $01
+    cp   GAMEPLAY_CREDITS                         ; $545D: $FE $01
     jr   z, jr_014_547F                           ; $545F: $28 $1E
 
     ld   a, [wObjectAffectingBGPalette]           ; $5461: $FA $CB $C3
@@ -1377,7 +1377,7 @@ jr_014_547F:
     ret  z                                        ; $548B: $C8
 
     ld   a, [wGameplayType]                       ; $548C: $FA $95 $DB
-    cp   $0B                                      ; $548F: $FE $0B
+    cp   GAMEPLAY_WORLD                           ; $548F: $FE $0B
     ret  nz                                       ; $5491: $C0
 
     ld   a, [wBGPaletteEffectAddress]             ; $5492: $FA $CC $C3

--- a/src/code/home/dialog.asm
+++ b/src/code/home/dialog.asm
@@ -161,9 +161,9 @@ func_23E4::
     ld   hl, data_23D2 - $02                      ; $23F2: $21 $D0 $23
     add  hl, de                                   ; $23F5: $19
     ld   a, [hl]                                  ; $23F6: $7E
-    add  a, $00                                   ; $23F7: $C6 $00
+    add  a, LOW(wD500)                            ; $23F7: $C6 $00
     ld   c, a                                     ; $23F9: $4F
-    ld   a, $D5                                   ; $23FA: $3E $D5
+    ld   a, HIGH(wD500)                           ; $23FA: $3E $D5
     adc  a, $00                                   ; $23FC: $CE $00
     ld   b, a                                     ; $23FE: $47
 

--- a/src/code/home/dialog.asm
+++ b/src/code/home/dialog.asm
@@ -148,14 +148,14 @@ data_23DC::
 
 ; Open dialog animation
 ; Saves tiles under the dialog box?
-label_23E4::
+func_23E4::
     ld   a, [wDialogState]                        ; $23E4: $FA $9F $C1
     bit  7, a                                     ; $23E7: $CB $7F
-    jr   z, label_23EF                            ; $23E9: $28 $04
+    jr   z, .jr_23EF                              ; $23E9: $28 $04
     and  $7F                                      ; $23EB: $E6 $7F
     add  a, $03                                   ; $23ED: $C6 $03
+.jr_23EF
 
-label_23EF::
     ld   e, a                                     ; $23EF: $5F
     ld   d, $00                                   ; $23F0: $16 $00
     ld   hl, data_23D2 - $02                      ; $23F2: $21 $D0 $23
@@ -166,6 +166,7 @@ label_23EF::
     ld   a, $D5                                   ; $23FA: $3E $D5
     adc  a, $00                                   ; $23FC: $CE $00
     ld   b, a                                     ; $23FE: $47
+
     ld   hl, data_23DC                            ; $23FF: $21 $DC $23
     add  hl, de                                   ; $2402: $19
     ld   a, [wBGOriginLow]                        ; $2403: $FA $2F $C1
@@ -186,36 +187,39 @@ label_23EF::
     and  a                                        ; $241B: $A7
     jr   nz, label_2444                           ; $241C: $20 $26
 
-label_241E::
+    ; DMG version of the loop
+.loop
     ld   a, [hli]                                 ; $241E: $2A
     ld   [bc], a                                  ; $241F: $02
     inc  bc                                       ; $2420: $03
+
     ld   a, l                                     ; $2421: $7D
     and  $1F                                      ; $2422: $E6 $1F
-    jr   nz, label_242B                           ; $2424: $20 $05
+    jr   nz, .jr_242B                             ; $2424: $20 $05
     ld   a, l                                     ; $2426: $7D
     dec  a                                        ; $2427: $3D
     and  $E0                                      ; $2428: $E6 $E0
     ld   l, a                                     ; $242A: $6F
+.jr_242B
 
-label_242B::
     inc  e                                        ; $242B: $1C
     ld   a, e                                     ; $242C: $7B
     cp   $12                                      ; $242D: $FE $12
-    jr   nz, label_241E                           ; $242F: $20 $ED
+    jr   nz, .loop                                ; $242F: $20 $ED
+
     ld   e, $00                                   ; $2431: $1E $00
     ldh  a, [hMultiPurpose0]                      ; $2433: $F0 $D7
     add  a, $20                                   ; $2435: $C6 $20
     ldh  [hMultiPurpose0], a                      ; $2437: $E0 $D7
-    jr   nc, label_243C                           ; $2439: $30 $01
+    jr   nc, .jr_243C                             ; $2439: $30 $01
     inc  h                                        ; $243B: $24
+.jr_243C
 
-label_243C::
     ld   l, a                                     ; $243C: $6F
     inc  d                                        ; $243D: $14
     ld   a, d                                     ; $243E: $7A
     cp   $02                                      ; $243F: $FE $02
-    jr   nz, label_241E                           ; $2441: $20 $DB
+    jr   nz, .loop                                ; $2441: $20 $DB
     ret                                           ; $2443: $C9
 
 label_2444::
@@ -312,7 +316,7 @@ UpdateDialogState_return:
     ret                                           ; $24AE: $C9
 
 DialogClosingBeginHandler::
-    jpsb func_01C_4AA8                            ; $24AF: $3E $1C $EA $00 $21 $C3 $A8 $4A
+    jpsb AnimateDialogClosing                     ; $24AF: $3E $1C $EA $00 $21 $C3 $A8 $4A
 
 DialogLetterAnimationStartHandler::
     ld   a, BANK(func_01C_49F1)                   ; $24B7: $3E $1C

--- a/src/code/home/interrupts.asm
+++ b/src/code/home/interrupts.asm
@@ -268,7 +268,7 @@ InterruptVBlank::
     jr   nc, .renderDialogText                    ; $04A0: $30 $0A
     ; DialogState < 5
     ; Open dialog
-    call label_23E4                               ; $04A2: $CD $E4 $23
+    call func_23E4                                ; $04A2: $CD $E4 $23
     ld   hl, wDialogState                         ; $04A5: $21 $9F $C1
     inc  [hl]  ; Increment DialogState            ; $04A8: $34
     jp   .vblankDone                              ; $04A9: $C3 $69 $05

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -2521,7 +2521,7 @@ wDungeonMinimap::
 wD4C0::
   ds $40 ; D4C0 - D4FF
 
-; Unlabeled
+; BG tilemap under a dialog box?
 wD500::
   ds $80 ; D500 - D57F
 


### PR DESCRIPTION
Part of #409. With the $D000 WRAM offseted by $10, the following issues are fixed:

- In the file selection menu, the code no longer crashes after ~1s, after having written invalid data to the audio WRAM;
- When closing a dialog box, the restored tiles under the dialog box are no longer corrupted.

Now the game is fairly playable with the whole WRAM offseted by $10.