### PR TITLE
code: document Eagle's Tower unused clouds tilemap

### DIFF
--- a/src/constants/gfx.asm
+++ b/src/constants/gfx.asm
@@ -66,7 +66,7 @@ TILEMAP_MENU_FILE_CREATION           equ $05
 TILEMAP_MENU_FILE_ERASE              equ $06
 TILEMAP_MINIMAP                      equ $07
 TILEMAP_WORLD_MAP                    equ $08
-TILEMAP_09                           equ $09
+TILEMAP_EAGLES_TOWER_CLOUDS          equ $09
 TILEMAP_GAME_OVER                    equ $0A
 TILEMAP_INVENTORY_DEBUG              equ $0B
 TILEMAP_MENU_FILE_COPY               equ $0C

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -3214,8 +3214,8 @@ wHasInstrument6::
 
 ; @TODO Dungeon 1-9 *flags*, not instrument checks
 ; bit 0: miniboss clear
-; bit 1: set if true
-; bit 2: (?)
+; bit 1: has instrument
+; bit 2: is eagle's tower collapsed
 ; 0 = false
 wHasInstrument7::
   ds 1 ; DB6B


### PR DESCRIPTION
Tilemap09 is actually the unused tilemap for animated Eagle's Tower clouds.

![Zelda_LinksAwakening_Eagle_Tower](https://user-images.githubusercontent.com/179923/160293110-4a765d30-143a-4028-9cc9-e0695d5271fd.png)


See [Eagle Tower Boss Fight](https://tcrf.net/The_Legend_of_Zelda:_Link%27s_Awakening_(Game_Boy)/Room_Design_Changes#Eagle_Tower_Boss_Fight) on The Cutting Room Floor.