### PR TITLE
Add label for marking getting lost in Mysterious Forest

### DIFF
--- a/src/code/entities/05_tarin.asm
+++ b/src/code/entities/05_tarin.asm
@@ -76,6 +76,7 @@ TarinEntityHandler::
     cp   $01                                      ; $496D: $FE $01
     jr   nz, jr_005_4995                          ; $496F: $20 $24
 
+    ; Handle Tarin's appearance in the credits
     ld   hl, wEntitiesPhysicsFlagsTable           ; $4971: $21 $40 $C3
     add  hl, bc                                   ; $4974: $09
     ld   [hl], $C4                                ; $4975: $36 $C4
@@ -103,8 +104,9 @@ TarinEntityHandler::
 jr_005_4995:
     ld   a, [wIsIndoor]                           ; $4995: $FA $A5 $DB
     and  a                                        ; $4998: $A7
-    jp   nz, label_005_4BC1                       ; $4999: $C2 $C1 $4B
+    jp   nz, TarinIndoorsHandler                  ; $4999: $C2 $C1 $4B
 
+    ; Handle Tarin's outdoor appearances
     ldh  a, [hRoomStatus]                         ; $499C: $F0 $F8
     and  ROOM_STATUS_EVENT_1                      ; $499E: $E6 $10
     jp   nz, ClearEntityStatus_05                 ; $49A0: $C2 $4B $7B
@@ -125,7 +127,7 @@ jr_005_4995:
     jr   nc, .jr_49CC                             ; $49B7: $30 $13
 
     ld   a, $01                                   ; $49B9: $3E $01
-    ld   [wC10C], a                               ; $49BB: $EA $0C $C1
+    ld   [wShouldGetLostInMysteriousWoods], a     ; $49BB: $EA $0C $C1
     ldh  a, [hFrameCounter]                       ; $49BE: $F0 $E7
     rra                                           ; $49C0: $1F
     rra                                           ; $49C1: $1F
@@ -487,7 +489,7 @@ func_005_4B89::
 Data_005_4BBF::
     db   $78, $00
 
-label_005_4BC1:
+TarinIndoorsHandler:
     ld   hl, wEntitiesPrivateState2Table          ; $4BC1: $21 $C0 $C2
     add  hl, bc                                   ; $4BC4: $09
     ld   a, [hl]                                  ; $4BC5: $7E

--- a/src/code/entities/_handlers.asm
+++ b/src/code/entities/_handlers.asm
@@ -276,7 +276,7 @@ func_020_4303::
     ld   [wC5A1], a                               ; $4306: $EA $A1 $C5
     xor  a                                        ; $4309: $AF
     ld   [wC5A0], a                               ; $430A: $EA $A0 $C5
-    ld   [wC10C], a                               ; $430D: $EA $0C $C1
+    ld   [wShouldGetLostInMysteriousWoods], a     ; $430D: $EA $0C $C1
     ldh  [hLinkSlowWalkingSpeed], a               ; $4310: $E0 $B2
     ld   [wC117], a                               ; $4312: $EA $17 $C1
     ld   [wC19D], a                               ; $4315: $EA $9D $C1

--- a/src/code/room_transition.asm
+++ b/src/code/room_transition.asm
@@ -391,8 +391,8 @@ RoomTransitionPrepareHandler::
     ; Overworld
     ;
 
-    ; If C10C != 0…
-    ld   a, [wC10C]                               ; $7A6D: $FA $0C $C1
+    ; If wShouldGetLostInMysteriousWoods != 0…
+    ld   a, [wShouldGetLostInMysteriousWoods]     ; $7A6D: $FA $0C $C1
     and  a                                        ; $7A70: $A7
     jr   z, .mysteriousWoodsEnd                   ; $7A71: $28 $11
 

--- a/src/constants/memory/wram.asm
+++ b/src/constants/memory/wram.asm
@@ -82,8 +82,8 @@ wC10A:
 wMusicTrackTiming:
   ds 1 ; C10B
 
-; Unlabeled
-wC10C:
+; Checks whether Link should get lost in the Mysterious Forest/Woods
+wShouldGetLostInMysteriousWoods:
   ds 1 ; C10C
 
 ; Index of the higher sprite slot that needs changing during a room transition.


### PR DESCRIPTION
By the way, I noticed the game itself is inconsistent when naming the Mysterious Forest/Woods, which I never noticed before, but should we perhaps be consistent?