### PR TITLE
fix RGB macro

### DIFF
--- a/src/code/macros.asm
+++ b/src/code/macros.asm
@@ -3,7 +3,7 @@
 ; RGB r, g, b
 ; values: 0 ~ 31
 macro RGB
-    db (\1) + (\2) << 5 + (\3) << 10
+    dw (\1) + (\2) << 5 + (\3) << 10
 endm
 
 ; Farcall using direct bank selection


### PR DESCRIPTION
tested with this change, and the macro works as expected:
```    RGB $1D, $6, $5```
is equivalent to
```    db $DD, $14```