### PR TITLE
tools: add --no-file-terminator to convert_background.py

### DIFF
--- a/src/data/backgrounds/README.md
+++ b/src/data/backgrounds/README.md
@@ -22,7 +22,7 @@ To make change to a tilemap:
 
 ## Background color
 
-Some tilemaps take advantage of the backround being pre-filled with an initial color.
+Some tilemaps take advantage of the background being pre-filled with an initial color.
 For instance, the file menu tilemaps assume that the background has been filled with black tiles
 (7E) beforehand.
 
@@ -41,3 +41,21 @@ tools/convert_background.py decode src/data/backgrounds/menu_file_creation.tilem
 # Re-encode the tilemap without storing the initial color
 tools/convert_background.py encode src/data/backgrounds/menu_file_creation.tilemap --filler 0x7E --output src/data/backgrounds/menu_file_creation.tilemap.encoded
 ```
+
+## File terminator
+
+Although most tilemaps end with a file terminator (0x00), some of them are partial tilemaps, and omit
+this terminator. At runtime, after rendering the tilemap, the game continue rendering and fallback on
+the next tilemap stored in the ROM or RAM (usually a menu).
+
+In the original game, this concerns these files:
+- menu_file_selection_commands.tilemap.encoded
+- menu_file_selection_commands.attrmap.encoded
+
+To handle this case, both the decoder and encoder support a `--no-file-terminator` option.
+
+When **decoding**, `--no-file-terminator` tells the decoder that the file is expected to end abruptely.
+
+When **encoding**, `--no-file-terminator` tells the encoder not to append the NULL file terminator at the end of the file.
+
+This option should be used when decoding and encoding the relevant files.

--- a/tools/convert_background.py
+++ b/tools/convert_background.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
     options_parser.add_argument('--output', '-o', type=str, metavar='outfile', action='store', help='file to write the output to')
     options_parser.add_argument('--width', type=int, metavar='tiles_count', default=20, action='store', help='number of tiles in the tilemap width')
     options_parser.add_argument('--filler', type=lambda x: int(x, 0), metavar='filler', default=None, action='store', help='filler byte used as the tilemap background')
+    options_parser.add_argument('--no-file-terminator', dest='has_file_terminator', default=True, action='store_false', help='operate on a partial tilemap without a file terminator (e.g. some menus)')
 
     operations_subparser = arg_parser.add_subparsers(title='commands', dest='command', required=True)
     decoding_parser = operations_subparser.add_parser('decode',  parents=[options_parser], help='convert a tilemap encoded with the ZLADX format to a raw tilemap')
@@ -51,11 +52,11 @@ if __name__ == "__main__":
     outfile = (args.output and open(args.output, 'wb')) or sys.stdout
 
     if args.command == 'decode':
-        result = BackgroundCoder.decode(data, args.width, args.filler or 0x00)
+        result = BackgroundCoder.decode(data, args.width, args.filler or 0x00, args.has_file_terminator)
         write_result(result, outfile, wrap_count=args.wrap)
 
     elif args.command == 'encode':
-        result = BackgroundCoder.encode(data, args.location, args.width, args.filler)
+        result = BackgroundCoder.encode(data, args.location, args.width, args.filler, args.has_file_terminator)
         write_result(result, outfile)
 
     outfile.close()


### PR DESCRIPTION
## The issue

Partial tilemaps don't end with a NULL terminator. Instead, commands cascade into the next tilemap stored in ROM or RAM.

This is used mostly by menu commands, which overwrite the larger menu tilemaps.

## The fix

When decoding, the `--no-file-terminator` option tells the decoder that the file is expected to end abruptely.

And when encoding, the `--no-file-terminator` option tells the encoder not to append the NULL file terminator at the end of the file.

Fix #448. Thanks @KelseyHigham for the implementation suggestion.