### PR TITLE
Support RGBDS v0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: kemenaran/rgbds:0.5.2
+      - image: kemenaran/rgbds:0.6.0
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,25 @@
 # Dev tools binaries and options
 #
 
-# Get rgbasm version
-ASMVER    := $(shell rgbasm --version | cut -f2 -dv)
-ASMVERMAJ := $(shell echo $(ASMVER) | cut -f1 -d.)
-ASMVERMIN := $(shell echo $(ASMVER) | cut -f2 -d.)
-
 2BPP    := rgbgfx
 
 ASM     := rgbasm
+
+# Get assembler version
+ASMVER    := $(shell $(ASM) --version | cut -f2 -dv)
+ASMVERMAJ := $(shell echo $(ASMVER) | cut -f1 -d.)
+ASMVERMIN := $(shell echo $(ASMVER) | cut -f2 -d.)
+
+# Abort if RGBDS version is too low and 'clean' is not the only target
+ifneq ($(MAKECMDGOALS), "clean")
+  ifeq ($(shell expr \
+    \( $(ASMVERMAJ) = 0 \) \&\
+    \( $(ASMVERMIN) \< 5 \)\
+  ), 1)
+    $(error Requires RGBDS version >= 0.5.0)
+  endif
+endif
+
 ASFLAGS := --export-all
 
 # If we're using RGBDS >= 0.6.0, add flags to force behavior that used to be default

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,29 @@
 #
 # Dev tools binaries and options
 #
+
+# Get rgbasm version
+ASMVER    := $(shell rgbasm --version | cut -f2 -dv)
+ASMVERMAJ := $(shell echo $(ASMVER) | cut -f1 -d.)
+ASMVERMIN := $(shell echo $(ASMVER) | cut -f2 -d.)
+
 2BPP    := rgbgfx
 
 ASM     := rgbasm
 ASFLAGS := --export-all
+
+# If we're using RGBDS >= 0.6.0, add flags to force behavior that used to be default
+ifeq ($(shell expr \
+  \( $(ASMVERMAJ) \> 0 \) \|\
+  \(\
+    \( $(ASMVERMAJ) = 0 \) \&\
+    \( $(ASMVERMIN) \> 5 \)\
+  \)\
+), 1)
+  ASFLAGS += \
+    --auto-ldh\
+    --nop-after-halt
+endif
 
 LD      := rgblink
 LDFLAGS :=


### PR DESCRIPTION
We explicitly opt into behavior that might stop being the default (LDH optimization and HALT/NOP).

This removes the following warnings when building with RGBASM >= v0.60:

```
rgbasm --export-all -DLANG=EN -DVERSION=0 -i src/ -o src/main.azle.o src/main.asm
warning: src/main.asm(16) -> src/code/bank0.asm(5) -> src/code/home/init.asm(12): [-Wobsolete]
    ld optimization will stop being the default; pass `-l` to opt into it
warning: src/main.asm(16) -> src/code/bank0.asm(6) -> src/code/home/render_loop.asm(368): [-Wobsolete]
    `nop` after `halt` will stop being the default; pass `-H` to opt into it
```