### PR TITLE
Generalize MBC constants

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -9,20 +9,20 @@ include "code/home/interrupts.asm"
 ; Switch to the bank defined in a, and save the active bank
 SwitchBank::
     ld   [wCurrentBank], a                        ; $080C: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $080F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $080F: $EA $00 $21
     ret                                           ; $0812: $C9
 
 ; Switch to the bank defined in a, depending on GB or GBC mode
 SwitchAdjustedBank::
     call AdjustBankNumberForGBC                   ; $0813: $CD $0B $0B
     ld   [wCurrentBank], a                        ; $0816: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $0819: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0819: $EA $00 $21
     ret                                           ; $081C: $C9
 
 ReloadSavedBank::
     push af                                       ; $081D: $F5
     ld   a, [wCurrentBank]                        ; $081E: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $0821: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0821: $EA $00 $21
     pop  af                                       ; $0824: $F1
     ret                                           ; $0825: $C9
 
@@ -34,7 +34,7 @@ LoadDungeonMinimapTiles::
     ; Select the bank containing the dungeon minimap tiles
     ld   a, BANK(DungeonMinimapTiles)             ; $0826: $3E $12
     call AdjustBankNumberForGBC                   ; $0828: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $082B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $082B: $EA $00 $21
 
     ; If hBGTilesLoadingStage < 8, load the tiles
     ldh  a, [hBGTilesLoadingStage]                ; $082E: $F0 $92
@@ -152,7 +152,7 @@ func_020_6A30_trampoline::
 
 RestoreBankAndReturn::
     ld   a, [wCurrentBank]                        ; $08DF: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $08E2: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $08E2: $EA $00 $21
     ret                                           ; $08E5: $C9
 
 func_020_6AC1_trampoline::
@@ -178,7 +178,7 @@ CopyLinkTunicPalette_trampoline::
 
 LoadBank1AndReturn::
     ld   a, $01                                   ; $0917: $3E $01
-    ld   [MBC3SelectBank], a                      ; $0919: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0919: $EA $00 $21
     ret                                           ; $091C: $C9
 
 func_91D::
@@ -198,7 +198,7 @@ func_91D::
 .jp_92F
     callsb GetBGAttributesAddressForObject        ; $092F: $3E $1A $EA $00 $21 $CD $76 $65
     ldh  a, [hMultiPurpose8]                      ; $0937: $F0 $DF
-    ld   [MBC3SelectBank], a                      ; $0939: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0939: $EA $00 $21
     ld   hl, wDrawCommandAlt                      ; $093C: $21 $91 $DC
     ld   a, [wDrawCommandsAltSize]                ; $093F: $FA $90 $DC
     ld   e, a                                     ; $0942: $5F
@@ -242,7 +242,7 @@ func_91D::
 ; Restore bank saved on stack and return
 RestoreStackedBankAndReturn::
     pop  af                                       ; $0973: $F1
-    ld   [MBC3SelectBank], a                      ; $0974: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0974: $EA $00 $21
     ret                                           ; $0977: $C9
 
 func_020_6D0E_trampoline::
@@ -262,7 +262,7 @@ func_983::
 
     ; Switch to the bank containing this room's palettes
     ldh  a, [hMultiPurpose8]                      ; $098B: $F0 $DF
-    ld   [MBC3SelectBank], a                      ; $098D: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $098D: $EA $00 $21
 
     ; Read value from address [hMultiPurposeA hMultiPurpose9]
     ldh  a, [hMultiPurpose9]                      ; $0990: $F0 $E0
@@ -375,7 +375,7 @@ CopyDataToVRAM_noDMA::
 ;  h   bank to switch back after the transfer
 CopyDataToVRAM::
     ; Switch to bank in a
-    ld   [MBC3SelectBank], a                      ; $0A13: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0A13: $EA $00 $21
 
     ; If running on DMG, use a loop to copy the data
     ldh  a, [hIsGBC]                              ; $0A16: $F0 $FE
@@ -398,14 +398,14 @@ CopyDataToVRAM::
     ; Fallthrough to switch back to the bank in h
 .restoreBankAndReturn
     ld   a, h                                     ; $0A2D: $7C
-    ld   [MBC3SelectBank], a                      ; $0A2E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0A2E: $EA $00 $21
     ret                                           ; $0A31: $C9
 
 ; Copy Color Dungeon tiles?
 CopyColorDungeonSymbols::
     push af                                       ; $0A32: $F5
     ld   a, BANK(ColorDungeonNpcTiles)            ; $0A33: $3E $35
-    ld   [MBC3SelectBank], a                      ; $0A35: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0A35: $EA $00 $21
     ld   hl, ColorDungeonNpcTiles + $F00          ; $0A38: $21 $00 $4F
     ld   de, wDCC0                                ; $0A3B: $11 $C0 $DC
     ld   bc, $20                                  ; $0A3E: $01 $20 $00
@@ -429,7 +429,7 @@ func_036_4F9B_trampoline::
 func_A5F::
     push af                                       ; $0A5F: $F5
     ld   a, $20                                   ; $0A60: $3E $20
-    ld   [MBC3SelectBank], a                      ; $0A62: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0A62: $EA $00 $21
     call RenderActiveEntitySpritesRect            ; $0A65: $CD $E6 $3C
     jp   RestoreStackedBankAndReturn              ; $0A68: $C3 $73 $09
 
@@ -540,7 +540,7 @@ AdjustBankNumberForGBC::
 ;   hl :        source address
 CopyObjectsAttributesToWRAM2::
     ldh  a, [hMultiPurpose0]                      ; $0B1A: $F0 $D7
-    ld   [MBC3SelectBank], a                      ; $0B1C: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B1C: $EA $00 $21
     ld   a, $02                                   ; $0B1F: $3E $02
     ld   [rSVBK], a                               ; $0B21: $E0 $70
     call CopyData                                 ; $0B23: $CD $14 $29
@@ -548,7 +548,7 @@ CopyObjectsAttributesToWRAM2::
     ld   [rSVBK], a                               ; $0B27: $E0 $70
     ; Restore bank $20
     ld   a, $20                                   ; $0B29: $3E $20
-    ld   [MBC3SelectBank], a                      ; $0B2B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B2B: $EA $00 $21
     ret                                           ; $0B2E: $C9
 
 ; On GBC, copy some overworld objects to ram bank 2
@@ -582,16 +582,16 @@ func_2BF::
 
     ldh  a, [hMultiPurpose2]                      ; $0B54: $F0 $D9
     and  $7F                                      ; $0B56: $E6 $7F
-    ld   [MBC3SelectBank], a                      ; $0B58: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B58: $EA $00 $21
     pop  bc                                       ; $0B5B: $C1
     ret                                           ; $0B5C: $C9
 
 ; Copy data from bank in a, then switch back to bank $28
 CopyData_trampoline::
-    ld   [MBC3SelectBank], a                      ; $0B5D: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B5D: $EA $00 $21
     call CopyData                                 ; $0B60: $CD $14 $29
     ld   a, $28                                   ; $0B63: $3E $28
-    ld   [MBC3SelectBank], a                      ; $0B65: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B65: $EA $00 $21
     ret                                           ; $0B68: $C9
 
 ; Copy data to vBGMap0
@@ -601,7 +601,7 @@ CopyData_trampoline::
 ;   hhMultiPurposeF  return bank to restore
 CopyBGMapFromBank::
     push hl                                       ; $0B69: $E5
-    ld   [MBC3SelectBank], a                      ; $0B6A: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B6A: $EA $00 $21
 
     ; If on GBC…
     ldh  a, [hIsGBC]                              ; $0B6D: $F0 $FE
@@ -631,7 +631,7 @@ CopyBGMapFromBank::
 .photoAlbumEnd
 
     ldh  a, [hMultiPurposeF]                      ; $0B90: $F0 $E6
-    ld   [MBC3SelectBank], a                      ; $0B92: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0B92: $EA $00 $21
     ret                                           ; $0B95: $C9
 
 CopyToBGMap0::
@@ -670,7 +670,7 @@ LoadBaseTiles_trampoline::
 
 func_BC5::
     ld   a, [w2_D16A]                             ; $0BC5: $FA $6A $D1
-    ld   [MBC3SelectBank], a                      ; $0BC8: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0BC8: $EA $00 $21
 .loop
     ld   a, [hli]                                 ; $0BCB: $2A
     ld   [de], a                                  ; $0BCC: $12
@@ -679,19 +679,19 @@ func_BC5::
     jr   nz, .loop                                ; $0BCF: $20 $FA
 
     ld   a, $28                                   ; $0BD1: $3E $28
-    ld   [MBC3SelectBank], a                      ; $0BD3: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0BD3: $EA $00 $21
     ret                                           ; $0BD6: $C9
 
 ; Generic trampoline, for calling a function into another bank.
 Farcall::
     ; Switch to bank wFarcallBank
     ld   a, [wFarcallBank]                        ; $0BD7: $FA $01 $DE
-    ld   [MBC3SelectBank], a                      ; $0BDA: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0BDA: $EA $00 $21
     ; Call the target function
     call Farcall_trampoline                       ; $0BDD: $CD $E7 $0B
     ; Switch back to bank wFarcallReturnBank
     ld   a, [wFarcallReturnBank]                  ; $0BE0: $FA $04 $DE
-    ld   [MBC3SelectBank], a                      ; $0BE3: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0BE3: $EA $00 $21
     ret                                           ; $0BE6: $C9
 
 ; Jump to address in wFarcallAdressHigh, wFarcallAdressLow
@@ -704,7 +704,7 @@ Farcall_trampoline::
 
 UpdateLinkWalkingAnimation_trampoline::
     ld   a, BANK(LinkAnimationsLists)             ; $0BF0: $3E $02
-    ld   [MBC3SelectBank], a                      ; $0BF2: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0BF2: $EA $00 $21
     call UpdateLinkWalkingAnimation               ; $0BF5: $CD $50 $1A
     jp   ReloadSavedBank                          ; $0BF8: $C3 $1D $08
 
@@ -782,10 +782,10 @@ ReadTileValueFromDiacriticsTable::
 
 ReadValueInDialogsBank::
     ld   a, BANK(CodepointToTileMap) ; or BANK(DialogBankTable) ; $0C2D: $3E $1C
-    ld   [MBC3SelectBank], a                      ; $0C2F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0C2F: $EA $00 $21
     add  hl, bc                                   ; $0C32: $09
     ld   a, [hl]                                  ; $0C33: $7E
-    ld   hl, MBC3SelectBank                       ; $0C34: $21 $00 $21
+    ld   hl, rSelectROMBank                       ; $0C34: $21 $00 $21
     ld   [hl], $01                                ; $0C37: $36 $01
     ret                                           ; $0C39: $C9
 
@@ -794,11 +794,11 @@ ReadValueInDialogsBank::
 ;   hl:  target address of the instrument tiles
 CopySirenInstrumentTiles::
     ld   a, BANK(SirenInstrumentsTiles)           ; $0C3A: $3E $0C
-    ld   [MBC3SelectBank], a                      ; $0C3C: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0C3C: $EA $00 $21
     ld   bc, $40                                  ; $0C3F: $01 $40 $00
     call CopyData                                 ; $0C42: $CD $14 $29
     ld   a, $01                                   ; $0C45: $3E $01
-    ld   [MBC3SelectBank], a                      ; $0C47: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0C47: $EA $00 $21
     ret                                           ; $0C4A: $C9
 
 PlayBombExplosionSfx::
@@ -986,7 +986,7 @@ label_D15::
 ; Actual loading will be done during the next vblank period.
 SelectRoomTilesets::
     ld   a, BANK(TilesetTables)                   ; $0D1E: $3E $20
-    ld   [MBC3SelectBank], a                      ; $0D20: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0D20: $EA $00 $21
 
     ; ------------------------------------------------------------
     ;
@@ -1381,7 +1381,7 @@ EndCreditsHandler::
 
 AnimateEntitiesAndRestoreBank17::
     ld   a, $03                                   ; $0EED: $3E $03
-    ld   [MBC3SelectBank], a                      ; $0EEF: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0EEF: $EA $00 $21
     ld   a, $17                                   ; $0EF2: $3E $17
 
 ; Call AnimateEntities, then restore bank in a
@@ -1393,13 +1393,13 @@ AnimateEntitiesAndRestoreBank::
 
 AnimateEntitiesAndRestoreBank01::
     ld   a, $03                                   ; $0EFC: $3E $03
-    ld   [MBC3SelectBank], a                      ; $0EFE: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0EFE: $EA $00 $21
     ld   a, $01                                   ; $0F01: $3E $01
     jr   AnimateEntitiesAndRestoreBank            ; $0F03: $18 $EF
 
 AnimateEntitiesAndRestoreBank02::
     ld   a, $03                                   ; $0F05: $3E $03
-    ld   [MBC3SelectBank], a                      ; $0F07: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0F07: $EA $00 $21
     ld   a, $02                                   ; $0F0A: $3E $02
     jr   AnimateEntitiesAndRestoreBank            ; $0F0C: $18 $E6
 
@@ -1881,7 +1881,7 @@ SetShieldVals::
 func_020_4B4A_trampoline::
     callsb func_020_4B4A                          ; $134B: $3E $20 $EA $00 $21 $CD $4A $4B
     ld   a, [wCurrentBank]                        ; $1353: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1356: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1356: $EA $00 $21
     ret                                           ; $1359: $C9
 
 PlaceBomb::
@@ -1902,7 +1902,7 @@ PlaceBomb::
 
     callsb ConvertToBombArrowIfNeeded             ; $1373: $3E $20 $EA $00 $21 $CD $81 $4B
     ld   a, [wCurrentBank]                        ; $137B: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $137E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $137E: $EA $00 $21
     ret                                           ; $1381: $C9
 
 UsePowerBracelet::
@@ -1919,7 +1919,7 @@ UseBoomerang::
 
     callsb func_020_4BFF                          ; $138E: $3E $20 $EA $00 $21 $CD $FF $4B
     ld   a, [wCurrentBank]                        ; $1396: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1399: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1399: $EA $00 $21
     ret                                           ; $139C: $C9
 
 data_139D::
@@ -2114,7 +2114,7 @@ UseMagicPowder::
     ret  c                                        ; $14B3: $D8
     callsb SprinkleMagicPowder                    ; $14B4: $3E $20 $EA $00 $21 $CD $47 $4C
     ld   a, [wCurrentBank]                        ; $14BC: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $14BF: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $14BF: $EA $00 $21
     ret                                           ; $14C2: $C9
 
 ; Horizontal speed boost when jumping while using Pegasus Boots
@@ -2695,13 +2695,13 @@ ApplyLinkMotionState::
 func_1819::
     callsb func_020_4AB3                          ; $1819: $3E $20 $EA $00 $21 $CD $B3 $4A
     ld   a, [wCurrentBank]                        ; $1821: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1824: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1824: $EA $00 $21
     ret                                           ; $1827: $C9
 
 func_1828::
     callsb func_020_49BA                          ; $1828: $3E $20 $EA $00 $21 $CD $BA $49
     ld   a, [wCurrentBank]                        ; $1830: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1833: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1833: $EA $00 $21
     ret                                           ; $1836: $C9
 
 LinkMotionMapFadeOutHandler::
@@ -2926,7 +2926,7 @@ LinkMotionMapFadeOutHandler::
 
 .label_19A4
     ld   a, $14                                   ; $19A4: $3E $14
-    ld   [MBC3SelectBank], a                      ; $19A6: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $19A6: $EA $00 $21
     call SetSpawnLocation                         ; $19A9: $CD $C2 $19
     push de                                       ; $19AC: $D5
     ldh  a, [hMapId]                              ; $19AD: $F0 $F7
@@ -3036,14 +3036,14 @@ func_1A22::
     callsb func_020_6C4F                          ; $1A22: $3E $20 $EA $00 $21 $CD $4F $6C
     callsb func_020_55CA                          ; $1A2A: $3E $20 $EA $00 $21 $CD $CA $55
     ld   a, [wCurrentBank]                        ; $1A32: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1A35: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1A35: $EA $00 $21
     ret                                           ; $1A38: $C9
 
 func_1A39::
     callsb func_020_6C7A                          ; $1A39: $3E $20 $EA $00 $21 $CD $7A $6C
     callsb func_020_563B                          ; $1A41: $3E $20 $EA $00 $21 $CD $3B $56
     ld   a, [wCurrentBank]                        ; $1A49: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1A4C: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1A4C: $EA $00 $21
     ret                                           ; $1A4F: $C9
 
 ; Update hLinkAnimationState with the correct walking animation id.
@@ -3157,7 +3157,7 @@ ReplaceMagicPowderTilesByToadstool::
 ReplaceDialogTilesByInstruments::
     ld   a, BANK(Npc2Tiles)                       ; $1E33: $3E $11
     call AdjustBankNumberForGBC                   ; $1E35: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1E38: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1E38: $EA $00 $21
 
     ld   a, [wCreditsScratch0]                    ; $1E3B: $FA $00 $D0
     swap a                                        ; $1E3E: $CB $37
@@ -3185,13 +3185,13 @@ ReplaceEndCreditsTiles::
 
     ld   a, $0C                                   ; $1E60: $3E $0C
     call AdjustBankNumberForGBC                   ; $1E62: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1E65: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1E65: $EA $00 $21
     ret                                           ; $1E68: $C9
 
 ReplaceTiles_08::
     ld   a, BANK(EndingTiles)                     ; $1E69: $3E $13
     call AdjustBankNumberForGBC                   ; $1E6B: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1E6E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1E6E: $EA $00 $21
 
     ld   a, [wCreditsScratch0]                    ; $1E71: $FA $00 $D0
     swap a                                        ; $1E74: $CB $37
@@ -3213,7 +3213,7 @@ ReplaceToadstoolTilesByMagicPowder::
     ld   de, $88E0                                ; $1E90: $11 $E0 $88
     ld   a, BANK(InventoryEquipmentItemsTiles)    ; $1E93: $3E $0C
     call AdjustBankNumberForGBC                   ; $1E95: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1E98: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1E98: $EA $00 $21
     ld   bc, TILE_SIZE * 2                        ; $1E9B: $01 $20 $00
     jp   CopyDataAndDrawLinkSprite                ; $1E9E: $C3 $3B $1F
 
@@ -3231,7 +3231,7 @@ ReplaceSlimeKeyTilesByGoldenLeaf::
 ReplaceTilesPairAndDrawLinkSprite::
     ld   a, BANK(LinkCharacter2Tiles)             ; $1EA7: $3E $0C
     call AdjustBankNumberForGBC                   ; $1EA9: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1EAC: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1EAC: $EA $00 $21
     ld   bc, TILE_SIZE * $2                       ; $1EAF: $01 $20 $00
     jp   CopyDataAndDrawLinkSprite                ; $1EB2: $C3 $3B $1F
 
@@ -3250,7 +3250,7 @@ ReplaceTiles_04::
 
 .replaceTiles
     call AdjustBankNumberForGBC                   ; $1EC1: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1EC4: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1EC4: $EA $00 $21
     ld   de, vTiles2 + $140                       ; $1EC7: $11 $40 $91
     jp   Copy4TilesAndDrawLinkSprite              ; $1ECA: $C3 $38 $1F
 
@@ -3294,7 +3294,7 @@ UpdateSwitchBlockTiles::
     push af                                       ; $1ED7: $F5
     ld   a, BANK(SwitchBlockTiles)                ; $1ED8: $3E $0C
     call AdjustBankNumberForGBC                   ; $1EDA: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1EDD: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1EDD: $EA $00 $21
     pop  af                                       ; $1EE0: $F1
 
     ; Mark Link as not interactive during the animation
@@ -3381,7 +3381,7 @@ CopyDataAndDrawLinkSprite::
     xor  a                                        ; $1F3E: $AF
     ldh  [hReplaceTiles], a                       ; $1F3F: $E0 $A5
     ld   a, BANK(LinkCharacterTiles)              ; $1F41: $3E $0C
-    ld   [MBC3SelectBank], a                      ; $1F43: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1F43: $EA $00 $21
     jp   DrawLinkSpriteAndReturn                  ; $1F46: $C3 $2E $1D
 
 ; Number of horizontal pixels the sword reaches in Link's direction when drawing the sword
@@ -3591,7 +3591,7 @@ ENDC
     ld   e, a                                     ; $204B: $5F
     ld   d, $00                                   ; $204C: $16 $00
     ld   a, BANK(SignpostDialogTable)             ; $204E: $3E $14
-    ld   [MBC3SelectBank], a                      ; $2050: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2050: $EA $00 $21
     ld   hl, SignpostDialogTable                  ; $2053: $21 $18 $51
     add  hl, de                                   ; $2056: $19
     ld   a, [wOcarinaSongFlags]                   ; $2057: $FA $49 $DB
@@ -3916,7 +3916,7 @@ BGRegionIncrement::
 UpdateBGRegion::
     ; Switch to Map Data bank
     ld   a, $08                                   ; $2209: $3E $08
-    ld   [MBC3SelectBank], a                      ; $220B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $220B: $EA $00 $21
     call DoUpdateBGRegion                         ; $220E: $CD $34 $22
     ; Reload saved bank and return
     jp   ReloadSavedBank                          ; $2211: $C3 $1D $08
@@ -3999,7 +3999,7 @@ DoUpdateBGRegion::
 
     ; Switch back to the objects tilemap bank
     ld   a, $08                                   ; $223C: $3E $08
-    ld   [MBC3SelectBank], a                      ; $223E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $223E: $EA $00 $21
 
 .loop
     push bc                                       ; $2241: $C5
@@ -4108,7 +4108,7 @@ DoUpdateBGRegion::
 
     ; Select object attributes bank
     ldh  a, [hMultiPurpose8]                      ; $22B8: $F0 $DF
-    ld   [MBC3SelectBank], a                      ; $22BA: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $22BA: $EA $00 $21
     ; Copy a row of the object attributes
     call CopyObjectRowToBGMap                     ; $22BD: $CD $14 $22
     ld   a, b                                     ; $22C0: $78
@@ -4141,7 +4141,7 @@ DoUpdateBGRegion::
     callsb func_020_49D9                          ; $22DD: $3E $20 $EA $00 $21 $CD $D9 $49
     ; Select BG attributes bank
     ldh  a, [hMultiPurpose8]                      ; $22E5: $F0 $DF
-    ld   [MBC3SelectBank], a                      ; $22E7: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $22E7: $EA $00 $21
     ; Copy a column of the object attributes
     call CopyObjectColumnToBGMap                  ; $22EA: $CD $24 $22
     ld   a, b                                     ; $22ED: $78
@@ -4200,9 +4200,9 @@ SetWorldMusicTrack::
 
 EnableExternalRAMWriting::
     push hl                                       ; $27D0: $E5
-    ld   hl, MBC3SRamBank                         ; $27D1: $21 $00 $40
+    ld   hl, rRAMB                                ; $27D1: $21 $00 $40
     ld   [hl], $00 ; Switch to RAM bank 0         ; $27D4: $36 $00
-    ld   hl, MBC3SRamEnable                       ; $27D6: $21 $00 $00
+    ld   hl, rRAMG                                ; $27D6: $21 $00 $00
     ld   [hl], CART_SRAM_ENABLE ; Enable external RAM writing ; $27D9: $36 $0A
     pop  hl                                       ; $27DB: $E1
     ret                                           ; $27DC: $C9
@@ -4210,7 +4210,7 @@ EnableExternalRAMWriting::
 ; Load soudtrack after map or gameplay transition
 label_27DD::
     ld   a, BANK(SelectMusicTrackAfterTransition) ; $27DD: $3E $02
-    ld   [MBC3SelectBank], a                      ; $27DF: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $27DF: $EA $00 $21
     push bc                                       ; $27E2: $C5
     call SelectMusicTrackAfterTransition          ; $27E3: $CD $46 $41
     pop  bc                                       ; $27E6: $C1
@@ -4464,7 +4464,7 @@ GetChestsStatusForRoom_trampoline::
 PlayBoomerangSfx_trampoline::
     callsb PlayBoomerangSfx                       ; $29F8: $3E $20 $EA $00 $21 $CD $98 $4C
     ld   a, [wCurrentBank]                        ; $2A00: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $2A03: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A03: $EA $00 $21
     ret                                           ; $2A06: $C9
 
 label_2A07::
@@ -4479,7 +4479,7 @@ label_2A07::
 ;   a    physics flags for the object
 GetObjectPhysicsFlags::
     ld   a, BANK(OverworldObjectPhysicFlags)      ; $2A12: $3E $08
-    ld   [MBC3SelectBank], a                      ; $2A14: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A14: $EA $00 $21
     ld   hl, OverworldObjectPhysicFlags           ; $2A17: $21 $D4 $4A
     ldh  a, [hMapId]                              ; $2A1A: $F0 $F7
     cp   MAP_COLOR_DUNGEON                        ; $2A1C: $FE $FF
@@ -4498,14 +4498,14 @@ GetObjectPhysicsFlagsAndRestoreBank3::
     call GetObjectPhysicsFlags                    ; $2A2C: $CD $12 $2A
     push af                                       ; $2A2F: $F5
     ld   a, $03                                   ; $2A30: $3E $03
-    ld   [MBC3SelectBank], a                      ; $2A32: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A32: $EA $00 $21
     pop  af                                       ; $2A35: $F1
     ret                                           ; $2A36: $C9
 
 LoadCreditsKoholintDisappearingTiles::
     ld   a, BANK(EndingTiles)                     ; $2A37: $3E $13
     call AdjustBankNumberForGBC                   ; $2A39: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2A3C: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A3C: $EA $00 $21
 
     ld   hl, EndingTiles + $2800                  ; $2A3F: $21 $00 $68
     ld   de, vTiles2                              ; $2A42: $11 $00 $90
@@ -4529,7 +4529,7 @@ LoadCreditsStairsTiles::
 LoadTileset15::
     ld   a, BANK(EndingTiles)                     ; $2A66: $3E $13
     call AdjustBankNumberForGBC                   ; $2A68: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2A6B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A6B: $EA $00 $21
 
     ld   hl, EndingTiles                          ; $2A6E: $21 $00 $40
     ld   de, vTiles0                              ; $2A71: $11 $00 $80
@@ -4538,7 +4538,7 @@ LoadTileset15::
 
     ld   a, BANK(Overworld1Tiles)                 ; $2A7A: $3E $0C
     call AdjustBankNumberForGBC                   ; $2A7C: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2A7F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A7F: $EA $00 $21
     ld   hl, Overworld1Tiles + $8E0 ; filler color ; $2A82: $21 $E0 $57
     ld   de, vTiles2 + $7F0                       ; $2A85: $11 $F0 $97
     ld   bc, TILE_SIZE                            ; $2A88: $01 $10 $00
@@ -4546,7 +4546,7 @@ LoadTileset15::
 
     ld   a, BANK(Npc4Tiles)                       ; $2A8E: $3E $12
     call AdjustBankNumberForGBC                   ; $2A90: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2A93: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2A93: $EA $00 $21
     ld   hl, Npc4Tiles + $100                     ; $2A96: $21 $00 $75
     ld   de, vTiles0                              ; $2A99: $11 $00 $80
     ld   bc, TILE_SIZE * 4                        ; $2A9C: $01 $40 $00
@@ -4562,7 +4562,7 @@ LoadTileset15::
 LoadCreditsKoholintViewsTiles::
     ld   a, BANK(Overworld1Tiles)                 ; $2AAE: $3E $0C
     call AdjustBankNumberForGBC                   ; $2AB0: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2AB3: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2AB3: $EA $00 $21
     ld   hl, Overworld1Tiles + $100               ; $2AB6: $21 $00 $50
     ld   de, vTiles2                              ; $2AB9: $11 $00 $90
     ld   bc, TILE_SIZE * $80                      ; $2ABC: $01 $00 $08
@@ -4570,7 +4570,7 @@ LoadCreditsKoholintViewsTiles::
 
     ld   a, BANK(Npc3Tiles)                       ; $2AC2: $3E $12
     call AdjustBankNumberForGBC                   ; $2AC4: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2AC7: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2AC7: $EA $00 $21
     ld   hl, Npc3Tiles + $2000                    ; $2ACA: $21 $00 $60
     ld   de, vTiles0                              ; $2ACD: $11 $00 $80
     ld   bc, TILE_SIZE * $80                      ; $2AD0: $01 $00 $08
@@ -4578,7 +4578,7 @@ LoadCreditsKoholintViewsTiles::
 
     ld   a, BANK(Overworld2Tiles)                 ; $2AD6: $3E $0F
     call AdjustBankNumberForGBC                   ; $2AD8: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2ADB: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2ADB: $EA $00 $21
     ld   hl, Overworld2Tiles + $600               ; $2ADE: $21 $00 $60
     ld   de, vTiles1                              ; $2AE1: $11 $00 $88
     ld   bc, TILE_SIZE * $80                      ; $2AE4: $01 $00 $08
@@ -4605,14 +4605,14 @@ label_2B01::
     call AdjustBankNumberForGBC                   ; $2B03: $CD $0B $0B
 
 label_2B06::
-    ld   [MBC3SelectBank], a                      ; $2B06: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2B06: $EA $00 $21
     ld   de, vTiles0                              ; $2B09: $11 $00 $80
     ld   bc, TILE_SIZE * $80                      ; $2B0C: $01 $00 $08
     call CopyData                                 ; $2B0F: $CD $14 $29
 
     ld   a, BANK(EndingTiles)                     ; $2B12: $3E $13
     call AdjustBankNumberForGBC                   ; $2B14: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2B17: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2B17: $EA $00 $21
     ld   hl, EndingTiles + $1800                  ; $2B1A: $21 $00 $58
     ld   de, vTiles0 + TILE_SIZE * $80            ; $2B1D: $11 $00 $88
     ld   bc, TILE_SIZE * $100                     ; $2B20: $01 $00 $10
@@ -4629,7 +4629,7 @@ LoadCreditsRollTiles::
 
     ld   a, BANK(Npc3Tiles)                       ; $2B34: $3E $12
     call AdjustBankNumberForGBC                   ; $2B36: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2B39: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2B39: $EA $00 $21
     ld   hl, Npc3Tiles + $2600                    ; $2B3C: $21 $00 $66
     ld   de, vTiles0                              ; $2B3F: $11 $00 $80
     ld   bc, TILE_SIZE * $8                       ; $2B42: $01 $80 $00
@@ -4639,7 +4639,7 @@ LoadCreditsRollTiles::
 
 IF __PATCH_1__
     ld   a, BANK(CharacterVfxTiles)
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
     ld   hl, CharacterVfxTiles + TILE_SIZE * $2
     ld   de, $8080
     ld   bc, TILE_SIZE * $2
@@ -4661,13 +4661,13 @@ IF __PATCH_1__
     ld   hl, CreditsRollTiles + $100
 
 .both
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
     ld   de, vTiles0 + $100
     ld   bc, TILE_SIZE * $70
     call CopyData
 
     ld   a, BANK(CreditsRollTiles)
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
     ld   hl, CreditsRollTiles + $0c0
     ld   de, vTiles0 + $C0
     ld   bc, TILE_SIZE * $4
@@ -4675,7 +4675,7 @@ IF __PATCH_1__
 ELSE
 .dmgOnly
     ld   a, BANK(FontLargeTiles)                  ; $2B50: $3E $10
-    ld   [MBC3SelectBank], a                      ; $2B52: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2B52: $EA $00 $21
     ld   hl, FontLargeTiles + $200                ; $2B55: $21 $00 $69
     ld   de, vTiles0 + $100                       ; $2B58: $11 $00 $81
     ld   bc, TILE_SIZE * $70                      ; $2B5B: $01 $00 $07
@@ -4683,7 +4683,7 @@ ELSE
 
 .cgbOnly
     ld   a, BANK(CreditsRollTiles)                ; $2B61: $3E $38
-    ld   [MBC3SelectBank], a                      ; $2B63: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2B63: $EA $00 $21
     ld   hl, CreditsRollTiles                     ; $2B66: $21 $00 $50
     ld   de, vTiles0                              ; $2B69: $11 $00 $80
     ld   bc, TILE_SIZE * $80                      ; $2B6C: $01 $00 $08
@@ -4715,14 +4715,14 @@ func_2B92::
     call AdjustBankNumberForGBC                   ; $2B92: $CD $0B $0B
 
 label_2B95::
-    ld   [MBC3SelectBank], a                      ; $2B95: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2B95: $EA $00 $21
     ld   de, vTiles0                              ; $2B98: $11 $00 $80
     ld   bc, TILE_SIZE * $80                      ; $2B9B: $01 $00 $08
     call CopyData                                 ; $2B9E: $CD $14 $29
 
     ld   a, BANK(EndingTiles)                     ; $2BA1: $3E $13
     call AdjustBankNumberForGBC                   ; $2BA3: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2BA6: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2BA6: $EA $00 $21
     ld   hl, EndingTiles + $3000                  ; $2BA9: $21 $00 $70
     ld   de, vTiles1                              ; $2BAC: $11 $00 $88
     ld   bc, TILE_SIZE * $80                      ; $2BAF: $01 $00 $08
@@ -4812,7 +4812,7 @@ LoadIndoorTiles::
     jr   nz, .notColorDungeon                     ; $2C37: $20 $1A
 
     ld   a, BANK(ColorDungeonTiles)               ; $2C39: $3E $35
-    ld   [MBC3SelectBank], a                      ; $2C3B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2C3B: $EA $00 $21
     ld   hl, ColorDungeonTiles + $200             ; $2C3E: $21 $00 $62
     ld   de, vTiles2                              ; $2C41: $11 $00 $90
     ld   bc, TILE_SIZE * $10                      ; $2C44: $01 $00 $01
@@ -4854,7 +4854,7 @@ LoadIndoorTiles::
     ;
 
     ld   a, BANK(DungeonWallsTilesPointers)       ; $2C77: $3E $20
-    ld   [MBC3SelectBank], a                      ; $2C79: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2C79: $EA $00 $21
     pop  de                                       ; $2C7C: $D1
     push de                                       ; $2C7D: $D5
     ld   hl, DungeonWallsTilesPointers            ; $2C7E: $21 $A9 $45
@@ -4874,7 +4874,7 @@ LoadIndoorTiles::
 
     ld   a, BANK(Items1Tiles)                     ; $2C9A: $3E $0C
     call AdjustBankNumberForGBC                   ; $2C9C: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2C9F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2C9F: $EA $00 $21
     ld   hl, Items1Tiles + $3C0                   ; $2CA2: $21 $C0 $47
     ld   de, wDCC0                                ; $2CA5: $11 $C0 $DC
     ld   bc, TILE_SIZE * $4                       ; $2CA8: $01 $40 $00
@@ -4888,7 +4888,7 @@ LoadIndoorTiles::
 
     ; Read the pointer to the objects tiles for this hMapId
     ld   a, BANK(DungeonItemsTilesPointers)       ; $2CB1: $3E $20
-    ld   [MBC3SelectBank], a                      ; $2CB3: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2CB3: $EA $00 $21
     pop  de                                       ; $2CB6: $D1
     ld   hl, DungeonItemsTilesPointers            ; $2CB7: $21 $CA $45
     add  hl, de                                   ; $2CBA: $19
@@ -4903,7 +4903,7 @@ LoadIndoorTiles::
     jr   nz, .colorDungeonEnd2                    ; $2CC7: $20 $08
     ld   hl, ColorDungeonTiles + $100             ; $2CC9: $21 $00 $61
     ld   a, BANK(ColorDungeonTiles)               ; $2CCC: $3E $35
-    ld   [MBC3SelectBank], a                      ; $2CCE: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2CCE: $EA $00 $21
 .colorDungeonEnd2
 
     ld   de, vTiles1 + $700                       ; $2CD1: $11 $00 $8F
@@ -4915,7 +4915,7 @@ LoadIndoorTiles::
     ;
 
     ld   a, [wCurrentBank]                        ; $2CDA: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $2CDD: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2CDD: $EA $00 $21
     ld   hl, InventoryIndoorItemsTiles            ; $2CE0: $21 $00 $7D
 
     ; If indoor, but not in a dungeon…
@@ -5007,7 +5007,7 @@ func_2D50::
 
     ld   a, BANK(InventoryEquipmentItemsTiles)    ; $2D58: $3E $0C
     call AdjustBankNumberForGBC                   ; $2D5A: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2D5D: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2D5D: $EA $00 $21
 
     ld   hl, InventoryEquipmentItemsTiles         ; $2D60: $21 $00 $48
     ld   de, vTiles1                              ; $2D63: $11 $00 $88
@@ -5131,7 +5131,7 @@ LoadStaticPictureTiles::
 LoadEaglesTowerTopTiles::
     ld   a, BANK(EaglesTowerTop1Tiles)            ; $2E21: $3E $13
     call AdjustBankNumberForGBC                   ; $2E23: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2E26: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2E26: $EA $00 $21
     ld   hl, EaglesTowerTop2Tiles                 ; $2E29: $21 $00 $7C
     ld   de, vTiles1 + $400                       ; $2E2C: $11 $00 $8C
     ld   bc, TILE_SIZE * $40                      ; $2E2F: $01 $00 $04
@@ -5272,7 +5272,7 @@ LoadRoomSpecificTiles::
 .bankAdjustmentEnd
 
     ; Do the actual copy to OAM tiles
-    ld   [MBC3SelectBank], a                      ; $2EF2: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2EF2: $EA $00 $21
     ldh  a, [hMultiPurpose0]                      ; $2EF5: $F0 $D7
     ld   d, a                                     ; $2EF7: $57
     ld   e, $00                                   ; $2EF8: $1E $00
@@ -5307,7 +5307,7 @@ LoadRoomSpecificTiles::
 
     ld   a, BANK(DungeonsTiles)                   ; $2F1C: $3E $0D
     call AdjustBankNumberForGBC                   ; $2F1E: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2F21: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2F21: $EA $00 $21
 
     ldh  a, [hIsSideScrolling]                    ; $2F24: $F0 $F9
     and  a                                        ; $2F26: $A7
@@ -5372,7 +5372,7 @@ LoadRoomSpecificTiles::
     cp   ROOM_INDOOR_B_CAMERA_SHOP                ; $2F71: $FE $B5
     jr   nz, .cameraShopEnd                       ; $2F73: $20 $12
     ld   a, BANK(CameraShopIndoorTiles)           ; $2F75: $3E $35
-    ld   [MBC3SelectBank], a                      ; $2F77: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2F77: $EA $00 $21
     ld   hl, CameraShopIndoorTiles                ; $2F7A: $21 $00 $66
     ld   de, vTiles1 + $700                       ; $2F7D: $11 $00 $8F
     ld   bc, TILE_SIZE * $20                      ; $2F80: $01 $00 $02
@@ -5392,7 +5392,7 @@ LoadRoomSpecificTiles::
     ret  nz                                       ; $2F8E: $C0
 
     ld   a, BANK(PhotoAlbumTiles)                 ; $2F8F: $3E $35
-    ld   [MBC3SelectBank], a                      ; $2F91: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2F91: $EA $00 $21
     ld   hl, PhotoAlbumTiles + $600               ; $2F94: $21 $00 $6E
     ld   de, vTiles2 + $690                       ; $2F97: $11 $90 $96
     ld   bc, TILE_SIZE                            ; $2F9A: $01 $10 $00
@@ -5410,7 +5410,7 @@ LoadRoomSpecificTiles::
     ;
     ld   a, BANK(Overworld2Tiles)                 ; $2FAD: $3E $0F
     call AdjustBankNumberForGBC                   ; $2FAF: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $2FB2: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2FB2: $EA $00 $21
 
     ; If the tileset is W_TILESET_KEEP, do nothing.
     ldh  a, [hWorldTileset]                       ; $2FB5: $F0 $94
@@ -5591,7 +5591,7 @@ doCopyObjectToBG:
     ; Copy tile attributes to BG map for tiles on the upper row
     push hl                                       ; $3055: $E5
     ldh  a, [hMultiPurpose8]                      ; $3056: $F0 $DF
-    ld   [MBC3SelectBank], a                      ; $3058: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3058: $EA $00 $21
     ldh  a, [hMultiPurpose9]                      ; $305B: $F0 $E0
     ld   h, a                                     ; $305D: $67
     ldh  a, [hMultiPurposeA]                      ; $305E: $F0 $E1
@@ -5627,7 +5627,7 @@ doCopyObjectToBG:
 
     ; Copy palettes from WRAM1 for tiles on the lower row
     ldh  a, [hMultiPurpose8]                      ; $3082: $F0 $DF
-    ld   [MBC3SelectBank], a                      ; $3084: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3084: $EA $00 $21
     ldh  a, [hMultiPurpose9]                      ; $3087: $F0 $E0
     ld   h, a                                     ; $3089: $67
     ldh  a, [hMultiPurposeA]                      ; $308A: $F0 $E1
@@ -5753,14 +5753,14 @@ LoadRoom::
     ;
 
     ld   a, BANK(OverworldRoomPointers)           ; $3119: $3E $09
-    ld   [MBC3SelectBank], a                      ; $311B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $311B: $EA $00 $21
     ; If loading an indoor room…
     ld   a, [wIsIndoor]                           ; $311E: $FA $A5 $DB
     and  a                                        ; $3121: $A7
     jr   z, .indoorSpecialCodeEnd                 ; $3122: $28 $16
     ; Do some stuff
     ld   a, BANK(func_014_5897)                   ; $3124: $3E $14
-    ld   [MBC3SelectBank], a                      ; $3126: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3126: $EA $00 $21
     ldh  [hRoomBank], a                           ; $3129: $E0 $E8
     call func_014_5897                            ; $312B: $CD $97 $58
     ; Reset wKillCount and wKillOrder array
@@ -5840,7 +5840,7 @@ LoadRoom::
 
     ; …by default use the bank for IndoorsA map
     ld   a, BANK(IndoorsARoomPointers)            ; $317C: $3E $0A
-    ld   [MBC3SelectBank], a                      ; $317E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $317E: $EA $00 $21
     ldh  [hRoomBank], a                           ; $3181: $E0 $E8
 
     ; If the room is in the Color Dungeon…
@@ -5874,7 +5874,7 @@ LoadRoom::
     jr   c, .fetchRoomAddress                     ; $31B1: $38 $71
     ; …use the bank for IndoorB map.
     ld   a, BANK(IndoorsBRoomPointers)            ; $31B3: $3E $0B
-    ld   [MBC3SelectBank], a                      ; $31B5: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $31B5: $EA $00 $21
     ldh  [hRoomBank], a                           ; $31B8: $E0 $E8
     ld   hl, IndoorsBRoomPointers                 ; $31BA: $21 $00 $40
     jr   .fetchRoomAddress                        ; $31BD: $18 $65
@@ -5976,7 +5976,7 @@ LoadRoom::
     jr   c, .parseRoomHeader                      ; $3233: $38 $05
     ; … select bank for second half of Overworld rooms
     ld   a, BANK(OverworldRoomsSecondHalf)        ; $3235: $3E $1A
-    ld   [MBC3SelectBank], a                      ; $3237: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3237: $EA $00 $21
 
     ;
     ; Parse room header
@@ -6738,7 +6738,7 @@ SetBankForRoom::
 
 .inside
     ; Load the bank $09 or $1A
-    ld   [MBC3SelectBank], a                      ; $3547: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3547: $EA $00 $21
     ret                                           ; $354A: $C9
 
 ; Load object or objects?
@@ -7234,7 +7234,7 @@ LoadRoomEntities::
     callsb UpdateRecentRoomsList                  ; $37FE: $3E $01 $EA $00 $21 $CD $02 $5F
 
     ld   a, BANK(OverworldEntitiesPointersTable)  ; $3806: $3E $16
-    ld   [MBC3SelectBank], a                      ; $3808: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3808: $EA $00 $21
 
     ; Reset the entities load order
     xor  a                                        ; $380B: $AF
@@ -7427,7 +7427,7 @@ LoadEntityFromDefinition::
     callsb PrepareEntityPositionForRoomTransition ; $38DC: $3E $01 $EA $00 $21 $CD $AB $5E
     ; Restore bank for entities placement data
     ld   a, BANK(OverworldEntitiesPointersTable)  ; $38E4: $3E $16
-    ld   [MBC3SelectBank], a                      ; $38E6: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $38E6: $EA $00 $21
     ret                                           ; $38E9: $C9
 
 ; Load the template for an indoor room
@@ -7436,7 +7436,7 @@ LoadRoomTemplate_trampoline::
     ; Load bank for LoadRoomTemplate
     ld   e, a                                     ; $38EA: $5F
     ld   a, BANK(LoadRoomTemplate)                ; $38EB: $3E $14
-    ld   [MBC3SelectBank], a                      ; $38ED: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $38ED: $EA $00 $21
     ld   a, e                                     ; $38F0: $7B
 
     ; Call function
@@ -7446,7 +7446,7 @@ LoadRoomTemplate_trampoline::
 
     ; Restore previous bank
     ldh  a, [hRoomBank]                           ; $38F6: $F0 $E8
-    ld   [MBC3SelectBank], a                      ; $38F8: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $38F8: $EA $00 $21
     ret                                           ; $38FB: $C9
 
 LoadWorldMapBGMap_trampoline::
@@ -7464,7 +7464,7 @@ SwitchToObjectsTilemapBank::
     ld   a, BANK(IndoorObjectsTilemapDMG)         ; $390F: $3E $08
 .end
     ; Switch to map bank
-    ld   [MBC3SelectBank], a                      ; $3911: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3911: $EA $00 $21
     ret                                           ; $3914: $C9
 
 LoadCreditsMarinPortraitTiles_trampoline::
@@ -7477,7 +7477,7 @@ include "code/home/entities.asm"
 
 ReplaceEvilEagleRiderVisibleTiles::
     ld   a, BANK(EvilEagleRiderVisibleTiles)      ; $3F93: $3E $05
-    ld   [MBC3SelectBank], a                      ; $3F95: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3F95: $EA $00 $21
     ld   hl, EvilEagleRiderVisibleTiles           ; $3F98: $21 $DE $59
     ld   de, vTiles0 + $460                       ; $3F9B: $11 $60 $84
     ld   bc, TILE_SIZE * 1                        ; $3F9E: $01 $10 $00
@@ -7487,7 +7487,7 @@ ReplaceEvilEagleRiderVisibleTiles::
 
 ReplaceEvilEagleRiderHiddenTiles::
     ld   a, BANK(EvilEagleRiderHiddenTiles)       ; $3FA9: $3E $05
-    ld   [MBC3SelectBank], a                      ; $3FAB: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3FAB: $EA $00 $21
     ld   hl, EvilEagleRiderHiddenTiles            ; $3FAE: $21 $FE $59
     ld   de, vTiles0 + $460                       ; $3FB1: $11 $60 $84
     ld   bc, TILE_SIZE * 1                        ; $3FB4: $01 $10 $00
@@ -7503,7 +7503,7 @@ ReplaceEvilEagleRiderHiddenTiles::
     ldh  [hReplaceTiles], a                       ; $3FC7: $E0 $A5
 
     ld   a, BANK(LinkCharacterTiles)              ; $3FC9: $3E $0C
-    ld   [MBC3SelectBank], a                      ; $3FCB: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3FCB: $EA $00 $21
     jp   DrawLinkSpriteAndReturn                  ; $3FCE: $C3 $2E $1D
 
 ; Copy data to second half of tiles memory
@@ -7518,12 +7518,12 @@ ReloadColorDungeonNpcTiles::
 
     ; Switch to bank $34 or $35
     ld   a, b                                     ; $3FD9: $78
-    ld   [MBC3SelectBank], a                      ; $3FDA: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3FDA: $EA $00 $21
 
     ld   hl, ColorDungeonNpcTiles                 ; $3FDD: $21 $00 $40
     ld   de, vTiles0 + $400                       ; $3FE0: $11 $00 $84
     ld   bc, TILE_SIZE * $40                      ; $3FE3: $01 $00 $04
     call CopyData                                 ; $3FE6: $CD $14 $29
     ld   a, BANK(InventoryEntryPoint)             ; $3FE9: $3E $20
-    ld   [MBC3SelectBank], a                      ; $3FEB: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3FEB: $EA $00 $21
     ret                                           ; $3FEE: $C9

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -1807,7 +1807,7 @@ UpdateRecentRoomsList::
 
 HideAllSprites::
     ; $0000 controls whether to enable external RAM writing
-    ld   hl, MBC3SRamEnable                       ; $5F2E: $21 $00 $00
+    ld   hl, rRAMG                                ; $5F2E: $21 $00 $00
 
     ; If CGB…
     ldh  a, [hIsGBC]                              ; $5F31: $F0 $FE

--- a/src/code/entities/07_horse_piece.asm
+++ b/src/code/entities/07_horse_piece.asm
@@ -72,7 +72,7 @@ HorsePieceEntityHandler::
 ._04 dw HorsePieceStateFinished                   ; $763E
 
 HorsePieceStateInit::
-    jp   HorsePieceCheckForPickup                  ; $7640: $C3 $33 $77
+    jp   HorsePieceCheckForPickup                 ; $7640: $C3 $33 $77
 
 HorsePieceRandomBounceX::
     db   $00, $0C, $10, $0C, $00, $F4, $F0, $F4
@@ -239,7 +239,7 @@ HorsePieceStateFinished::
     ld   a, $01                                   ; $772B: $3E $01
     call SetEntitySpriteVariant                   ; $772D: $CD $0C $3B
 .notFallDown
-    jp   HorsePieceCheckForPickup                  ; $7730: $C3 $33 $77
+    jp   HorsePieceCheckForPickup                 ; $7730: $C3 $33 $77
 
 HorsePieceCheckForPickup:
     call CheckLinkCollisionWithEnemy_trampoline   ; $7733: $CD $5A $3B

--- a/src/code/home/animated_tiles.asm
+++ b/src/code/home/animated_tiles.asm
@@ -9,7 +9,7 @@ AnimateMarinBeachTiles::
     ret  nz                                       ; $1AD0: $C0
     ld   a, BANK(MarinBeachWavesTiles)            ; $1AD1: $3E $10
     call AdjustBankNumberForGBC                   ; $1AD3: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1AD6: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1AD6: $EA $00 $21
     ld   hl, MarinBeachWavesTiles                 ; $1AD9: $21 $00 $65
     ld   de, vTiles2 + $500                       ; $1ADC: $11 $00 $95
     ldh  a, [hFrameCounter]                       ; $1ADF: $F0 $E7
@@ -83,7 +83,7 @@ AnimateTiles::
     ; Switch to the bank with intro tiles
     ld   a, $10                                   ; $1B27: $3E $10
     call AdjustBankNumberForGBC                   ; $1B29: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1B2C: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1B2C: $EA $00 $21
     ; Copy 32 bytes of data from address stored at wD006 to address stored at wD008
     ld   a, [wD006]                               ; $1B2F: $FA $06 $D0
     ld   l, a                                     ; $1B32: $6F
@@ -229,7 +229,7 @@ AnimateCounterTilesGroup::
     callsb LoadCounterAnimatedTiles               ; $1C00: $3E $01 $EA $00 $21 $CD $AA $61
     ld   a, $0C                                   ; $1C08: $3E $0C
     call AdjustBankNumberForGBC                   ; $1C0A: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1C0D: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1C0D: $EA $00 $21
     jp   DrawLinkSpriteAndReturn                  ; $1C10: $C3 $2E $1D
 
 ; Load the given frame for the animated tiles group
@@ -300,19 +300,19 @@ LoadAnimatedTilesFrame::
     jr   nz, .endMapFF                            ; $1C5E: $20 $27
 
     ld   a, BANK(ConfigureAnimatedTilesCopy)      ; $1C60: $3E $20
-    ld   [MBC3SelectBank], a                      ; $1C62: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1C62: $EA $00 $21
     ld   b, $01                                   ; $1C65: $06 $01
     call ConfigureAnimatedTilesCopy               ; $1C67: $CD $F7 $47
     jr   z, .next                                 ; $1C6A: $28 $06
-    ld   [MBC3SelectBank], a                      ; $1C6C: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1C6C: $EA $00 $21
     call CopyData                                 ; $1C6F: $CD $14 $29
 .next
     ld   a, BANK(ConfigureAnimatedTilesCopy)      ; $1C72: $3E $20
-    ld   [MBC3SelectBank], a                      ; $1C74: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1C74: $EA $00 $21
     ld   b, $00                                   ; $1C77: $06 $00
     call ConfigureAnimatedTilesCopy               ; $1C79: $CD $F7 $47
     jr   z, .endMapFF                             ; $1C7C: $28 $09
-    ld   [MBC3SelectBank], a                      ; $1C7E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1C7E: $EA $00 $21
     ld   de, $96C0                                ; $1C81: $11 $C0 $96
     call CopyData                                 ; $1C84: $CD $14 $29
 .endMapFF
@@ -360,7 +360,7 @@ AnimateWarpTilesGroup::
 IF __PATCH_3__
     ld   a, BANK(AnimatedTiles)
     call AdjustBankNumberForGBC
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
 ENDC
     ld   h, HIGH(AnimatedTiles) + $6              ; $1CC6: $26 $70
 
@@ -422,7 +422,7 @@ AnimatePhotoTilesGroup::
 CopyLinkTilesPair::
     ld   a, BANK(LinkCharacterTiles)              ; $1D0A: $3E $0C
     call AdjustBankNumberForGBC                   ; $1D0C: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1D0F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1D0F: $EA $00 $21
 
 .loop
     ld   a, [bc]                                  ; $1D12: $0A
@@ -432,14 +432,14 @@ CopyLinkTilesPair::
     jr   nz, .loop                                ; $1D16: $20 $FA
 
     ld   a, BANK(func_020_54F5)                   ; $1D18: $3E $20
-    ld   [MBC3SelectBank], a                      ; $1D1A: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1D1A: $EA $00 $21
     ret                                           ; $1D1D: $C9
 
 SkipTilesGroupAnimation::
     callsb func_020_54F5                          ; $1D1E: $3E $20 $EA $00 $21 $CD $F5 $54
     ld   a, $0C                                   ; $1D26: $3E $0C
     call AdjustBankNumberForGBC                   ; $1D28: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1D2B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1D2B: $EA $00 $21
 
 ; Called during V-Blank
 DrawLinkSprite::
@@ -613,7 +613,7 @@ ReplaceMarinTiles::
     ld   hl, Npc3Tiles + $2080                    ; $1DF2: $21 $80 $60
 
 .copyTiles
-    ld   [MBC3SelectBank], a                      ; $1DF5: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1DF5: $EA $00 $21
     ld   de, vTiles0 + $400                       ; $1DF8: $11 $00 $84
     ld   bc, TILE_SIZE * 4                        ; $1DFB: $01 $40 $00
     jp   CopyDataAndDrawLinkSprite                ; $1DFE: $C3 $3B $1F
@@ -643,6 +643,6 @@ ReplaceTradingItemTiles::
     ld   bc, TILE_SIZE * 4                        ; $1E1D: $01 $40 $00
     ld   a, BANK(Items1Tiles)                     ; $1E20: $3E $0C
     call AdjustBankNumberForGBC                   ; $1E22: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $1E25: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1E25: $EA $00 $21
 
     jp   CopyDataAndDrawLinkSprite                ; $1E28: $C3 $3B $1F

--- a/src/code/home/check_items_to_use.asm
+++ b/src/code/home/check_items_to_use.asm
@@ -192,5 +192,5 @@ CheckItemsToUse::
     ; Special code for the Color Dungeon
     callsb func_020_48CA                          ; $128D: $3E $20 $EA $00 $21 $CD $CA $48
     ld   a, [wCurrentBank]                        ; $1295: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $1298: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $1298: $EA $00 $21
     ret                                           ; $129B: $C9

--- a/src/code/home/copy_data.asm
+++ b/src/code/home/copy_data.asm
@@ -5,10 +5,10 @@
 ;   de : destination address
 ;   hl : source address
 CopyDataFromBank::
-    ld   [MBC3SelectBank], a                      ; $2908: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2908: $EA $00 $21
     call CopyData                                 ; $290B: $CD $14 $29
     ld   a, $01                                   ; $290E: $3E $01
-    ld   [MBC3SelectBank], a                      ; $2910: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2910: $EA $00 $21
     ret                                           ; $2913: $C9
 
 ; Copy data

--- a/src/code/home/dialog.asm
+++ b/src/code/home/dialog.asm
@@ -325,7 +325,7 @@ DialogClosingBeginHandler::
 
 DialogLetterAnimationStartHandler::
     ld   a, BANK(ClearLetterPixels)               ; $24B7: $3E $1C
-    ld   [MBC3SelectBank], a                      ; $24B9: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $24B9: $EA $00 $21
     ld   a, [wDialogScrollDelay]                  ; $24BC: $FA $72 $C1
     and  a                                        ; $24BF: $A7
     jr   z, .delayOver                            ; $24C0: $28 $05
@@ -339,7 +339,7 @@ DialogLetterAnimationStartHandler::
 
 DialogLetterAnimationEndHandler::
     ld   a, BANK(DialogPointerTable)              ; $24CD: $3E $1C
-    ld   [MBC3SelectBank], a                      ; $24CF: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $24CF: $EA $00 $21
     ld   a, [wDialogState]                        ; $24D2: $FA $9F $C1
     ld   c, a                                     ; $24D5: $4F
     ld   a, [wDialogNextCharPosition]             ; $24D6: $FA $71 $C1
@@ -399,7 +399,7 @@ DialogLetterAnimationEndHandler::
 
 DialogDrawNextCharacterHandler::
     ld   a, BANK(DialogPointerTable)              ; $2529: $3E $1C
-    ld   [MBC3SelectBank], a                      ; $252B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $252B: $EA $00 $21
     ld   a, [wDialogCharacterIndex]               ; $252E: $FA $70 $C1
     and  $1F                                      ; $2531: $E6 $1F
     ld   c, a                                     ; $2533: $4F
@@ -446,7 +446,7 @@ IF __USE_FIXED_DIALOG_BANKS__
     ld   e,  BANK(Dialog200)
 .foundBank
     ld   a, e
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
 ELSE
     push de                                       ; $2563: $D5
     ld   a, [wDialogIndex]                        ; $2564: $FA $73 $C1
@@ -457,7 +457,7 @@ ELSE
     add  hl, de                                   ; $256F: $19
     ld   a, [hl] ; bank                           ; $2570: $7E
     and  $3F                                      ; $2571: $E6 $3F
-    ld   [MBC3SelectBank], a                      ; $2573: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $2573: $EA $00 $21
     pop  hl                                       ; $2576: $E1
 ENDC
     ld   a, [wDialogCharacterIndex]               ; $2577: $FA $70 $C1
@@ -569,7 +569,7 @@ ENDR
     ldh  [hMultiPurpose1], a                      ; $2608: $E0 $D8
     ld   e, a                                     ; $260A: $5F
     ld   a, BANK(CodepointToTileMap)              ; $260B: $3E $1C
-    ld   [MBC3SelectBank], a                      ; $260D: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $260D: $EA $00 $21
     ld   hl, CodepointToTileMap                   ; $2610: $21 $41 $46
     add  hl, de                                   ; $2613: $19
     ld   e, [hl]                                  ; $2614: $5E
@@ -602,7 +602,7 @@ ENDR
     ; Check if the current character has a diacritic tile above
     ; (if compiled with support for diacritics)
     ld   a, BANK(CodepointToDiacritic)            ; $263C: $3E $1C
-    ld   [MBC3SelectBank], a ; current character  ; $263E: $EA $00 $21
+    ld   [rSelectROMBank], a ; current character  ; $263E: $EA $00 $21
     ldh  a, [hMultiPurpose1]                      ; $2641: $F0 $D8
     ld   e, a                                     ; $2643: $5F
     ld   d, $00                                   ; $2644: $16 $00
@@ -692,7 +692,7 @@ DialogBreakHandler::
     ; button, but this information is only used
     ; if __SKIP_DIALOG_SUPPORT__ is set.
     ld   a, BANK(DialogBankTable)                 ; $26C3: $3E $1C
-    ld   [MBC3SelectBank], a                      ; $26C5: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $26C5: $EA $00 $21
     ld   a, [wGameplayType]                       ; $26C8: $FA $95 $DB
     cp   GAMEPLAY_WORLD_MAP                       ; $26CB: $FE $07
     jp   z, SkipDialog                            ; $26CD: $CA $8B $27

--- a/src/code/home/entities.asm
+++ b/src/code/home/entities.asm
@@ -411,15 +411,11 @@ SpawnNewEntityInRange_trampoline::
     ret                                           ; $3BA9: $C9
 
 ApplyVectorTowardsLink_trampoline::
-    ld   hl, rSelectROMBank                       ; $3BAA: $21 $00 $21
-    ld   [hl], BANK(ApplyVectorTowardsLink)       ; $3BAD: $36 $03
-    call ApplyVectorTowardsLink                   ; $3BAF: $CD $C7 $7E
+    callhl ApplyVectorTowardsLink                 ; $3BAA: $21 $00 $21 $36 $03 $CD $C7 $7E
     jp   ReloadSavedBank                          ; $3BB2: $C3 $1D $08
 
 GetVectorTowardsLink_trampoline::
-    ld   hl, rSelectROMBank                       ; $3BB5: $21 $00 $21
-    ld   [hl], BANK(GetVectorTowardsLink)         ; $3BB8: $36 $03
-    call GetVectorTowardsLink                     ; $3BBA: $CD $45 $7E
+    callhl GetVectorTowardsLink                   ; $3BB5: $21 $00 $21 $36 $03 $CD $45 $7E
     jp   ReloadSavedBank                          ; $3BBD: $C3 $1D $08
 
 ; Render a pair of sprites for the active entity to the OAM buffer.
@@ -969,10 +965,8 @@ label_3E34::
     callhl SmashRock                              ; $3E34: $21 $00 $21 $36 $03 $CD $07 $54
     jp   ReloadSavedBank                          ; $3E3C: $C3 $1D $08
 
-LoadHeartsAndRuppeesCount::
-    ld   hl, rSelectROMBank                       ; $3E3F: $21 $00 $21
-    ld   [hl], BANK(LoadRupeesDigits)             ; $3E42: $36 $02
-    call LoadRupeesDigits                         ; $3E44: $CD $CE $62
+LoadHeartsAndRupeesCount::
+    callhl LoadRupeesDigits                       ; $3E3F: $21 $00 $21 $36 $02 $CD $CE $62
     call LoadHeartsCount                          ; $3E47: $CD $14 $64
     jp   ReloadSavedBank                          ; $3E4A: $C3 $1D $08
 

--- a/src/code/home/entities.asm
+++ b/src/code/home/entities.asm
@@ -9,11 +9,11 @@
 ;   a    value read from BowWowEatableEntitiesTable
 CanBowWowEatEntity::
     ld   a, $14                                   ; $3925: $3E $14
-    ld   [MBC3SelectBank], a                      ; $3927: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3927: $EA $00 $21
     ld   hl, BowWowEatableEntitiesTable           ; $392A: $21 $18 $52
     add  hl, de                                   ; $392D: $19
     ld   a, [hl]                                  ; $392E: $7E
-    ld   hl, MBC3SelectBank                       ; $392F: $21 $00 $21
+    ld   hl, rSelectROMBank                       ; $392F: $21 $00 $21
     ld   [hl], $05                                ; $3932: $36 $05
     ret                                           ; $3934: $C9
 
@@ -46,7 +46,7 @@ label_3970::
 label_397B::
     callsb func_014_5347                          ; $397B: $3E $14 $EA $00 $21 $CD $47 $53
     ld   a, $03                                   ; $3983: $3E $03
-    ld   [MBC3SelectBank], a                      ; $3985: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3985: $EA $00 $21
     ret                                           ; $3988: $C9
 
 data_3989::
@@ -102,7 +102,7 @@ AnimateEntities::
     ld   [wOAMNextAvailableSlot], a               ; $39CB: $EA $C0 $C3
     callsb func_020_4303                          ; $39CE: $3E $20 $EA $00 $21 $CD $03 $43
     xor  a                                        ; $39D6: $AF
-    ld   [MBC3SelectBank], a                      ; $39D7: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $39D7: $EA $00 $21
     ld   a, [wDialogState]                        ; $39DA: $FA $9F $C1
     and  a                                        ; $39DD: $A7
     jr   nz, .label_39E3                          ; $39DE: $20 $03
@@ -111,7 +111,7 @@ AnimateEntities::
 .label_39E3
     ld   a, BANK(func_020_6352)                   ; $39E3: $3E $20
     ld   [wCurrentBank], a                        ; $39E5: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $39E8: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $39E8: $EA $00 $21
     call func_020_6352                            ; $39EB: $CD $52 $63
 
     ; Initialize the entities counter
@@ -150,7 +150,7 @@ AnimateEntities::
 ResetEntity_trampoline::
     callsb ResetEntity                            ; $3A0A: $3E $15 $EA $00 $21 $CD $00 $40
     ld   a, $03                                   ; $3A12: $3E $03
-    ld   [MBC3SelectBank], a                      ; $3A14: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3A14: $EA $00 $21
     ret                                           ; $3A17: $C9
 
 ; For a given entity slot, call the relevant entity handler
@@ -176,7 +176,7 @@ AnimateEntity::
 
     ld   a, BANK(UpdateEntityPositionForRoomTransition) ; $3A2D: $3E $19
     ld   [wCurrentBank], a                        ; $3A2F: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $3A32: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3A32: $EA $00 $21
 
     ldh  a, [hActiveEntityType]                   ; $3A35: $F0 $EB
     cp   ENTITY_RAFT_RAFT_OWNER                   ; $3A37: $FE $6A
@@ -200,13 +200,13 @@ AnimateEntity::
 
     ld   a, BANK(UpdateEntityTimers)              ; $3A54: $3E $14
     ld   [wCurrentBank], a                        ; $3A56: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $3A59: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3A59: $EA $00 $21
     call UpdateEntityTimers                       ; $3A5C: $CD $73 $4D
 
     ; Select bank 3
     ld   a, $03                                   ; $3A5F: $3E $03
     ld   [wCurrentBank], a                        ; $3A61: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $3A64: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3A64: $EA $00 $21
 
     ldh  a, [hActiveEntityStatus]                 ; $3A67: $F0 $EA
     cp   ENTITY_STATUS_ACTIVE                     ; $3A69: $FE $05
@@ -227,14 +227,14 @@ ExecuteActiveEntityHandler_trampoline::
     call ExecuteActiveEntityHandler               ; $3A81: $CD $8D $3A
     ld   a, $03                                   ; $3A84: $3E $03
     ld   [wCurrentBank], a                        ; $3A86: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $3A89: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3A89: $EA $00 $21
     ret                                           ; $3A8C: $C9
 
 ; Read the entity handler address in the handlers table,
 ; then jump to execution.
 ExecuteActiveEntityHandler::
     ld   a, BANK(EntityHandlersTable)             ; $3A8D: $3E $20
-    ld   [MBC3SelectBank], a                      ; $3A8F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3A8F: $EA $00 $21
 
     ; de = active entity id
     ldh  a, [hActiveEntityType]                   ; $3A92: $F0 $EB
@@ -261,7 +261,7 @@ ExecuteActiveEntityHandler::
     ld   l, e                                     ; $3AA1: $6B
     ld   h, d                                     ; $3AA2: $62
     ld   [wCurrentBank], a                        ; $3AA3: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $3AA6: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3AA6: $EA $00 $21
 
     ; Jump to the entity handler
     jp   hl                                       ; $3AA9: $E9
@@ -391,7 +391,7 @@ label_3B7B::
 SpawnNewEntity_trampoline::
     push af                                       ; $3B86: $F5
     ld   a, BANK(SpawnNewEntity)                  ; $3B87: $3E $03
-    ld   [MBC3SelectBank], a                      ; $3B89: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3B89: $EA $00 $21
     pop  af                                       ; $3B8C: $F1
     call SpawnNewEntity                           ; $3B8D: $CD $CA $64
     rr   l                                        ; $3B90: $CB $1D
@@ -402,7 +402,7 @@ SpawnNewEntity_trampoline::
 SpawnNewEntityInRange_trampoline::
     push af                                       ; $3B98: $F5
     ld   a, BANK(SpawnNewEntityInRange)           ; $3B99: $3E $03
-    ld   [MBC3SelectBank], a                      ; $3B9B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3B9B: $EA $00 $21
     pop  af                                       ; $3B9E: $F1
     call SpawnNewEntityInRange                    ; $3B9F: $CD $CC $64
     rr   l                                        ; $3BA2: $CB $1D
@@ -411,13 +411,13 @@ SpawnNewEntityInRange_trampoline::
     ret                                           ; $3BA9: $C9
 
 ApplyVectorTowardsLink_trampoline::
-    ld   hl, MBC3SelectBank                       ; $3BAA: $21 $00 $21
+    ld   hl, rSelectROMBank                       ; $3BAA: $21 $00 $21
     ld   [hl], BANK(ApplyVectorTowardsLink)       ; $3BAD: $36 $03
     call ApplyVectorTowardsLink                   ; $3BAF: $CD $C7 $7E
     jp   ReloadSavedBank                          ; $3BB2: $C3 $1D $08
 
 GetVectorTowardsLink_trampoline::
-    ld   hl, MBC3SelectBank                       ; $3BB5: $21 $00 $21
+    ld   hl, rSelectROMBank                       ; $3BB5: $21 $00 $21
     ld   [hl], BANK(GetVectorTowardsLink)         ; $3BB8: $36 $03
     call GetVectorTowardsLink                     ; $3BBA: $CD $45 $7E
     jp   ReloadSavedBank                          ; $3BBD: $C3 $1D $08
@@ -699,7 +699,7 @@ RenderActiveEntitySprite::
 
 label_3CD9::
     ld   a, $15                                   ; $3CD9: $3E $15
-    ld   [MBC3SelectBank], a                      ; $3CDB: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3CDB: $EA $00 $21
     jr   label_3C71                               ; $3CDE: $18 $91
 
 ; Render a large rectangle of sprites using the entire OAM buffer.
@@ -970,7 +970,7 @@ label_3E34::
     jp   ReloadSavedBank                          ; $3E3C: $C3 $1D $08
 
 LoadHeartsAndRuppeesCount::
-    ld   hl, MBC3SelectBank                       ; $3E3F: $21 $00 $21
+    ld   hl, rSelectROMBank                       ; $3E3F: $21 $00 $21
     ld   [hl], BANK(LoadRupeesDigits)             ; $3E42: $36 $02
     call LoadRupeesDigits                         ; $3E44: $CD $CE $62
     call LoadHeartsCount                          ; $3E47: $CD $14 $64
@@ -982,7 +982,7 @@ label_3E4D::
     jp   SwitchBank                               ; $3E57: $C3 $0C $08
 
 label_3E5A::
-    ld   hl, MBC3SelectBank                       ; $3E5A: $21 $00 $21
+    ld   hl, rSelectROMBank                       ; $3E5A: $21 $00 $21
     ld   [hl], BANK(func_020_5C9C)                ; $3E5D: $36 $20
     ld   c, $01                                   ; $3E5F: $0E $01
     ld   b, $00                                   ; $3E61: $06 $00
@@ -1168,7 +1168,7 @@ data_3F48::
 DidKillEnemy::
     ld   a, BANK(SpawnEnemyDrop)                  ; $3F50: $3E $03
     ld   [wEnemyWasKilled], a                     ; $3F52: $EA $13 $C1
-    ld   [MBC3SelectBank], a                      ; $3F55: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $3F55: $EA $00 $21
     call SpawnEnemyDrop                           ; $3F58: $CD $CF $55
     call ReloadSavedBank                          ; $3F5B: $CD $1D $08
 

--- a/src/code/home/header.asm
+++ b/src/code/home/header.asm
@@ -79,7 +79,7 @@ CopyTilesToPieceOfHeartMeter::
     ldh  [hBGTilesLoadingStage], a
 .restoreBank0C
     ld   a, $0C
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
     ret
 
 section "Entry", rom0[$100]

--- a/src/code/home/interrupts.asm
+++ b/src/code/home/interrupts.asm
@@ -129,7 +129,7 @@ InterruptSerial::
     push af                                       ; $0408: $F5
     callsb PrinterInterruptSerial                 ; $0409: $3E $28 $EA $00 $21 $CD $01 $46
     ld   a, [wCurrentBank]                        ; $0411: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $0414: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0414: $EA $00 $21
     pop  af                                       ; $0417: $F1
     reti                                          ; $0418: $D9
 
@@ -187,13 +187,13 @@ LoadRequestedGfx::
     ; Read and execute a wDrawCommand for loading wBGMapToLoad.
     callsb GetBGCopyRequest                       ; $0445: $3E $20 $EA $00 $21 $CD $77 $45
     ld   a, BANK(BGTilemaps)                      ; $044D: $3E $08
-    ld   [MBC3SelectBank], a                      ; $044F: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $044F: $EA $00 $21
     call ExecuteDrawCommands.noRoomTransition     ; $0452: $CD $2D $29
 
     ; Restore tilesets bank
     ld   a, $0C                                   ; $0455: $3E $0C
     call AdjustBankNumberForGBC                   ; $0457: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $045A: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $045A: $EA $00 $21
 
 .clearFlagsAndReturn
     xor  a                                        ; $045D: $AF
@@ -416,7 +416,7 @@ InterruptVBlank::
     jr   z, .vblankDone                           ; $0559: $28 $0E
     callsb CopyPalettesToVRAM                     ; $055B: $3E $21 $EA $00 $21 $CD $00 $40
     ld   a, [wCurrentBank]                        ; $0563: $FA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $0566: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0566: $EA $00 $21
 
 .vblankDone
     ei                                            ; $0569: $FB
@@ -465,7 +465,7 @@ PhotoAlbumVBlankHandler::
     callsw PrinterInterruptVBlank                 ; $05AB: $3E $28 $CD $0C $08 $CD $16 $46
     pop  af                                       ; $05B3: $F1
     ld   [wCurrentBank], a                        ; $05B4: $EA $AF $DB
-    ld   [MBC3SelectBank], a                      ; $05B7: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $05B7: $EA $00 $21
     jr   InterruptVBlank.vblankDoneInterruptsEnabled ; $05BA: $18 $AE
 
 ; Copy requested BG tiles or entity tiles to VRAM during V-Blank.
@@ -516,7 +516,7 @@ ENDC
 
     ld   a, BANK(Dungeons2Tiles)                  ; $05EE: $3E $0D
     call AdjustBankNumberForGBC                   ; $05F0: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $05F3: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $05F3: $EA $00 $21
     ldh  a, [hBGTilesLoadingStage]                ; $05F6: $F0 $92
     ld   c, a                                     ; $05F8: $4F
     ld   b, $00                                   ; $05F9: $06 $00
@@ -542,7 +542,7 @@ ENDC
     cp   MAP_COLOR_DUNGEON                        ; $061E: $FE $FF
     jr   nz, .colorDungeonEnd                     ; $0620: $20 $0D
     callsb GetColorDungeonTilesAddress            ; $0622: $3E $20 $EA $00 $21 $CD $16 $46
-    ld   [MBC3SelectBank], a                      ; $062A: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $062A: $EA $00 $21
     jr   .copyData                                ; $062D: $18 $12
 .colorDungeonEnd
 
@@ -579,7 +579,7 @@ ENDC
 LoadOverworldBGTiles::
     ld   a, $0F                                   ; $0656: $3E $0F
     call AdjustBankNumberForGBC                   ; $0658: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $065B: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $065B: $EA $00 $21
     ; de = vTiles2 + [hBGTilesLoadingStage] * 6
     ldh  a, [hBGTilesLoadingStage]                ; $065E: $F0 $92
     ld   c, a                                     ; $0660: $4F
@@ -686,7 +686,7 @@ ENDC
     call AdjustBankNumberForGBC                   ; $06F4: $CD $0B $0B
 .adjustBankEnd
 
-    ld   [MBC3SelectBank], a                      ; $06F7: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $06F7: $EA $00 $21
     ldh  a, [hEntityTilesLoadingStageA]           ; $06FA: $F0 $93
     ld   c, a                                     ; $06FC: $4F
     ld   b, $00                                   ; $06FD: $06 $00
@@ -764,7 +764,7 @@ UpdateEntityTilesB::
     call AdjustBankNumberForGBC                   ; $0761: $CD $0B $0B
 .jp_0764
 
-    ld   [MBC3SelectBank], a                      ; $0764: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $0764: $EA $00 $21
     ld   a, [wEntityTilesLoadingStageB]           ; $0767: $FA $0F $C1
     ld   c, a                                     ; $076A: $4F
     ld   b, $00                                   ; $076B: $06 $00
@@ -858,7 +858,7 @@ LoadBGTilesCommands8ToD::
     ld   l, a                                     ; $07E9: $6F
     ld   a, $0C                                   ; $07EA: $3E $0C
     call AdjustBankNumberForGBC                   ; $07EC: $CD $0B $0B
-    ld   [MBC3SelectBank], a                      ; $07EF: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $07EF: $EA $00 $21
     ; Data length
     ld   bc, $40                                  ; $07F2: $01 $40 $00
     call CopyData                                 ; $07F5: $CD $14 $29

--- a/src/code/home/render_loop.asm
+++ b/src/code/home/render_loop.asm
@@ -165,7 +165,7 @@ ENDC
     ; Else, render a non-interactive transition effect.
 
     ld   a, BANK(ApplyFadeToWhite_DMG)            ; $027C: $3E $14
-    ld   [MBC3SelectBank], a                      ; $027E: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $027E: $EA $00 $21
 
     ; Increment frame count for the transition effect
     ld   a, [wTransitionGfxFrameCount]            ; $0281: $FA $80 $C1
@@ -214,7 +214,7 @@ ENDC
 .transitionDone
     ; Render transition effect
     ld   a, BANK(RenderTransitionEffect)          ; $02B7: $3E $14
-    ld   [MBC3SelectBank], a                      ; $02B9: $EA $00 $21
+    ld   [rSelectROMBank], a                      ; $02B9: $EA $00 $21
     pop  af                                       ; $02BC: $F1
     call RenderTransitionEffect                   ; $02BD: $CD $38 $50
 

--- a/src/code/macros.asm
+++ b/src/code/macros.asm
@@ -19,13 +19,13 @@ endm
 ; Farcall using direct bank selection
 macro callsb
     ld   a, BANK(\1)
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
     call \1
 endm
 
 ; Farcall using direct bank selection with hl
 macro callhl
-    ld   hl, MBC3SelectBank
+    ld   hl, rSelectROMBank
     ld   [hl], BANK(\1)
     call \1
 endm
@@ -40,7 +40,7 @@ endm
 ; Jump using SwitchBank
 macro jpsb
     ld   a, BANK(\1)
-    ld   [MBC3SelectBank], a
+    ld   [rSelectROMBank], a
     jp   \1
 endm
 

--- a/src/code/world_handler.asm
+++ b/src/code/world_handler.asm
@@ -9,7 +9,7 @@ WorldHandlerEntryPoint::
 ._1 dw GameplayWorldLoadRoomHandler               ; $4377
 ._2 dw GameplayWorldSelectTilesetHandler          ; $4379
 ._3 dw GameplayWorldLoadRoomTilemapHandler        ; $437B
-._4 dw GameplayWorldLoadHeartsAndRuppeesHandler   ; $437D
+._4 dw GameplayWorldLoadHeartsAndRupeesHandler    ; $437D
 ._5 dw GameplayWorldLoadABButtonsHandler          ; $437F
 ._6 dw GameplayWorldLoad6Handler                  ; $4381
 ._7 dw WorldInteractiveHandler                    ; $4383
@@ -296,18 +296,18 @@ GameplayWorldLoadRoomTilemapHandler::
     call IncrementGameplaySubtype                 ; $44F5: $CD $D6 $44
     ret                                           ; $44F8: $C9
 
-GameplayWorldLoadHeartsAndRuppeesHandler::
+GameplayWorldLoadHeartsAndRupeesHandler::
 IF __PATCH_A__ == 1
     call IncrementGameplaySubtype
     ld a, [ROM_DebugTool2]
     and a
     ret nz
-    call LoadHeartsAndRuppeesCount
+    call LoadHeartsAndRupeesCount
 ELIF __PATCH_A__ == 2
     call IncrementGameplaySubtype
-    call LoadHeartsAndRuppeesCount
+    call LoadHeartsAndRupeesCount
 ELSE
-    call LoadHeartsAndRuppeesCount                ; $44F9: $CD $3F $3E
+    call LoadHeartsAndRupeesCount                 ; $44F9: $CD $3F $3E
     call IncrementGameplaySubtype                 ; $44FC: $CD $D6 $44
 ENDC
     ret                                           ; $44FF: $C9

--- a/src/constants/constants.asm
+++ b/src/constants/constants.asm
@@ -3,7 +3,6 @@
 ;
 include "constants/hardware.inc"
 include "constants/joypad.asm"
-include "constants/mbc3.asm"
 include "constants/defines.asm"
 
 ;

--- a/src/constants/defines.asm
+++ b/src/constants/defines.asm
@@ -7,3 +7,7 @@
 HALF_HEARTS equs "* 4"
 FULL_HEARTS equs "* 8"
 
+; LADX uses $2100 as the address for the register to
+; switch ROM banks (all addresses in the $2000-$2FFF
+; range map to this register)
+rSelectROMBank EQU rROMB0 + $100

--- a/src/constants/mbc3.asm
+++ b/src/constants/mbc3.asm
@@ -1,7 +1,0 @@
-; MBC3
-MBC3SRamEnable EQU $0000
-MBC3RomBank    EQU $2000
-MBC3SelectBank EQU $2100
-MBC3SRamBank   EQU $4000
-MBC3LatchClock EQU $6000
-MBC3RTC        EQU $A000


### PR DESCRIPTION
- Use hardware.inc constants where possible
- Rename MBC3SelectBank to rSelectROMBank (LADX doesn't use MBC3)