### PR TITLE
Add speakers to dialog lines

### DIFF
--- a/src/text/dialog_1.asm
+++ b/src/text/dialog_1.asm
@@ -1,4 +1,4 @@
-Dialog000::
+Dialog000:: ; Tarin
     db "Whoa, boy! Where"
     db "ya off to in    "
     db "such a hurry?   "
@@ -6,7 +6,7 @@ Dialog000::
     db "got somethin' ta"
     db "tell ya!@"
 
-Dialog001::
+Dialog001:: ; Marin
     db "What a relief! I"
     db "thought you'd   "
     db "never wake up!  "
@@ -20,7 +20,7 @@ Dialog001::
     db "You are on      "
     db "Koholint Island!@"
 
-Dialog002::
+Dialog002:: ; Marin
     db "Follow the lane "
     db "south to reach  "
     db "the beach where "
@@ -32,7 +32,7 @@ Dialog002::
     db "area, so be     "
     db "careful, okay?@"
 
-Dialog003::
+Dialog003:: ; Marin
     db "Hi!  Tarin went "
     db "to the forest to"
     db "look for toad-  "
@@ -43,21 +43,21 @@ Dialog003::
     db "'Ballad of the  "
     db "Wind Fish.'@"
 
-Dialog004::
+Dialog004:: ; Marin, probably
     db "Hey!  That's a  "
     db "nice Ocarina you"
     db "have there! Will"
     db "you accompany   "
     db "me as I sing?@"
 
-Dialog005::
+Dialog005:: ; Marin
     db "I just love to  "
     db "sing-- what can "
     db "I say?  What do "
     db "you like to do, "
     db "#####?@"
 
-Dialog006::
+Dialog006:: ; Marin
     db "#####, Tarin's  "
     db "taking a nap at "
     db "home.  I don't  "
@@ -70,20 +70,20 @@ Dialog006::
     db "'Ballad of the  "
     db "Wind Fish!'@"
 
-Dialog007::
+Dialog007:: ; Narrator
     db "Eh? It's locked!"
     db "You can open the"
     db "door with the   "
     db "Nightmare Key.@"
 
-Dialog008::
+Dialog008:: ; Narrator
     db "You got a Piece "
     db "of Power!  You  "
     db "can feel the    "
     db "energy flowing  "
     db "through you!@"
 
-Dialog009::
+Dialog009:: ; Witch
     db "Ahhh... It has  "
     db "the Sleepy Toad-"
     db "stool, it does! "
@@ -91,7 +91,7 @@ Dialog009::
     db "something in a  "
     db "jiffy, we will!@"
 
-Dialog00A::
+Dialog00A:: ; Tarin
     db "The last thing I"
     db "kin remember was"
     db "bitin' into a   "
@@ -104,28 +104,28 @@ Dialog00A::
     db "but it sure was "
     db "fun!@"
 
-Dialog00B::
+Dialog00B:: ; Tarin
     db "I'm all tucker'd"
     db "out...  I think "
     db "I better set a  "
     db "spell before I  "
     db "head home...@"
 
-Dialog00C::
+Dialog00C:: ; Witch
     db "Double double,  "
     db "toil and trouble"
     db "a toadstool mix "
     db "makes powder for"
     db "tricks!@"
 
-Dialog00D::
+Dialog00D:: ; Tarin
     db "As a raccoon, my"
     db "nose is verrry  "
     db "sensitive, ta   "
     db "stuff like dust "
     db "and powder...@"
 
-Dialog00E::
+Dialog00E:: ; Narrator
     db "It's the toad-  "
     db "stool you picked"
     db "in the woods.   "
@@ -136,7 +136,7 @@ Dialog00E::
     db "wafts into your "
     db "nostrils.@"
 
-Dialog00F::
+Dialog00F:: ; Narrator
     db "You pick the    "
     db "toadstool... As "
     db "you hold it over"
@@ -145,19 +145,19 @@ Dialog00F::
     db "flows into your "
     db "nostrils.@"
 
-Dialog010::
+Dialog010:: ; Tarin
     db "Hrrrm...Snore..."
     db "Hunh?... If'n ya"
     db "don' know...call"
     db "old man Ulrira! "
     db "Zonk...Snore...@"
 
-Dialog011::
+Dialog011:: ; Tarin
     db "I'm tired... I'm"
     db "goin' ta sleep  "
     db "now... Zzzzzz...@"
 
-Dialog012::
+Dialog012:: ; Talking Tree
     db "Well that was a "
     db "surprise!  Hey! "
     db "I'll tell you a "
@@ -170,7 +170,7 @@ Dialog012::
     db "the wall with a "
     db "Bomb!@"
 
-Dialog013::
+Dialog013:: ; Narrator, probably
     db "You've learned  "
     db "the 'Ballad of  "
     db "the Wind Fish!' "
@@ -178,7 +178,7 @@ Dialog013::
     db "always remain in"
     db "your heart!@"
 
-Dialog014::
+Dialog014:: ; Marin, probably
     db "Please remember "
     db "this song!  You "
     db "should play it  "
@@ -187,13 +187,13 @@ Dialog014::
     db "fresh in your   "
     db "mind!@"
 
-Dialog015::
+Dialog015:: ; Marin, probably
     db "Please!  I want "
     db "you to learn it!"
     db "This song is my "
     db "favorite!@"
 
-Dialog016::
+Dialog016:: ; Marin, probably
     db "So, how do you  "
     db "like it?  It's  "
     db "really touching,"
@@ -202,7 +202,7 @@ Dialog016::
     db "mind?           "
     db "    Yes  No<ask>"
 
-Dialog017::
+Dialog017:: ; Crazy Tracy
     db "Hi there, big   "
     db "guy!  I'm Crazy "
     db "Tracy!  I've got"
@@ -210,19 +210,19 @@ Dialog017::
     db "for sale that'll"
     db "pump you up!@"
 
-Dialog018::
+Dialog018:: ; Crazy Tracy
     db "Will you give me"
     db "28 Rupees for my"
     db "secret?         "
     db "    Give Don't<ask>"
 
-Dialog019::
+Dialog019:: ; Crazy Tracy
     db "How about it?   "
     db "42 Rupees for my"
     db "little secret..."
     db "    Give Don't<ask>"
 
-Dialog01A::
+Dialog01A:: ; Crazy Tracy
     db "All right, come "
     db "here and I'll   "
     db "rub it on you!  "
@@ -239,18 +239,18 @@ ENDC
     db "Drop by again,  "
     db "big guy!@"
 
-Dialog01B::
+Dialog01B:: ; Crazy Tracy, probably
     db "Beat it, then!  "
     db "Come back when  "
     db "you have some   "
     db "cash!@"
 
-Dialog01C::
+Dialog01C:: ; Crazy Tracy
     db "... ... ... ... "
     db "But I won't sell"
     db "it to you!@"
 
-Dialog01D::
+Dialog01D:: ; Crazy Tracy, probably
     db "Well!  I'm only "
     db "offering you a  "
     db "secret that will"
@@ -258,35 +258,35 @@ Dialog01D::
     db "You're such a   "
     db "chicken!!@"
 
-Dialog01E::
+Dialog01E:: ; Crazy Tracy
     db "...You're so    "
     db "cute!  I'll give"
     db "you a 7 Rupee   "
     db "discount!@"
 
-Dialog01F::
+Dialog01F:: ; Narrator
     db "You got Marin!  "
     db "Is this your big"
     db "chance?@"
 
-Dialog020::
+Dialog020:: ; Fox
     db "GRRRR...@"
 
-Dialog021::
+Dialog021:: ; Tarin
     db "Heh heh heh ho! "
     db "You're goin' ta "
     db "be lost, thanks "
     db "to me!  Heh heh!@"
 
-Dialog022::
+Dialog022:: ; BowWow
     db "BOW WOW!        "
     db "BOW WOW!@"
 
-Dialog023::
+Dialog023:: ; ChowChow
     db "YIP YIP!        "
     db "YIP YIP!@"
 
-Dialog024::
+Dialog024:: ; Great Fairy
     db "Let's heal your "
     db "wounds and get  "
     db "rid of all that "
@@ -294,7 +294,7 @@ Dialog024::
     db "your eyes and   "
     db "relax...@"
 
-Dialog025::
+Dialog025:: ; Grim Creeper (D7 Mini-Boss)
     db "You dirty rat!  "
     db "You k-k-k...beat"
     db "my brothers!    "
@@ -302,7 +302,7 @@ Dialog025::
     db "I'll never      "
     db "forget you!@"
 
-Dialog026::
+Dialog026:: ; Grim Creeper (D7 Mini-Boss)
     db "Hey runt!  You  "
     db "think you can   "
     db "take me?!  All  "
@@ -310,7 +310,7 @@ Dialog026::
     db "this punk out   "
     db "of my face!@"
 
-Dialog027::
+Dialog027:: ; Papahl
     db "Yep!  Those're  "
     db "my boys!  I'm   "
     db "Papahl, pleased "
@@ -320,7 +320,7 @@ Dialog027::
     db "keep a look out "
     db "for me, hear?@"
 
-Dialog028::
+Dialog028:: ; Marin, probably
     db "Yes!!  Yes!!    "
     db "Break them!     "
     db "Break them all! "
@@ -328,7 +328,7 @@ Dialog028::
     db "What?  What's   "
     db "wrong?@"
 
-Dialog029::
+Dialog029:: ; Shopkeeper
     db "Aye Caramba!    "
     db "Kid, you have a "
     db "lot to learn,   "
@@ -336,96 +336,96 @@ Dialog029::
     db "something you   "
     db "have no use for!@"
 
-Dialog02A::
+Dialog02A:: ; Narrator
     db "You've got a    "
     db "Heart!  Thump!  "
     db "One of your     "
     db "Heart Containers"
     db "is filled!@"
 
-Dialog02B::
-Dialog02C::
+Dialog02B:: ; Shopkeeper, Link
+Dialog02C:: ; Shopkeeper, Link
     db "Bow & Arrow Set "
     db "Only 980 Rupees!"
     db "    Buy  No Way<ask>"
 
-Dialog02D::
+Dialog02D:: ; Shopkeeper, Link
     db "   10 Arrows    "
     db "   10 Rupees    "
     db "    Buy  Don't<ask>"
 
-Dialog02E::
+Dialog02E:: ; Shopkeeper
     db "Hey!  Welcome!  "
     db "See something   "
     db "you like?!  Just"
     db "bring it here!@"
 
-Dialog02F::
+Dialog02F:: ; Shopkeeper
     db "Hey! You! Stop! "
     db "You gotta pay!  "
     db "Put it back!@"
 
-Dialog030::
+Dialog030:: ; Shopkeeper, Link
     db "  Deluxe Shovel "
     db "   200 Rupees!  "
     db "Seems expensive!"
     db "    Buy  No Way!"
     db "<ask>"
 
-Dialog031::
+Dialog031:: ; Shopkeeper, Link
     db "   Three Hearts "
     db "    10 Rupees!  "
     db "    Buy  Don't<ask>"
 
-Dialog032::
+Dialog032:: ; Shopkeeper, Link
     db "     Shield     "
     db "    20 Rupees!  "
     db "    Buy  Don't<ask>"
 
-Dialog033::
+Dialog033:: ; Shopkeeper, Link
     db "    Ten Bombs   "
     db "    10 Rupees   "
     db "    Buy  Don't<ask>"
 
-Dialog034::
+Dialog034:: ; Shopkeeper
     db "Sorry, kid!  You"
     db "don't have the  "
     db "Rupees!  Come   "
     db "back when you   "
     db "have the cash!@"
 
-Dialog035::
+Dialog035:: ; Shopkeeper
     db "Thanks a lot!   "
     db "And come again!@"
 
-Dialog036::
+Dialog036:: ; Narrator
     db "Guess what?  You"
     db "got it for free."
     db "Are you proud of"
     db "yourself?@"
 
-Dialog037::
-Dialog038::
+Dialog037:: ; Shopkeeper
+Dialog038:: ; Shopkeeper
     db "I wasn't kidding"
     db "when I said pay!"
     db "Now, you'll pay "
     db "the ultimate    "
     db "price!!@"
 
-Dialog039::
+Dialog039:: ; Narrator
     db "Hunh?  It sounds"
     db "like the castle "
     db "gate opened! You"
     db "can easily leave"
     db "the castle now!@"
 
-Dialog03A::
-Dialog03B::
+Dialog03A:: ; Trendy Gamester
+Dialog03B:: ; Trendy Gamester
     db "  TRENDY GAME!  "
     db " One Play 10 Rs."
     db "    Play No<ask>"
 
-Dialog03C::
+Dialog03C:: ; Trendy Gamester
     db "The A and B     "
     db "Buttons move the"
     db "crane...The rest"
@@ -434,37 +434,37 @@ Dialog03C::
     db "buttons to play!"
     db "Good Luck!@"
 
-Dialog03D::
+Dialog03D:: ; Narrator
     db "It's a Shield!  "
     db "There is space  "
     db "for your name!@"
 
-Dialog03E::
+Dialog03E:: ; Trendy Gamester, Link
     db "Challenge Again?"
     db "    Play No<ask>"
 
-Dialog03F::
+Dialog03F:: ; Trendy Gamester
     db "Good Luck!@"
 
-Dialog040::
+Dialog040:: ; Trendy Gamester
     db "We're closing up"
     db "for today!  Come"
     db "again, anytime!@"
 
-Dialog041::
+Dialog041:: ; Narrator
     db "You got some    "
     db "Magic Powder!   "
     db "Try to sprinkle "
     db "it on many      "
     db "things!@"
 
-Dialog042::
+Dialog042:: ; Trendy Gamester, probably
     db "It's 30 Rupees! "
     db "You can play the"
     db "game three more "
     db "times with this!@"
 
-Dialog043::
+Dialog043:: ; Ghost
     db "Cough Cough...  "
     db "Don't sprinkle  "
     db "that on me...   "
@@ -472,14 +472,14 @@ Dialog043::
     db "curse you!      "
     db "Cough Cough...@"
 
-Dialog044::
+Dialog044:: ; Narrator
     db "You got a Yoshi "
     db "Doll!  Recently,"
     db "he seems to be  "
     db "showing up in   "
     db "many games!@"
 
-Dialog045::
+Dialog045:: ; Fisherman
     db "How about some  "
     db "fishing, little "
     db "buddy? I'll only"
@@ -488,12 +488,12 @@ Dialog045::
     db "    Fish Not Now"
     db "<ask>"
 
-Dialog046::
+Dialog046:: ; Fisherman
     db "You have to have"
     db "more passion!   "
     db "Live a little!@"
 
-Dialog047::
+Dialog047:: ; Fisherman
     db "Okay, here's how"
     db "you do it.  Use "
     db "<left> and <right> on the <dpad>"
@@ -503,21 +503,21 @@ Dialog047::
     db "Button rapidly  "
     db "to reel him in!@"
 
-Dialog048::
+Dialog048:: ; Fisherman, Link
     db "Why not try one "
     db "more time,      "
     db "little buddy?   "
     db "    Cast Not Now"
     db "<ask>"
 
-Dialog049::
+Dialog049:: ; Fisherman, Link
     db "Wow! That one   "
     db "got away!  Want "
     db "to try again?   "
     db "    Cast Not Now"
     db "<ask>"
 
-Dialog04A::
+Dialog04A:: ; Fisherman, Link
     db "Wow! Nice Fish! "
     db "It's a lunker!! "
     db "I'll give you a "
@@ -526,19 +526,19 @@ Dialog04A::
     db "    Cast Not Now"
     db "<ask>"
 
-Dialog04B::
+Dialog04B:: ; Fisherman, Link
     db "This pond's all "
     db "fished out.  Why"
     db "not try your    "
     db "luck in the sea?"
     db "    Okay No<ask>"
 
-Dialog04C::
+Dialog04C:: ; Fisherman, Link
     db "Did I say that? "
     db "Forget it, okay?"
     db "Run along now...@"
 
-Dialog04D::
+Dialog04D:: ; Fisherman, Link
     db "It's a runt!    "
     db "I'll only give  "
     db "you a 5 Rupees  "
@@ -547,7 +547,7 @@ Dialog04D::
     db "again!          "
     db "    Okay No<ask>"
 
-Dialog04E::
+Dialog04E:: ; Fisherman
     db "You're short of "
     db "Rupees?  Don't  "
     db "worry about it. "
@@ -556,40 +556,40 @@ Dialog04E::
     db "have more money,"
     db "little buddy.@"
 
-Dialog04F::
+Dialog04F:: ; Narrator
     db "You've got a    "
     db "Piece of Heart! "
     db "Press SELECT on "
     db "the Subscreen   "
     db "to see.@"
 
-Dialog050::
+Dialog050:: ; Narrator
     db "You collected   "
     db "four Pieces of  "
     db "Heart.  Now, you"
     db "have a complete "
     db "Heart Container!@"
 
-Dialog051::
+Dialog051:: ; Narrator
     db "Brrrr... This is"
     db "a block of solid"
     db "ice!  It's very "
     db "cold!@"
 
-Dialog052::
+Dialog052:: ; Genie (D2 Nightmare)
     db "NYAH NYAH! You  "
     db "can't hurt me as"
     db "long as I have  "
     db "my bottle!@"
 
-Dialog053::
+Dialog053:: ; Genie (D2 Nightmare)
     db "Waaaah! You- you"
     db "broke my bottle!"
     db "Why, you... You "
     db "make me hopping "
     db "mad!!!@"
 
-Dialog054::
+Dialog054:: ; Tarin
     db "Well, #####, ya "
     db "finally snapped "
     db "out of it...    "
@@ -608,7 +608,7 @@ ELSE
     db "this shield!@"
 ENDC
 
-Dialog055::
+Dialog055:: ; Tarin
     db "Oh, yeah... Some"
     db "other stuff like"
     db "this washed up  "
@@ -621,200 +621,200 @@ Dialog055::
     db "seen 'em all    "
     db "over the place!@"
 
-Dialog056::
+Dialog056:: ; Map
     db "Level 1--       "
     db "     Tail Cave@"
 
-Dialog057::
+Dialog057:: ; Map
     db "Level 2--       "
     db "   Bottle Grotto@"
 
-Dialog058::
+Dialog058:: ; Map
     db "Level 3--       "
     db "      Key Cavern@"
 
-Dialog059::
+Dialog059:: ; Map
     db "Level 4--       "
     db " Angler's Tunnel@"
 
-Dialog05A::
+Dialog05A:: ; Map
     db "Level 5--       "
     db "   Catfish's Maw@"
 
-Dialog05B::
+Dialog05B:: ; Map
     db "Level 6--       "
     db "     Face Shrine@"
 
-Dialog05C::
+Dialog05C:: ; Map
     db "Level 7--       "
     db "   Eagle's Tower@"
 
-Dialog05D::
+Dialog05D:: ; Map
     db "Level 8--       "
     db "     Turtle Rock@"
 
-Dialog05E::
+Dialog05E:: ; Map
     db "Wind Fish's Egg @"
 
-Dialog05F::
-Dialog060::
+Dialog05F:: ; Map
+Dialog060:: ; Map
     db "Mountain Bridge @"
 
-Dialog061::
+Dialog061:: ; Map
     db "Sale's House O' "
     db "    Bananas@"
 
-Dialog062::
+Dialog062:: ; Map
     db "Pothole Field@"
 
-Dialog063::
+Dialog063:: ; Map
     db "    House By    "
     db "     The Bay@"
 
-Dialog064::
+Dialog064:: ; Map
     db "   Trendy Game@"
 
-Dialog065::
+Dialog065:: ; Map
     db "  Town Tool Shop@"
 
-Dialog066::
+Dialog066:: ; Map
     db "Marin and       "
     db "   Tarin's House@"
 
-Dialog067::
+Dialog067:: ; Map
     db "   Witch's Hut@"
 
-Dialog068::
+Dialog068:: ; Map
     db "  Yarna Desert@"
 
-Dialog069::
+Dialog069:: ; Map
     db "  Ukuku Prairie@"
 
-Dialog06A::
+Dialog06A:: ; Map
     db "Mysterious Woods@"
 
-Dialog06B::
+Dialog06B:: ; Map
     db "  Mt. Tamaranch @"
 
-Dialog06C::
+Dialog06C:: ; Map
     db "     Tal Tal    "
     db " Mountain Range @"
 
-Dialog06D::
+Dialog06D:: ; Map
     db "  Signpost Maze @"
 
-Dialog06E::
+Dialog06E:: ; Map
     db "  Mabe Village  @"
 
-Dialog06F::
+Dialog06F:: ; Map
     db " Animal Village @"
 
-Dialog070::
+Dialog070:: ; Map
     db "    Cemetery    @"
 
-Dialog071::
+Dialog071:: ; Map
     db "   Rapids Ride  @"
 
-Dialog072::
+Dialog072:: ; Map
     db "Koholint Prairie@"
 
-Dialog073::
+Dialog073:: ; Map
     db " Toronbo Shores@"
 
-Dialog074::
+Dialog074:: ; Map
     db "  Martha's Bay@"
 
-Dialog075::
+Dialog075:: ; Map
     db "East of the Bay@"
 
-Dialog076::
+Dialog076:: ; Map
     db "  Goponga Swamp@"
 
-Dialog077::
+Dialog077:: ; Map
     db "   Face Shrine @"
 
-Dialog078::
+Dialog078:: ; Map
     db " Kanalet Castle@"
 
-Dialog079::
+Dialog079:: ; Map
     db "Tal Tal Heights@"
 
-Dialog07A::
+Dialog07A:: ; Map
     db "Tabahl Wasteland@"
 
-Dialog07B::
+Dialog07B:: ; Map
     db "  South of the  "
     db "    Village@"
 
-Dialog07C::
+Dialog07C:: ; Map
     db "  Fishing Pond  @"
 
-Dialog07D::
+Dialog07D:: ; Map
     db "Madam MeowMeow's"
     db "     House      "
     db " Beware of Dog!@"
 
-Dialog07E::
+Dialog07E:: ; Map
     db "Old Man Ulrira's"
     db "     House      @"
 
-Dialog07F::
+Dialog07F:: ; Map
     db "Weird Mr. Write @"
 
-Dialog080::
+Dialog080:: ; Map
     db " Crazy Tracy's  "
     db "  Health Spa@"
 
-Dialog081::
+Dialog081:: ; Map
     db "Quadruplet's    "
     db "      House@"
 
-Dialog082::
+Dialog082:: ; Map
     db "  Dream Shrine  @"
 
-Dialog083::
+Dialog083:: ; Signpost
     db "Telephone Booth "
     db "<down> Signpost Maze @"
 
-Dialog084::
+Dialog084:: ; Map
     db "Seashell Mansion@"
 
-Dialog085::
+Dialog085:: ; Map, probably
     db "Richard's Villa @"
 
-Dialog086::
+Dialog086:: ; Map
     db "     Hen House  @"
 
-Dialog087::
+Dialog087:: ; Map
     db "Village Library @"
 
-Dialog088::
+Dialog088:: ; Map
     db "    Raft Shop   @"
 
-Dialog089::
+Dialog089:: ; Map
     db "    Warp Hole   @"
 
-Dialog08A::
+Dialog08A:: ; Narrator
     db "This rock has   "
     db "many cracks...  "
     db "There must be   "
     db "some way to     "
     db "shatter it...@"
 
-Dialog08B::
+Dialog08B:: ; Narrator
     db "Oh? What a weird"
     db "object!  There  "
     db "must be some way"
     db "to tackle this  "
     db "obstacle.@"
 
-Dialog08C::
+Dialog08C:: ; Narrator
     db "Hunh?  This rock"
     db "has a key hole! "
     db "You should come "
     db "back with a key!@"
 
-Dialog08D::
+Dialog08D:: ; Narrator
     db "Wow!  This looks"
     db "pretty heavy!   "
     db "You won't be    "
@@ -822,31 +822,31 @@ Dialog08D::
     db "with just your  "
     db "bare hands...@"
 
-Dialog08E::
+Dialog08E:: ; Narrator, probably
     db "Well, it's an   "
     db "Ocarina, but you"
     db "don't know how  "
     db "to play it...@"
 
-Dialog08F::
+Dialog08F:: ; Marin, probably
     db "No!  No!  Poor  "
     db "hen!  Stop that!@"
 
-Dialog090::
+Dialog090:: ; Narrator
     db "You found the   "
     db "Power Bracelet! "
     db "At last, you can"
     db "pick up pots and"
     db "stones!@"
 
-Dialog091::
+Dialog091:: ; Narrator
     db "You got your    "
     db "shield back!    "
     db "Press the button"
     db "and repel       "
     db "enemies with it!@"
 
-Dialog092::
+Dialog092:: ; idk
     db "Ahhh... Yess... "
     db "That dust was so"
     db "refreshing...   "
@@ -860,66 +860,66 @@ Dialog092::
     db "other side of   "
     db "the wall... Bye!@"
 
-Dialog093::
+Dialog093:: ; Narrator
     db "You've got the  "
     db "Hook Shot!  Its "
     db "chain stretches "
     db "long when you   "
     db "use it!@"
 
-Dialog094::
+Dialog094:: ; Narrator
     db "You've got the  "
     db "Magic Rod!  Now "
     db "you can burn    "
     db "things! Burn it!"
     db "Burn, baby burn!@"
 
-Dialog095::
+Dialog095:: ; Narrator
     db "You've got the  "
     db "Pegasus Boots!  "
     db "If you hold down"
     db "the Button, you "
     db "can dash!@"
 
-Dialog096::
+Dialog096:: ; Narrator
     db "You've got the  "
     db "Ocarina!  You   "
     db "should learn to "
     db "play many songs!@"
 
-Dialog097::
+Dialog097:: ; Narrator
     db "You've got the  "
     db "Roc's Feather!  "
     db "It feels like   "
     db "your body is a  "
     db "lot lighter!@"
 
-Dialog098::
+Dialog098:: ; Narrator
     db "You've got a    "
     db "Shovel!  Now you"
     db "can feel the joy"
     db "of digging!@"
 
-Dialog099::
+Dialog099:: ; Narrator
     db "You've got some "
     db "Magic Powder!   "
     db "Try sprinkling  "
     db "it on a variety "
     db "of things!@"
 
-Dialog09A::
+Dialog09A:: ; Narrator, probably
     db "You've got a    "
     db "bomb! Way to    "
     db "go!@"
 
-Dialog09B::
+Dialog09B:: ; Narrator
     db "You found your  "
     db "Sword!  It must "
     db "be yours because"
     db "it has your name"
     db "engraved on it!@"
 
-Dialog09C::
+Dialog09C:: ; Narrator
     db "You've got the  "
     db "Flippers! If you"
     db "press the B     "
@@ -927,7 +927,7 @@ Dialog09C::
     db "swim, you can   "
     db "dive underwater!@"
 
-Dialog09D::
+Dialog09D:: ; Narrator
     db "You've got the  "
     db "Magnifying Lens!"
     db "This will reveal"
@@ -935,34 +935,34 @@ Dialog09D::
     db "couldn't see    "
     db "before!@"
 
-Dialog09E::
-Dialog09F::
+Dialog09E:: ; Narrator
+Dialog09F:: ; Narrator
     db "You've got a    "
     db "new Sword!  You "
     db "should put your "
     db "name on it right"
     db "away!@"
 
-Dialog0A0::
+Dialog0A0:: ; Narrator
     db "You found the   "
     db "secret medicine!"
     db "You should apply"
     db "this and see    "
     db "what happens!@"
 
-Dialog0A1::
+Dialog0A1:: ; Narrator
     db "You've got the  "
     db "Tail Key!  Now  "
     db "you can open the"
     db "Tail Cave gate!@"
 
-Dialog0A2::
+Dialog0A2:: ; Narrator
     db "You've got the  "
     db "Slime Key!  Now "
     db "you can open the"
     db "gate in Ukuku   "
     db "Prairie!@"
 
-Dialog0A3::
+Dialog0A3:: ; Narrator
     db "You've got the  "
     db "Angler Key!@"

--- a/src/text/dialog_1.asm
+++ b/src/text/dialog_1.asm
@@ -43,7 +43,7 @@ Dialog003:: ; Marin
     db "'Ballad of the  "
     db "Wind Fish.'@"
 
-Dialog004:: ; Marin, probably
+Dialog004:: ; Marin
     db "Hey!  That's a  "
     db "nice Ocarina you"
     db "have there! Will"
@@ -170,7 +170,7 @@ Dialog012:: ; Talking Tree
     db "the wall with a "
     db "Bomb!@"
 
-Dialog013:: ; Narrator, probably
+Dialog013:: ; Narrator
     db "You've learned  "
     db "the 'Ballad of  "
     db "the Wind Fish!' "
@@ -178,7 +178,7 @@ Dialog013:: ; Narrator, probably
     db "always remain in"
     db "your heart!@"
 
-Dialog014:: ; Marin, probably
+Dialog014:: ; Marin
     db "Please remember "
     db "this song!  You "
     db "should play it  "
@@ -187,13 +187,13 @@ Dialog014:: ; Marin, probably
     db "fresh in your   "
     db "mind!@"
 
-Dialog015:: ; Marin, probably
+Dialog015:: ; Marin
     db "Please!  I want "
     db "you to learn it!"
     db "This song is my "
     db "favorite!@"
 
-Dialog016:: ; Marin, probably
+Dialog016:: ; Marin
     db "So, how do you  "
     db "like it?  It's  "
     db "really touching,"
@@ -239,7 +239,7 @@ ENDC
     db "Drop by again,  "
     db "big guy!@"
 
-Dialog01B:: ; Crazy Tracy, probably
+Dialog01B:: ; Crazy Tracy
     db "Beat it, then!  "
     db "Come back when  "
     db "you have some   "
@@ -250,7 +250,7 @@ Dialog01C:: ; Crazy Tracy
     db "But I won't sell"
     db "it to you!@"
 
-Dialog01D:: ; Crazy Tracy, probably
+Dialog01D:: ; Crazy Tracy
     db "Well!  I'm only "
     db "offering you a  "
     db "secret that will"
@@ -269,7 +269,7 @@ Dialog01F:: ; Narrator
     db "Is this your big"
     db "chance?@"
 
-Dialog020:: ; Fox
+Dialog020:: ; Mutt
     db "GRRRR...@"
 
 Dialog021:: ; Tarin
@@ -320,7 +320,7 @@ Dialog027:: ; Papahl
     db "keep a look out "
     db "for me, hear?@"
 
-Dialog028:: ; Marin, probably
+Dialog028:: ; Marin
     db "Yes!!  Yes!!    "
     db "Break them!     "
     db "Break them all! "
@@ -779,7 +779,7 @@ Dialog083:: ; Signpost
 Dialog084:: ; Map
     db "Seashell Mansion@"
 
-Dialog085:: ; Map, probably
+Dialog085:: ; Map
     db "Richard's Villa @"
 
 Dialog086:: ; Map
@@ -822,13 +822,13 @@ Dialog08D:: ; Narrator
     db "with just your  "
     db "bare hands...@"
 
-Dialog08E:: ; Narrator, probably
+Dialog08E:: ; Narrator
     db "Well, it's an   "
     db "Ocarina, but you"
     db "don't know how  "
     db "to play it...@"
 
-Dialog08F:: ; Marin, probably
+Dialog08F:: ; Marin
     db "No!  No!  Poor  "
     db "hen!  Stop that!@"
 
@@ -846,7 +846,7 @@ Dialog091:: ; Narrator
     db "and repel       "
     db "enemies with it!@"
 
-Dialog092:: ; idk
+Dialog092:: ; Desert skull
     db "Ahhh... Yess... "
     db "That dust was so"
     db "refreshing...   "
@@ -907,7 +907,7 @@ Dialog099:: ; Narrator
     db "it on a variety "
     db "of things!@"
 
-Dialog09A:: ; Narrator, probably
+Dialog09A:: ; Narrator
     db "You've got a    "
     db "bomb! Way to    "
     db "go!@"

--- a/src/text/dialog_2.asm
+++ b/src/text/dialog_2.asm
@@ -103,7 +103,7 @@ Dialog0B4:: ; Genie (D2 Nightmare)
     db "this time!!     "
     db "HO HO HO!@"
 
-Dialog0B5:: ; idk
+Dialog0B5:: ; Slime Eel (D5 Nightmare)
     db "TSSSK, TSSSK!   "
     db "You don't ssseem"
     db "to know what    "
@@ -121,7 +121,7 @@ Dialog0B6:: ; Facade (D6 Nightmare)
     db "go, talking too "
     db "much again...@"
 
-Dialog0B7:: ; idk
+Dialog0B7:: ; Facade (D6 Nightmare)
     db "Okay, listen up!"
     db "If the Wind Fish"
     db "wakes up, every-"
@@ -482,8 +482,8 @@ Dialog0D0:: ; Wind Fish
     db "LET US AWAKEN..."
     db "   TOGETHER!!@"
 
-Dialog0D1:: ; Wind Fish, probably
-Dialog0D2:: ; Wind Fish, probably
+Dialog0D1:: ; Wind Fish
+Dialog0D2:: ; Wind Fish
     db " PLAY THE EIGHT "
     db "  INSTRUMENTS!  "
     db "PLAY THE SONG OF"
@@ -494,8 +494,8 @@ Dialog0D4:: ; Map, probably
 Dialog0D5:: ; Map, probably
     db "Mermaid Statue  @"
 
-Dialog0D6:: ; idk
-Dialog0D7:: ; idk
+Dialog0D6:: ; Owl
+Dialog0D7:: ; Owl
     db "...#####, you   "
     db "have beaten all "
     db "the Nightmares! "
@@ -533,7 +533,7 @@ Dialog0D9:: ; Owl
     db "wait for you    "
     db "there!  Hoot!@"
 
-Dialog0DA:: ; idk
+Dialog0DA:: ; Lanmola
     db "Annoyance!  You "
     db "are only getting"
     db "in the way!@"
@@ -566,12 +566,12 @@ Dialog0DC:: ; Mamu
     db "What do you do? "
     db "    Pay  Leave<ask>"
 
-Dialog0DD:: ; Mamu, probably
+Dialog0DD:: ; Mamu
     db "Thank you...    "
     db "Thank you very  "
     db "much... Croak!@"
 
-Dialog0DE:: ; Mamu, probably
+Dialog0DE:: ; Mamu
     db "Well, that's a  "
     db "shame, but we   "
     db "don't play for  "
@@ -586,7 +586,7 @@ Dialog0DF:: ; Narrator
     db "even liven up   "
     db "unliving things!@"
 
-Dialog0E0:: ; Mamu, probably
+Dialog0E0:: ; Mamu
     db "If you play this"
     db "song, you'll    "
     db "make everything "
@@ -633,7 +633,7 @@ Dialog0E5:: ; Li'l Devil
     db "Hah!  Take care!"
     db "See you again!@"
 
-Dialog0E6:: ; Narrator, probably
+Dialog0E6:: ; Narrator
     db "??  There is a  "
     db "picture carved  "
     db "on the wall, but"
@@ -641,7 +641,7 @@ Dialog0E6:: ; Narrator, probably
     db "because it's too"
     db "dark in here...@"
 
-Dialog0E7:: ; idk
+Dialog0E7:: ; Southern Face Shrine mural
     db "TO THE FINDER..."
     db "  THE ISLE OF   "
     db "KOHOLINT, IS BUT"
@@ -732,7 +732,7 @@ Dialog0F4:: ; Signpost, probably
     db "Entrance to the "
     db " Animal Village@"
 
-Dialog0F5:: ; idk
+Dialog0F5:: ; Nightmare (final boss)
     db "We were born of "
     db "nightmares... To"
     db "take over this  "
@@ -754,7 +754,7 @@ Dialog0F5:: ; idk
     db "defeat us!!!    "
     db "Let's rumble!@"
 
-Dialog0F6:: ; idk
+Dialog0F6:: ; Nightmare (final boss)
     db "This island is  "
     db "going to dis-   "
     db "appear...  Our  "
@@ -763,19 +763,19 @@ Dialog0F6:: ; idk
     db "Our world...    "
     db "Our... world... @"
 
-Dialog0F7:: ; Marin, probably
+Dialog0F7:: ; Marin
     db "Wow!  #####, can"
     db "I try this?!    "
     db "What do you say?"
     db "    Okay No Way<ask>"
 
-Dialog0F8:: ; Marin, probably
+Dialog0F8:: ; Marin
     db "C'mon!  I want  "
     db "to do it! Can I?"
     db "It looks so fun!"
     db "    Yes  Okay<ask>"
 
-Dialog0F9:: ; idk
+Dialog0F9:: ; Trendy Gamester
     db "You're good!    "
     db "You're a pro,   "
     db "aren't you?     "

--- a/src/text/dialog_2.asm
+++ b/src/text/dialog_2.asm
@@ -1,18 +1,18 @@
-Dialog0A4::
+Dialog0A4:: ; Narrator
     db "You've got the  "
     db "Face Key!@"
 
-Dialog0A5::
+Dialog0A5:: ; Narrator
     db "You've got the  "
     db "Bird Key!@"
 
-Dialog0A6::
+Dialog0A6:: ; Narrator
     db "At last, you got"
     db "a Map!  Press   "
     db "the START Button"
     db "to look at it!@"
 
-Dialog0A7::
+Dialog0A7:: ; Narrator
     db "You've got the  "
     db "Compass!  Now,  "
     db "you can see     "
@@ -26,14 +26,14 @@ Dialog0A7::
     db "hidden in a room"
     db "when you enter! @"
 
-Dialog0A8::
+Dialog0A8:: ; Narrator
     db "You found a     "
     db "stone beak!     "
     db "Let's find the  "
     db "owl statue that "
     db "belongs to it.@"
 
-Dialog0A9::
+Dialog0A9:: ; Narrator
     db "You've got the  "
     db "Nightmare's Key!"
     db "Now you can open"
@@ -41,55 +41,55 @@ Dialog0A9::
     db "Nightmare's     "
     db "Lair!@"
 
-Dialog0AA::
+Dialog0AA:: ; Narrator
     db "You got a Small "
     db "Key!  You can   "
     db "open a locked   "
     db "door.@"
 
-Dialog0AB::
+Dialog0AB:: ; Narrator
     db "   You got 20   "
     db "     Rupees!    "
     db "      JOY!@"
 
-Dialog0AC::
+Dialog0AC:: ; Narrator
     db "    You got 50  "
     db "      Rupees!   "
     db "    Very Nice!@"
 
-Dialog0AD::
+Dialog0AD:: ; Narrator
     db "   You got 100  "
     db "     Rupees!    "
     db "  You're Happy!@"
 
-Dialog0AE::
+Dialog0AE:: ; Narrator
     db "   You got 200  "
     db "     Rupees!    "
     db "You're Ecstatic!@"
 
-Dialog0AF::
+Dialog0AF:: ; Hippo
     db "Leave me alone! "
     db "I'm trying to   "
     db "sit still so    "
     db "Schule can paint"
     db "my portrait!@"
 
-Dialog0B0::
+Dialog0B0:: ; Moldorm (D1 Nightmare)
     db "BUZZZZZ! BUZZZZ!"
     db "   OUTZZZIDER!  @"
 
-Dialog0B1::
+Dialog0B1:: ; Slime Eyes (D3 Nightmare)
     db "NEENER NEENER!  "
     db "You can't find  "
     db "me!  NYAH NYAH!@"
 
-Dialog0B2::
+Dialog0B2:: ; Angler Fish (D4 Nightmare)
     db "BLOOOP! BLOOOP! "
     db "  GLUB!  GLUB!  "
     db "OGGGH!  FOOOOD! "
     db "BLOOOOP!  GLUB!@"
 
-Dialog0B3::
+Dialog0B3:: ; Slime Eel (D5 Nightmare)
     db "Ssso...you are  "
     db "the outsssider, "
     db "come to wake the"
@@ -97,13 +97,13 @@ Dialog0B3::
     db "KEEE-HEE-HEEEH! "
     db "I shall eat you!@"
 
-Dialog0B4::
+Dialog0B4:: ; Genie (D2 Nightmare)
     db "HO HO HO!       "
     db "I'm your bad guy"
     db "this time!!     "
     db "HO HO HO!@"
 
-Dialog0B5::
+Dialog0B5:: ; idk
     db "TSSSK, TSSSK!   "
     db "You don't ssseem"
     db "to know what    "
@@ -113,7 +113,7 @@ Dialog0B5::
     db "What a fool...  "
     db "KEE-HEE-HEH!!@"
 
-Dialog0B6::
+Dialog0B6:: ; Facade (D6 Nightmare)
     db "Hey dummy! Need "
     db "a hint?  My weak"
     db "point is... !!  "
@@ -121,7 +121,7 @@ Dialog0B6::
     db "go, talking too "
     db "much again...@"
 
-Dialog0B7::
+Dialog0B7:: ; idk
     db "Okay, listen up!"
     db "If the Wind Fish"
     db "wakes up, every-"
@@ -131,8 +131,8 @@ Dialog0B7::
     db "And I do mean..."
     db "EVERYTHING!@"
 
-Dialog0B8::
-Dialog0B9::
+Dialog0B8:: ; Grim Creeper (D7 Nightmare)
+Dialog0B9:: ; Grim Creeper (D7 Nightmare)
     db "My energy...    "
     db "gone...I...lost!"
     db "But you will be "
@@ -142,7 +142,7 @@ Dialog0B9::
     db "...are...in...  "
     db "his...dream...@"
 
-Dialog0BA::
+Dialog0BA:: ; Grim Creeper (D7 Nightmare)
     db "BAH!  I'm not   "
     db "going to hold   "
     db "back!  I'm going"
@@ -150,8 +150,8 @@ Dialog0BA::
     db "you were never  "
     db "born!!@"
 
-Dialog0BB::
-Dialog0BC::
+Dialog0BB:: ; Hot Head (D8 Nightmare)
+Dialog0BC:: ; Hot Head (D8 Nightmare)
     db "CRACKLE-FWOOOSH!"
     db "You're finished!"
     db "I will never let"
@@ -159,7 +159,7 @@ Dialog0BC::
     db "Instruments of  "
     db "the Sirens!!@"
 
-Dialog0BD::
+Dialog0BD:: ; Hot Head (D8 Nightmare)
     db "C-C-CRACKLE!    "
     db "Why did you come"
     db "here?  If it    "
@@ -172,9 +172,9 @@ Dialog0BD::
     db "too...are in... "
     db "...the dream...@"
 
-Dialog0BE::
-Dialog0BF::
-Dialog0C0::
+Dialog0BE:: ; Owl
+Dialog0BF:: ; Owl
+Dialog0C0:: ; Owl
     db "Hoot!  Ho, brave"
     db "lad, on your    "
     db "quest to wake   "
@@ -203,7 +203,7 @@ Dialog0C0::
     db "The Wind Fish is"
     db "watching...Hoot!@"
 
-Dialog0C1::
+Dialog0C1:: ; Owl
     db "Hoot!  Take the "
     db "key and go to   "
     db "the Tail Cave.  "
@@ -214,7 +214,7 @@ Dialog0C1::
     db "Wind Fish is    "
     db "waiting!  Hooot!@"
 
-Dialog0C2::
+Dialog0C2:: ; Owl
     db "Hoooot!  That is"
     db "an 'Instrument  "
     db "of the Sirens!' "
@@ -238,7 +238,7 @@ Dialog0C2::
     db "Goponga Swamp!! "
     db "Hoot, indeed!@"
 
-Dialog0C3::
+Dialog0C3:: ; Owl
     db "Hoot!  That is a"
     db "fearsome looking"
     db "animal you have "
@@ -247,7 +247,7 @@ Dialog0C3::
     db "Instrument is in"
     db "Goponga Swamp!@"
 
-Dialog0C4::
+Dialog0C4:: ; Owl
     db "Hoooot! The Wind"
     db "Fish sleeps long"
     db "and dreamily in "
@@ -262,7 +262,7 @@ Dialog0C4::
     db "for you to leave"
     db "the island! Hoo!@"
 
-Dialog0C5::
+Dialog0C5:: ; Owl
     db "Hoot!  How many "
     db "Instruments     "
     db "have you gotten "
@@ -284,7 +284,7 @@ Dialog0C5::
     db "show you the    "
     db "way! Hoot Hoot!@"
 
-Dialog0C6::
+Dialog0C6:: ; Owl
     db "Hoot!  The shape"
     db "of the key shows"
     db "a fish, swimming"
@@ -296,7 +296,7 @@ Dialog0C6::
     db "top and you will"
     db "reach your goal!@"
 
-Dialog0C7::
+Dialog0C7:: ; Owl
     db "Hoot!  There are"
     db "two shrines, one"
     db "to the north,   "
@@ -309,7 +309,7 @@ Dialog0C7::
     db "You will learn  "
     db "much there...@"
 
-Dialog0C8::
+Dialog0C8:: ; Owl
     db "Hoot!  I see you"
     db "have read the   "
     db "relief...  While"
@@ -335,7 +335,7 @@ Dialog0C8::
     db "Someday you will"
     db "know for sure...@"
 
-Dialog0C9::
+Dialog0C9:: ; Owl
     db "Hoot!  The many "
     db "monsters of this"
     db "island fear that"
@@ -353,7 +353,7 @@ Dialog0C9::
     db "Fly like a bird!"
     db "Hoot! Hoot!@"
 
-Dialog0CA::
+Dialog0CA:: ; Owl
     db "Hoot hoot!      "
     db "Your path is    "
     db "not easy, but   "
@@ -363,7 +363,7 @@ Dialog0CA::
     db "is getting      "
     db " restless.@"
 
-Dialog0CB::
+Dialog0CB:: ; Owl
     db "Hoot!  It has   "
     db "been some time  "
     db "since our paths "
@@ -380,7 +380,7 @@ Dialog0CB::
     db "sleeps.  Carry  "
     db "onward!  Hoot!@"
 
-Dialog0CC::
+Dialog0CC:: ; Owl
     db "Hoot!  That girl"
     db "sang her song in"
     db "front of the    "
@@ -402,15 +402,15 @@ Dialog0CC::
     db "Wind Fish waits "
     db "for you!  Hoot!@"
 
-Dialog0CD::
+Dialog0CD:: ; Owl
     db "The time has    "
     db "come... The Wind"
     db "Fish awaits...  "
     db "Enter the Egg..."
     db "Hoot! Hoot!@"
 
-Dialog0CE::
-Dialog0CF::
+Dialog0CE:: ; Owl
+Dialog0CF:: ; Owl
     db "Hoot! Young lad,"
     db "I mean... #####,"
     db "the hero!  You  "
@@ -445,7 +445,7 @@ Dialog0CF::
     db "will wake soon. "
     db "Good bye...Hoot!@"
 
-Dialog0D0::
+Dialog0D0:: ; Wind Fish
     db "... ... ... ... "
     db " ... ... ... ..."
     db " I AM THE WIND  "
@@ -482,34 +482,34 @@ Dialog0D0::
     db "LET US AWAKEN..."
     db "   TOGETHER!!@"
 
-Dialog0D1::
-Dialog0D2::
+Dialog0D1:: ; Wind Fish, probably
+Dialog0D2:: ; Wind Fish, probably
     db " PLAY THE EIGHT "
     db "  INSTRUMENTS!  "
     db "PLAY THE SONG OF"
     db "   AWAKENING!!@"
 
-Dialog0D3::
-Dialog0D4::
-Dialog0D5::
+Dialog0D3:: ; Map, probably
+Dialog0D4:: ; Map, probably
+Dialog0D5:: ; Map, probably
     db "Mermaid Statue  @"
 
-Dialog0D6::
-Dialog0D7::
+Dialog0D6:: ; idk
+Dialog0D7:: ; idk
     db "...#####, you   "
     db "have beaten all "
     db "the Nightmares! "
     db "Climb the stairs"
     db "before you!@"
 
-Dialog0D8::
+Dialog0D8:: ; Schule Donavitch
     db "Ach! Vat are you"
     db "looking at vith "
     db "zat magnifying  "
     db "lens?  Stop it  "
     db "at vonce!@"
 
-Dialog0D9::
+Dialog0D9:: ; Owl
     db "  Hoot!  Hoot!  "
     db "So you are the  "
     db "lad who owns the"
@@ -533,12 +533,12 @@ Dialog0D9::
     db "wait for you    "
     db "there!  Hoot!@"
 
-Dialog0DA::
+Dialog0DA:: ; idk
     db "Annoyance!  You "
     db "are only getting"
     db "in the way!@"
 
-Dialog0DB::
+Dialog0DB:: ; Mamu
     db "Ribbit!  Ribbit!"
     db "Hey, man, I'm   "
     db "Mamu, on vocals!"
@@ -548,7 +548,7 @@ Dialog0DB::
     db "squat about     "
     db "music!  Ribbit!@"
 
-Dialog0DC::
+Dialog0DC:: ; Mamu
     db "Ribbit!  Ribbit!"
     db "I'm Mamu, on    "
     db "vocals!  But I  "
@@ -566,18 +566,18 @@ Dialog0DC::
     db "What do you do? "
     db "    Pay  Leave<ask>"
 
-Dialog0DD::
+Dialog0DD:: ; Mamu, probably
     db "Thank you...    "
     db "Thank you very  "
     db "much... Croak!@"
 
-Dialog0DE::
+Dialog0DE:: ; Mamu, probably
     db "Well, that's a  "
     db "shame, but we   "
     db "don't play for  "
     db "free!@"
 
-Dialog0DF::
+Dialog0DF:: ; Narrator
     db "You've learned  "
     db "The Frog's Song "
     db "of Soul!  It's a"
@@ -586,14 +586,14 @@ Dialog0DF::
     db "even liven up   "
     db "unliving things!@"
 
-Dialog0E0::
+Dialog0E0:: ; Mamu, probably
     db "If you play this"
     db "song, you'll    "
     db "make everything "
     db "around you feel "
     db "more alive!@"
 
-Dialog0E1::
+Dialog0E1:: ; Li'l Devil
     db "Hey, Kid!  You  "
     db "woke me up from "
     db "a fine nap!!    "
@@ -603,28 +603,28 @@ Dialog0E1::
     db "Are you ready?! "
     db "    Yes  N-No<ask>"
 
-Dialog0E2::
+Dialog0E2:: ; Li'l Devil
     db "I'll let you    "
     db "carry more Magic"
     db "Powder!  He He! "
     db "Are you ready?! "
     db "    Yes  N-No<ask>"
 
-Dialog0E3::
+Dialog0E3:: ; Li'l Devil
     db "Okay, I'll let  "
     db "you carry more  "
     db "Bombs! He He He!"
     db "Are you ready?! "
     db "    Yes  N-No<ask>"
 
-Dialog0E4::
+Dialog0E4:: ; Li'l Devil
     db "Fine, I'll let  "
     db "you have more   "
     db "arrows! Heh Heh!"
     db "Are you ready?! "
     db "    Yes  N-No<ask>"
 
-Dialog0E5::
+Dialog0E5:: ; Li'l Devil
     db "Heh Heh Heh!    "
     db "You deserve it! "
     db "Now look at all "
@@ -633,7 +633,7 @@ Dialog0E5::
     db "Hah!  Take care!"
     db "See you again!@"
 
-Dialog0E6::
+Dialog0E6:: ; Narrator, probably
     db "??  There is a  "
     db "picture carved  "
     db "on the wall, but"
@@ -641,7 +641,7 @@ Dialog0E6::
     db "because it's too"
     db "dark in here...@"
 
-Dialog0E7::
+Dialog0E7:: ; idk
     db "TO THE FINDER..."
     db "  THE ISLE OF   "
     db "KOHOLINT, IS BUT"
@@ -661,14 +661,14 @@ Dialog0E7::
     db "... ... ... ... "
     db "What?  Illusion?@"
 
-Dialog0E8::
+Dialog0E8:: ; Narrator
     db "You've found a  "
     db "Gold Leaf! Press"
     db "START to see    "
     db "how many you've "
     db "collected!@"
 
-Dialog0E9::
+Dialog0E9:: ; Narrator
     db "At last!  You've"
     db "got the final   "
     db "Golden Leaf!    "
@@ -676,16 +676,16 @@ Dialog0E9::
     db "Richard about   "
     db "that key...@"
 
-Dialog0EA::
-Dialog0EB::
-Dialog0EC::
+Dialog0EA:: ; Narrator
+Dialog0EB:: ; Narrator
+Dialog0EC:: ; Narrator
     db "You've got a    "
     db "Guardian Acorn! "
     db "It will reduce  "
     db "the damage you  "
     db "take by half!@"
 
-Dialog0ED::
+Dialog0ED:: ; Narrator
     db "You've got the  "
     db "Mirror Shield!  "
     db "You can now turn"
@@ -693,14 +693,14 @@ Dialog0ED::
     db "you couldn't    "
     db "block before!@"
 
-Dialog0EE::
+Dialog0EE:: ; Narrator
     db "You've got a    "
     db "more Powerful   "
     db "Bracelet!  Now  "
     db "you can almost  "
     db "lift a whale!@"
 
-Dialog0EF::
+Dialog0EF:: ; Narrator
     db "You found a     "
     db "Secret Seashell!"
     db "If you collect a"
@@ -709,30 +709,30 @@ Dialog0EF::
     db "is bound to     "
     db "happen!@"
 
-Dialog0F0::
+Dialog0F0:: ; Raft Guy
     db "Want to go on a "
     db "raft ride for a "
     db "hundred Rupees? "
     db "    Yes  No Way<ask>"
 
-Dialog0F1::
+Dialog0F1:: ; Raft Guy
     db "Okay, the raft  "
     db "is ready for you"
     db "outside!  Enjoy!@"
 
-Dialog0F2::
+Dialog0F2:: ; Signpost, probably
     db "Waterfall at the"
     db "    Shrine@"
 
-Dialog0F3::
+Dialog0F3:: ; Signpost, probably
     db " South of the   "
     db "    Shrine@"
 
-Dialog0F4::
+Dialog0F4:: ; Signpost, probably
     db "Entrance to the "
     db " Animal Village@"
 
-Dialog0F5::
+Dialog0F5:: ; idk
     db "We were born of "
     db "nightmares... To"
     db "take over this  "
@@ -754,7 +754,7 @@ Dialog0F5::
     db "defeat us!!!    "
     db "Let's rumble!@"
 
-Dialog0F6::
+Dialog0F6:: ; idk
     db "This island is  "
     db "going to dis-   "
     db "appear...  Our  "
@@ -763,19 +763,19 @@ Dialog0F6::
     db "Our world...    "
     db "Our... world... @"
 
-Dialog0F7::
+Dialog0F7:: ; Marin, probably
     db "Wow!  #####, can"
     db "I try this?!    "
     db "What do you say?"
     db "    Okay No Way<ask>"
 
-Dialog0F8::
+Dialog0F8:: ; Marin, probably
     db "C'mon!  I want  "
     db "to do it! Can I?"
     db "It looks so fun!"
     db "    Yes  Okay<ask>"
 
-Dialog0F9::
+Dialog0F9:: ; idk
     db "You're good!    "
     db "You're a pro,   "
     db "aren't you?     "
@@ -784,25 +784,25 @@ Dialog0F9::
     db "Pros aren't     "
     db "allowed in here!@"
 
-Dialog0FA::
+Dialog0FA:: ; Hippo
     db "Go away!@"
 
-Dialog0FB::
+Dialog0FB:: ; idk
     db "Quit it!@"
 
-Dialog0FC::
+Dialog0FC:: ; Narrator
     db "This is not a   "
     db "chest...  What? "
     db "You knew that?  "
     db "Okay.@"
 
-Dialog0FD::
+Dialog0FD:: ; Narrator
     db "##### checked   "
     db "the chest.  Wow!"
     db "This is a nice  "
     db "chest!@"
 
-Dialog0FE::
+Dialog0FE:: ; Witch
     db "It's all ready, "
     db "it is!  Take    "
     db "care, as there's"
@@ -810,42 +810,42 @@ Dialog0FE::
     db "Why not try a   "
     db "bit in my hut?@"
 
-Dialog0FF::
+Dialog0FF:: ; Tarin
     db "Hey!  What are  "
     db "ya doin' in my  "
     db "chest?!  Where'd"
     db "you learn ta do "
     db "such a thing?!@"
 
-Dialog100::
+Dialog100:: ; Narrator
     db "You've got the  "
     db "Full Moon Cello!@"
 
-Dialog101::
+Dialog101:: ; Narrator
     db "You've got the  "
     db "Conch Horn!@"
 
-Dialog102::
+Dialog102:: ; Narrator
     db "You've got the  "
     db "Sea Lily's Bell!@"
 
-Dialog103::
+Dialog103:: ; Narrator
     db "You've got the  "
     db "Surf Harp!@"
 
-Dialog104::
+Dialog104:: ; Narrator
     db "You've got the  "
     db "Wind Marimba!@"
 
-Dialog105::
+Dialog105:: ; Narrator
     db "You've got the  "
     db "Coral Triangle!@"
 
-Dialog106::
+Dialog106:: ; Narrator
     db "You've got the  "
     db "Organ of        "
     db "  Evening Calm!@"
 
-Dialog107::
+Dialog107:: ; Narrator
     db "You've got the  "
     db "Thunder Drum!@"

--- a/src/text/dialog_3.asm
+++ b/src/text/dialog_3.asm
@@ -1,27 +1,27 @@
-Dialog108::
+Dialog108:: ; Photographer
     db "Hi! It's me, the"
     db "photographer!   "
     db "You seem curious"
     db "about Grandpa   "
     db "Ulrira.@"
 
-Dialog109::
+Dialog109:: ; Photographer
     db "I'll call this  "
     db "'##### Dis-     "
     db "covers Ulrira's "
     db "Secret!'@"
 
-Dialog10A::
+Dialog10A:: ; Photographer, probably
     db "#####, now run  "
     db "away before he  "
     db "finds you.@"
 
-Dialog10B::
+Dialog10B:: ; Photographer
     db "I'll go develop "
     db "this. Come see  "
     db "it later, OK?@"
 
-Dialog10C::
+Dialog10C:: ; Photographer
     db "I just LOVE to  "
     db "take pictures.  "
     db "Will you let me "
@@ -29,13 +29,13 @@ Dialog10C::
     db "picture?        "
     db "    YES  NO<ask>"
 
-Dialog10D::
+Dialog10D:: ; Photographer
     db "Go to the back  "
     db "of the room and "
     db "stand in front  "
     db "of the screen.@"
 
-Dialog10E::
+Dialog10E:: ; Photographer
     db "Hey! I haven't  "
     db "taken your      "
     db "picture yet! Go "
@@ -43,13 +43,13 @@ Dialog10E::
     db "in front of the "
     db "screen!@"
 
-Dialog10F::
+Dialog10F:: ; Photographer
     db "I'll call this  "
     db "'Here Stands A  "
     db "Brave Man.'     "
     db "Say cheese!@"
 
-Dialog110::
+Dialog110:: ; Narrator
     db "This owl statue "
     db "is trying to say"
     db "something, but  "
@@ -58,25 +58,25 @@ Dialog110::
     db "because it has  "
     db "no beak.@"
 
-Dialog111::
+Dialog111:: ; Master Stalfos (D5 Mini-Boss)
     db "'I've got what  "
     db "was inside this "
     db "box.  Come and  "
     db "get it, if you  "
     db "can!'  Master <skull>@"
 
-Dialog112::
+Dialog112:: ; idk
     db "Gulp!  You found"
     db "me!  You're a   "
     db "real pesky kid, "
     db "you know that?!@"
 
-Dialog113::
+Dialog113:: ; idk
     db "Arrgh!  I can't "
     db "beat you!  I'm  "
     db "outta here!@"
 
-Dialog114::
+Dialog114:: ; idk
     db "You again?!  You"
     db "keep going and  "
     db "going... I can't"
@@ -84,21 +84,21 @@ Dialog114::
     db "All right, let's"
     db "do it!@"
 
-Dialog115::
+Dialog115:: ; BowWow
     db "WOOF! Dig! RUFF!@"
 
-Dialog116::
+Dialog116:: ; Narrator
     db "You put the     "
     db "missing scale in"
     db "the mermaid     "
     db "statue!@"
 
-Dialog117::
+Dialog117:: ; idk
     db "Hey! Be more    "
     db "careful next    "
     db "time!@"
 
-Dialog118::
+Dialog118:: ; Kid
     db "Hey, man!  When "
     db "you want to save"
     db "just push all   "
@@ -108,7 +108,7 @@ Dialog118::
     db "what that means,"
     db "I'm just a kid!@"
 
-Dialog119::
+Dialog119:: ; Kid
     db "Well, it seems  "
     db "that after you  "
     db "save, you will  "
@@ -120,7 +120,7 @@ Dialog119::
     db "'cause I'm just "
     db "a kid!@"
 
-Dialog11A::
+Dialog11A:: ; Kid
     db "I heard that you"
     db "can press SELECT"
     db "to look at the  "
@@ -130,7 +130,7 @@ Dialog11A::
     db "they mean by    "
     db "that...@"
 
-Dialog11B::
+Dialog11B:: ; Kid
     db "When you're     "
     db "running out of  "
     db "Hearts, you'd   "
@@ -140,14 +140,14 @@ Dialog11B::
     db "idea, I'm just a"
     db "kid!@"
 
-Dialog11C::
+Dialog11C:: ; Kid
     db "Hey, dude! What "
     db "do you think of "
     db "Marin?  Uhh...  "
     db "I don't know,   "
     db "I'm just a kid!@"
 
-Dialog11D::
+Dialog11D:: ; Kid
     db "Where are you   "
     db "from, brother?  "
     db "...Outside the  "
@@ -156,7 +156,7 @@ Dialog11D::
     db "never thought   "
     db "about it...@"
 
-Dialog11E::
+Dialog11E:: ; Kid
     db "The giant egg on"
     db "top of Tamaranch"
     db "Mountain?  They "
@@ -166,7 +166,7 @@ Dialog11E::
     db "Why?  I don't   "
     db "know either...@"
 
-Dialog11F::
+Dialog11F:: ; Kid
     db "Dude!  You're   "
     db "asking me when  "
     db "we started to   "
@@ -178,7 +178,7 @@ Dialog11F::
     db "makes my head   "
     db "hurt!@"
 
-Dialog120::
+Dialog120:: ; Kid
     db "Marin? She likes"
     db "to go stare at  "
     db "the ocean all by"
@@ -187,7 +187,7 @@ Dialog120::
     db "kid, don't ask  "
     db "me!@"
 
-Dialog121::
+Dialog121:: ; Kid
     db "Hey... Where're "
     db "you two going   "
     db "together?  Hunh?"
@@ -195,7 +195,7 @@ Dialog121::
     db "mean anything..."
     db "I'm just a kid!@"
 
-Dialog122::
+Dialog122:: ; Kid
     db "Hey hey, bro!   "
     db "About the Dream "
     db "Shrine there... "
@@ -207,26 +207,26 @@ Dialog122::
     db "as I'm just a   "
     db "kid!@"
 
-Dialog123::
+Dialog123:: ; Kid, probably
     db "Hunh?!  Marin's "
     db "not with you?   "
     db "What happened to"
     db "her?@"
 
-Dialog124::
+Dialog124:: ; Fisherman, probably
     db "WHOA! That's a  "
     db "big one! Hey,   "
     db "photo guy! Can  "
     db "you take a      "
     db "picture of this?@"
 
-Dialog125::
+Dialog125:: ; Fisherman
     db "I have a        "
     db "feelin' that    "
     db "I'll catch a big"
     db "fish again.@"
 
-Dialog126::
+Dialog126:: ; Zora, probably
     db "If you keep me a"
     db "secret, I'll    "
     db "tell you some-  "
@@ -238,11 +238,11 @@ Dialog126::
     db "find someone    "
     db "like me.@"
 
-Dialog127::
+Dialog127:: ; Mamasha
     db "Tsk tsk...  What"
     db "a shame...@"
 
-Dialog128::
+Dialog128:: ; Mamasha, probably
     db "Oh thank you!   "
     db "You are indeed a"
     db "generous person!"
@@ -250,14 +250,14 @@ Dialog128::
     db "you this in     "
     db "return!@"
 
-Dialog129::
+Dialog129:: ; Mamasha, probably
     db "You traded your "
     db "<yoshi> for <ribbon>!  Maybe "
     db "you can trade   "
     db "the ribbon for  "
     db "something else!@"
 
-Dialog12A::
+Dialog12A:: ; Mamasha
     db "Because they all"
     db "look alike, even"
     db "I am sometimes  "
@@ -270,19 +270,19 @@ Dialog12A::
     db "but I couldn't  "
     db "get it.@"
 
-Dialog12B::
+Dialog12B:: ; Mamasha
     db "Oh!  Will you   "
     db "give that doll  "
     db "to my baby?!    "
     db "    Yes  No<ask>"
 
-Dialog12C::
+Dialog12C:: ; Mamasha
     db "Because they all"
     db "look alike, even"
     db "I am sometimes  "
     db "confused...     @"
 
-Dialog12D::
+Dialog12D:: ; Richard
     db "Ahem!  Really, I"
     db "must insist that"
     db "you not bring   "
@@ -293,7 +293,7 @@ Dialog12D::
     db "we can talk!    "
     db "Good Bye!@"
 
-Dialog12E::
+Dialog12E:: ; Photographer, probably
     db "You want to know"
     db "about that      "
     db "ghost? I'll bet "
@@ -302,7 +302,7 @@ Dialog12E::
     db "Are you ready   "
     db "for a picture?@"
 
-Dialog12F::
+Dialog12F:: ; Madam MeowMeow
     db "Ho ho ho!       "
     db "I really appre- "
     db "ciate what you  "
@@ -318,13 +318,13 @@ Dialog12F::
     db "Meow... ... ... "
     db "L-l-lucky!@"
 
-Dialog130::
+Dialog130:: ; Madam MeowMeow
     db "Ho ho ho!  My   "
     db "BowWow is so    "
     db "proud of his    "
     db "fine fur coat!@"
 
-Dialog131::
+Dialog131:: ; Madam MeowMeow
     db "AIEEEEEEEE!     "
     db "It's terrrrible!"
     db "My BowWow was   "
@@ -335,7 +335,7 @@ Dialog131::
     db "help my poor    "
     db "BowWow!!@"
 
-Dialog132::
+Dialog132:: ; Madam MeowMeow
     db "Oh thank you!   "
     db "I'm so happy you"
     db "brought my baby "
@@ -347,7 +347,7 @@ Dialog132::
     db "out a lot!  You "
     db "will?!  Thanks!@"
 
-Dialog133::
+Dialog133:: ; Weird Mr. Write
     db "Well... I pretty"
     db "much stick to   "
     db "myself, me and  "
@@ -359,7 +359,7 @@ Dialog133::
     db "I never receive "
     db "a response...@"
 
-Dialog134::
+Dialog134:: ; Weird Mr. Write
     db "What's this?!  A"
     db "letter for me?! "
     db "I'm so happy!   "
@@ -367,7 +367,7 @@ Dialog134::
     db "letter came with"
     db "a photograph!@"
 
-Dialog135::
+Dialog135:: ; Weird Mr. Write
     db "Mmm... She's so "
     db "beautiful...    "
     db "I must give you "
@@ -380,30 +380,30 @@ Dialog135::
     db "that be?        "
     db "    Fine No...<ask>"
 
-Dialog136::
+Dialog136:: ; Narrator
     db "You got a Broom "
     db "as your reward  "
     db "from Mr. Write! "
     db "But that photo  "
     db "was not of...@"
 
-Dialog137::
+Dialog137:: ; Weird Mr. Write
     db "Please! I really"
     db "must insist you "
     db "have this <broom>!    "
     db "    Okay No Way<ask>"
 
-Dialog138::
+Dialog138:: ; Weird Mr. Write
     db "Oh boy!  Letter "
     db "writing is such "
     db "a great hobby!@"
 
-Dialog139::
+Dialog139:: ; Weird Mr. Write
     db "Hello!  I'm     "
     db "writing back to "
     db "Christine now!@"
 
-Dialog13A::
+Dialog13A:: ; Richard
     db "Salutations!    "
     db "You wouldn't    "
     db "know by the look"
@@ -429,7 +429,7 @@ Dialog13A::
     db "I fled...       "
     db "    Okay No Way<ask>"
 
-Dialog13B::
+Dialog13B:: ; Richard
     db "I am impressed. "
     db "There are five  "
     db "leaves in all.  "
@@ -437,7 +437,7 @@ Dialog13B::
     db "a shovel on your"
     db "way back.@"
 
-Dialog13C::
+Dialog13C:: ; Richard
     db "Well, I never!  "
     db "I thought you   "
     db "looked cowardly,"
@@ -445,7 +445,7 @@ Dialog13C::
     db "leave me... just"
     db "get out here!@"
 
-Dialog13D::
+Dialog13D:: ; Richard
     db "Ahh!  Tres Bien!"
     db "I see you have  "
     db "recovered all of"
@@ -455,13 +455,13 @@ Dialog13D::
     db "find your       "
     db "reward!@"
 
-Dialog13E::
+Dialog13E:: ; Richard
     db "I am forever in "
     db "your debt for   "
     db "getting my      "
     db "leaves back!@"
 
-Dialog13F::
+Dialog13F:: ; Richard
     db "Ah!  Bonjour!   "
     db "#####, for the  "
     db "love of justice,"
@@ -469,7 +469,7 @@ Dialog13F::
     db "you must find   "
     db "all the leaves!@"
 
-Dialog140::
+Dialog140:: ; Ulrira, Narrator
     db "Er...Uh...Hmm..."
     db "How to say...   "
     db "Please call...  "
@@ -479,7 +479,7 @@ Dialog140::
     db "is a shy guy,   "
     db "in person...@"
 
-Dialog141::
+Dialog141:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hello!  It's me,"
     db "Ulrira!  Ask me "
@@ -489,7 +489,7 @@ Dialog141::
     db "give me a call! "
     db "Bye! CLICK!'@"
 
-Dialog142::
+Dialog142:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hello, this is  "
     db "Ulrira! ...Well,"
@@ -503,7 +503,7 @@ Dialog142::
     db "what you wanted "
     db "to know! CLICK!'@"
 
-Dialog143::
+Dialog143:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Yes, this is    "
     db "Ulrira.  The    "
@@ -517,7 +517,7 @@ Dialog143::
     db "him for a walk  "
     db "there?  CLICK!'@"
 
-Dialog144::
+Dialog144:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hi, it's Ulrira!"
     db "...Have you met "
@@ -534,7 +534,7 @@ Dialog144::
     db "you for now!    "
     db "Bye!  CLICK!'@"
 
-Dialog145::
+Dialog145:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Old man Ulrira  "
     db "here! ...Do you "
@@ -544,7 +544,7 @@ Dialog145::
     db "village again!  "
     db "Bye!  CLICK!'@"
 
-Dialog146::
+Dialog146:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira speaking!"
     db "You know, there "
@@ -556,7 +556,7 @@ Dialog146::
     db "to you later!   "
     db "CLICK!'@"
 
-Dialog147::
+Dialog147:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ya, it's Ulrira!"
     db "You say you     "
@@ -569,7 +569,7 @@ Dialog147::
     db "Bye!            "
     db "CLICK!'@"
 
-Dialog148::
+Dialog148:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira here! ..."
     db "Shovel...  Did  "
@@ -580,7 +580,7 @@ Dialog148::
     db "and there!  Bye!"
     db "CLICK!'@"
 
-Dialog149::
+Dialog149:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ya, it's Ulrira!"
     db "The cave in the "
@@ -591,7 +591,7 @@ Dialog149::
     db "intended!  Bye! "
     db "CLICK!'@"
 
-Dialog14A::
+Dialog14A:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hi, this is     "
     db "Ulrira!  In the "
@@ -607,7 +607,7 @@ Dialog14A::
     db "I have to be?   "
     db "Bye! CLICK!'@"
 
-Dialog14B::
+Dialog14B:: ; Ulrira
     db "'BRRING! BRRING!"
     db "This is Ulrira! "
     db "Now you're being"
@@ -618,7 +618,7 @@ Dialog14B::
     db "wants to go?    "
     db "Bye! CLICK!'@"
 
-Dialog14C::
+Dialog14C:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hi, it's Ulrira!"
     db "The Catfish's   "
@@ -628,7 +628,7 @@ Dialog14C::
     db "place to dive!  "
     db "Bye!  CLICK!'@"
 
-Dialog14D::
+Dialog14D:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira here! ..."
     db "Have you been to"
@@ -639,7 +639,7 @@ Dialog14D::
     db "interesting     "
     db "ruin... CLICK!'@"
 
-Dialog14E::
+Dialog14E:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hi, it's Ulrira!"
     db "Have you heard  "
@@ -658,7 +658,7 @@ Dialog14E::
     db "for you?  I hope"
     db "so! Bye! CLICK!'@"
 
-Dialog14F::
+Dialog14F:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hi, it's Ulrira!"
     db "The head of the "
@@ -669,71 +669,71 @@ Dialog14F::
     db "It's true! True!"
     db "Bye!  CLICK!'@"
 
-Dialog150::
+Dialog150:: ; Wind Fish, probably
     db "   ...SWAMP...  "
     db " A path opens..."
     db "in the blooms...@"
 
-Dialog151::
+Dialog151:: ; Wind Fish, probably
     db "  ...PRAIRIE... "
     db "  ...PRAIRIE... "
     db " The Prairie is "
     db "     waiting...@"
 
-Dialog152::
+Dialog152:: ; Wind Fish, probably
     db "...WATERFALL... "
     db "It is hidden in "
     db "the waterfall...@"
 
-Dialog153::
+Dialog153:: ; Wind Fish, probably
     db "    ...BAY...   "
     db "Your road goes  "
     db "into the bay... @"
 
-Dialog154::
+Dialog154:: ; Wind Fish, probably
     db "   ...SHRINE... "
     db "An island secret"
     db "in the shrine...@"
 
-Dialog155::
+Dialog155:: ; Wind Fish, probably
     db " ...MOUNTAIN... "
     db "Something calls "
     db "  ...from the   "
     db "  mountains...@"
 
-Dialog156::
+Dialog156:: ; Wind Fish, probably
     db "  ...OCARINA... "
     db "The music of the"
     db "Ocarina leads...@"
 
-Dialog157::
+Dialog157:: ; Wind Fish, probably
     db "    ...EGG....  "
     db "The Egg on the  "
     db "mountain calls!@"
 
-Dialog158::
-Dialog159::
+Dialog158:: ; Grandma Yahoo
+Dialog159:: ; Grandma Yahoo
     db "Then YOU sweep  "
     db "the island!@"
 
-Dialog15A::
+Dialog15A:: ; Grandma Yahoo
     db "YAHOO!   I'm    "
     db "fine, and you?!@"
 
-Dialog15B::
+Dialog15B:: ; Grandma Yahoo
     db "YAHOO!  I worked"
     db "too hard and now"
     db "my broom is worn"
     db "to the handle!@"
 
-Dialog15C::
+Dialog15C:: ; Grandma Yahoo
     db "YAHOO!  YAHOO!  "
     db "A new broom?!   "
     db "For me?  It is, "
     db "isn't it?!      "
     db "    Yes  No<ask>"
 
-Dialog15D::
+Dialog15D:: ; Grandma Yahoo
     db "Okay!  In return"
     db "you can have    "
     db "this fishing    "
@@ -741,52 +741,52 @@ Dialog15D::
     db "when I swept by "
     db "the river bank!@"
 
-Dialog15E::
+Dialog15E:: ; Narrator
     db "You exchanged <broom> "
     db "for the fishing "
     db "hook <fishhook>!  What   "
     db "will the fishing"
     db "hook become?@"
 
-Dialog15F::
+Dialog15F:: ; Grandma Yahoo
     db "YAHOO!  A new   "
     db "broom!  Superb!@"
 
-Dialog160::
+Dialog160:: ; Kiki
     db "Kiiiki!  What?! "
     db "All right, mutt!"
     db "Let's battle!!@"
 
-Dialog161::
+Dialog161:: ; Kiki
     db "Chi-kiita! Chi- "
     db "kiita!  Kiki the"
     db "monkey!  Hungry!"
     db "Kiki the monkey!@"
 
-Dialog162::
+Dialog162:: ; Kiki
     db "    <bananas>!    <bananas>!    "
     db "Oooh! Ooh! Kiki!"
     db "Monkeys!  Come! "
     db "Repay him! Kiki!@"
 
-Dialog163::
+Dialog163:: ; Kiki
     db "Monkey business!"
     db "Done!  Bye bye! "
     db "Oooh!  Kiki!@"
 
-Dialog164::
+Dialog164:: ; Narrator
     db "You found a     "
     db "stick a monkey  "
     db "left behind...  "
     db "You take it!@"
 
-Dialog165::
+Dialog165:: ; Kiki, Narrator, Link
     db "    <bananas>!    <bananas>!    "
     db "  Oooh!  Oooh!  "
     db " Give to Kiki!? "
     db "    Yes  No!<ask>"
 
-Dialog166::
+Dialog166:: ; Christine
     db "You don't know  "
     db "the proper      "
     db "etiquette when  "
@@ -802,7 +802,7 @@ Dialog166::
     db "case, hibiscus  "
     db "are best...@"
 
-Dialog167::
+Dialog167:: ; Christine
     db "Oh, you brought "
     db "me a hibiscus!  "
     db "How sweet! Well,"
@@ -813,7 +813,7 @@ Dialog167::
     db "Will you listen?"
     db "    Yes  No<ask>"
 
-Dialog168::
+Dialog168:: ; Christine
     db "I would like you"
     db "to take this    "
     db "letter to a Mr. "
@@ -822,18 +822,18 @@ Dialog168::
     db "the Mysterious  "
     db "Forest, please!@"
 
-Dialog169::
+Dialog169:: ; Christine
     db "...Is that so?  "
     db "And I thought   "
     db "you were a      "
     db "gentleman...@"
 
-Dialog16A::
+Dialog16A:: ; Narrator
     db "You traded <flower2> for"
     db "a goat's letter "
     db "<letter>!  ...Great!?@"
 
-Dialog16B::
+Dialog16B:: ; Christine
     db "You know, some- "
     db "times I can't   "
     db "help eating a   "
@@ -844,18 +844,18 @@ Dialog16B::
     db "Mr. Write... How"
     db "embarrassing!@"
 
-Dialog16C::
+Dialog16C:: ; Narrator
     db "You've saved    "
     db "BowWow!  What a "
     db "fearsome beast!@"
 
-Dialog16D::
+Dialog16D:: ; Narrator
     db "Wow! The Rooster"
     db "has recovered!  "
     db "He seems very   "
     db "friendly!@"
 
-Dialog16E::
+Dialog16E:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ya, it's Ulrira!"
     db "My wife went to "
@@ -870,7 +870,7 @@ Dialog16E::
     db "Bye!            "
     db "CLICK!'@"
 
-Dialog16F::
+Dialog16F:: ; Kid, probably
     db "Grandma's not   "
     db "here. She's in  "
     db "the Animal      "
@@ -879,7 +879,7 @@ Dialog16F::
     db "Ulrira said on  "
     db "the phone!@"
 
-Dialog170::
+Dialog170:: ; Papahl
     db "Yep, Papahl got "
     db "lost, just like "
     db "he said!  Now, I"
@@ -889,38 +889,38 @@ Dialog170::
     db "vittles?        "
     db "    Yes  Nope<ask>"
 
-Dialog171::
+Dialog171:: ; Papahl
     db "You're one cold "
     db "hombre...@"
 
-Dialog172::
+Dialog172:: ; Papahl
     db "This <pineapple> is so    "
     db "delicious!  I'm "
     db "going to eat the"
     db "<pineapple> right now!    "
     db " Bon Appetit!@"
 
-Dialog173::
+Dialog173:: ; Papahl
     db "AH!  This isn't "
     db "meant to be a   "
     db "reward...  Here,"
     db "take this <flower2>!    "
     db "It's a hibiscus!@"
 
-Dialog174::
+Dialog174:: ; Narrator
     db "You traded the <pineapple>"
     db "for the <flower2>!@"
 
-Dialog175::
+Dialog175:: ; Papahl
     db "Delicious!  Yum!"
     db "I'm filled with "
     db "energy, now!@"
 
-Dialog176::
+Dialog176:: ; Papahl, probably
     db "I've got to say,"
     db "thanks again!@"
 
-Dialog177::
+Dialog177:: ; Papahl
     db "Yep, Papahl got "
     db "lost, just like "
     db "he said!  Now, I"
@@ -930,7 +930,7 @@ Dialog177::
     db "vittles?        "
     db "    Nope Can't<ask>"
 
-Dialog178::
+Dialog178:: ; Grandma Yahoo
     db "She's had an    "
     db "awful tragedy   "
     db "in the house    "
@@ -939,7 +939,7 @@ Dialog178::
     db "and all I can do"
     db "is sweep!@"
 
-Dialog179::
+Dialog179:: ; Spirit of the Mansion
     db "I am the spirit "
     db "of the mansion. "
     db "I have been     "
@@ -954,17 +954,17 @@ Dialog179::
     db "the ultimate    "
     db "sword!@"
 
-Dialog17A::
+Dialog17A:: ; Spirit of the Mansion
     db "Hmmm. No        "
     db "response. You   "
     db "must not have   "
     db "enough shells.@"
 
-Dialog17B::
+Dialog17B:: ; Spirit of the Mansion
     db "My job here     "
     db "is finished.@"
 
-Dialog17C::
+Dialog17C:: ; idk, might be unused?
     db "Hey you! Have   "
     db "you been to the "
     db "Camera Shop in  "
@@ -977,12 +977,12 @@ Dialog17C::
     db " Seems kinda    "
     db " funny to me.@"
 
-Dialog17D::
+Dialog17D:: ; Map, probably
     db "Step right up   "
     db "and get your    "
     db "souvenir photo!@"
 
-Dialog17E::
+Dialog17E:: ; Witch
     db "Good job!       "
     db "Use it on your  "
     db "enemies and see "
@@ -994,7 +994,7 @@ Dialog17E::
     db "I will make you "
     db "more.@"
 
-Dialog17F::
+Dialog17F:: ; Genie (D2 Nightmare)
     db ". . . .! I can't"
     db "move! But I am  "
     db "still all right."
@@ -1003,7 +1003,7 @@ Dialog17F::
     db "break this      "
     db "bottle!@"
 
-Dialog180::
+Dialog180:: ; CiaoCiao
     db "Make-up! Jewels!"
     db "Dresses!  I want"
     db "it all!  Sigh..."
@@ -1011,7 +1011,7 @@ Dialog180::
     db "accessories     "
     db "would be nice...@"
 
-Dialog181::
+Dialog181:: ; CiaoCiao, Link
     db "Make-up! Jewels!"
     db "Dresses!  I want"
     db "it all!  Sigh..."
@@ -1024,45 +1024,45 @@ Dialog181::
     db "dog food?       "
     db "    Yes  No!<ask>"
 
-Dialog182::
+Dialog182:: ; Narrator
     db "You exchanged <ribbon> "
     db "for <dogfood>! It's full"
     db "of juicy beef!@"
 
-Dialog183::
+Dialog183:: ; CiaoCiao
     db "Lucky!  Thanks! "
     db "Well, here's    "
     db "your <dogfood>!@"
 
-Dialog184::
+Dialog184:: ; CiaoCiao
     db "Eh?!  I can't   "
     db "believe it!  You"
     db "are the worst!!@"
 
-Dialog185::
+Dialog185:: ; Manbo
     db "I am Manbo,     "
     db "child of the Sun"
     db "Fish!  Have you "
     db "got an Ocarina? "
     db "    Yes  No<ask>"
 
-Dialog186::
+Dialog186:: ; Manbo
     db "Very well...    "
     db "Glub Blub Bloop!@"
 
-Dialog187::
+Dialog187:: ; Manbo
     db "Ahaha!  Then I  "
     db "can teach you my"
     db "song! Bloop!@"
 
-Dialog188::
+Dialog188:: ; Narrator
     db "You've learned  "
     db "Manbo's Mambo!  "
     db "When you get out"
     db "of the water,   "
     db "play it!@"
 
-Dialog189::
+Dialog189:: ; Manbo
     db "I am Manbo,     "
     db "child of the Sun"
     db "Fish!  When you "
@@ -1073,12 +1073,12 @@ Dialog189::
     db "dungeons, too!  "
     db "Cha-cha-cha!@"
 
-Dialog18A::
+Dialog18A:: ; Manbo
     db "Aha... You don't"
     db "have an Ocarina,"
     db "so...Glub glub!@"
 
-Dialog18B::
+Dialog18B:: ; idk
     db "Chickens these  "
     db "days don't have "
     db "the fighting    "
@@ -1089,7 +1089,7 @@ Dialog18B::
     db "But now, see?   "
     db "Cluck cluck!@"
 
-Dialog18C::
+Dialog18C:: ; idk
     db "Wow!  Amazing!  "
     db "That rooster is "
     db "actually flying!"
@@ -1100,17 +1100,17 @@ Dialog18C::
     db "your head? Cluck"
     db "Cluck!@"
 
-Dialog18D::
+Dialog18D:: ; idk
     db "Wooo!  Finally! "
     db "This flying     "
     db "rooster is the  "
     db "greatest!@"
 
-Dialog18E::
+Dialog18E:: ; Weathervane
     db " Here Sleeps The"
     db " Flying Rooster@"
 
-Dialog18F::
+Dialog18F:: ; Schule Donavitch
     db "Iz zat zee      "
     db "Mermaid scale?  "
     db "I can't use it  "

--- a/src/text/dialog_3.asm
+++ b/src/text/dialog_3.asm
@@ -65,18 +65,18 @@ Dialog111:: ; Master Stalfos (D5 Mini-Boss)
     db "get it, if you  "
     db "can!'  Master <skull>@"
 
-Dialog112:: ; idk
+Dialog112:: ; Master Stalfos (D5 Mini-Boss)
     db "Gulp!  You found"
     db "me!  You're a   "
     db "real pesky kid, "
     db "you know that?!@"
 
-Dialog113:: ; idk
+Dialog113:: ; Master Stalfos (D5 Mini-Boss)
     db "Arrgh!  I can't "
     db "beat you!  I'm  "
     db "outta here!@"
 
-Dialog114:: ; idk
+Dialog114:: ; Master Stalfos (D5 Mini-Boss)
     db "You again?!  You"
     db "keep going and  "
     db "going... I can't"
@@ -213,7 +213,7 @@ Dialog123:: ; Kid, probably
     db "What happened to"
     db "her?@"
 
-Dialog124:: ; Fisherman, probably
+Dialog124:: ; Fisherman
     db "WHOA! That's a  "
     db "big one! Hey,   "
     db "photo guy! Can  "
@@ -226,7 +226,7 @@ Dialog125:: ; Fisherman
     db "I'll catch a big"
     db "fish again.@"
 
-Dialog126:: ; Zora, probably
+Dialog126:: ; Zora
     db "If you keep me a"
     db "secret, I'll    "
     db "tell you some-  "
@@ -250,7 +250,7 @@ Dialog128:: ; Mamasha, probably
     db "you this in     "
     db "return!@"
 
-Dialog129:: ; Mamasha, probably
+Dialog129:: ; Narrator
     db "You traded your "
     db "<yoshi> for <ribbon>!  Maybe "
     db "you can trade   "
@@ -293,7 +293,7 @@ Dialog12D:: ; Richard
     db "we can talk!    "
     db "Good Bye!@"
 
-Dialog12E:: ; Photographer, probably
+Dialog12E:: ; Photographer
     db "You want to know"
     db "about that      "
     db "ghost? I'll bet "
@@ -954,7 +954,7 @@ Dialog179:: ; Spirit of the Mansion
     db "the ultimate    "
     db "sword!@"
 
-Dialog17A:: ; Spirit of the Mansion
+Dialog17A:: ; Narrator
     db "Hmmm. No        "
     db "response. You   "
     db "must not have   "
@@ -1078,7 +1078,7 @@ Dialog18A:: ; Manbo
     db "have an Ocarina,"
     db "so...Glub glub!@"
 
-Dialog18B:: ; idk
+Dialog18B:: ; Henhouse Keeper
     db "Chickens these  "
     db "days don't have "
     db "the fighting    "
@@ -1089,7 +1089,7 @@ Dialog18B:: ; idk
     db "But now, see?   "
     db "Cluck cluck!@"
 
-Dialog18C:: ; idk
+Dialog18C:: ; Henhouse Keeper
     db "Wow!  Amazing!  "
     db "That rooster is "
     db "actually flying!"
@@ -1100,7 +1100,7 @@ Dialog18C:: ; idk
     db "your head? Cluck"
     db "Cluck!@"
 
-Dialog18D:: ; idk
+Dialog18D:: ; Henhouse Keeper
     db "Wooo!  Finally! "
     db "This flying     "
     db "rooster is the  "

--- a/src/text/dialog_4.asm
+++ b/src/text/dialog_4.asm
@@ -28,12 +28,12 @@ Dialog192:: ; Marin
     db "what is your    "
     db "favorite song?@"
 
-Dialog193:: ; Marin, probably
+Dialog193:: ; Marin
     db "Please, don't   "
     db "ever forget this"
     db "song...or me...@"
 
-Dialog194:: ; Marin, probably
+Dialog194:: ; Marin
     db "Thank you for   "
     db "everything!     "
     db "#####, you are  "
@@ -57,13 +57,13 @@ Dialog195:: ; Marin
     db "never forgive   "
     db "you!@"
 
-Dialog196:: ; Fox
+Dialog196:: ; Mutt, narrator
     db "... ... ... ... "
     db "It seems to be  "
     db "totally absorbed"
     db "in Marin's song!@"
 
-Dialog197:: ; Marin, probably
+Dialog197:: ; Marin
     db "They say the    "
     db "'Ballad of the  "
     db "Wind Fish' is a "
@@ -74,7 +74,7 @@ Dialog197:: ; Marin, probably
     db "he make my wish "
     db "come true?@"
 
-Dialog198:: ; Marin, probably
+Dialog198:: ; Marin
     db "Eh?  You want me"
     db "to go in there? "
     db "No, I think I'll"
@@ -82,12 +82,12 @@ Dialog198:: ; Marin, probably
     db "Take care of    "
     db "yourself, #####!@"
 
-Dialog199:: ; Marin, probably
+Dialog199:: ; Marin
     db "Ahhh!  Ahhh, you"
     db "are a bad boy,  "
     db "#####!@"
 
-Dialog19A:: ; idk, maybe Crazy Tracy?
+Dialog19A:: ; Crazy Tracy
     db "Here's some     "
     db "bonus treatment!"
     db "Behold!  Your   "
@@ -293,8 +293,8 @@ Dialog1C3:: ; Signpost
     db "touch them with "
     db "your bare hands!@"
 
-Dialog1C4:: ; idk
-Dialog1C5:: ; idk
+Dialog1C4:: ; Tarin
+Dialog1C5:: ; Tarin
     db "I was hungry    "
     db "somethin' fierce"
     db "so I went and   "
@@ -435,7 +435,7 @@ Dialog1D4:: ; Chef Bear
     db "are here too... "
     db "Sorry...@"
 
-Dialog1D5:: ; Marin, probably
+Dialog1D5:: ; Marin
     db "Oh, #####, I'm  "
     db "glad you found  "
     db "this place.     "
@@ -444,7 +444,7 @@ Dialog1D5:: ; Marin, probably
     db "for a while?    "
     db "    Yes! No...<ask>"
 
-Dialog1D6:: ; Marin, probably
+Dialog1D6:: ; Marin
     db "Okay, I'll just "
     db "watch the waves "
     db "for a while...@"
@@ -501,7 +501,7 @@ Dialog1DB:: ; Marin
     db "you...Err...Uhh,"
     db "Ha ha ha ha!@"
 
-Dialog1DC:: ; Marin, probably
+Dialog1DC:: ; Marin
     db "Hunh? The walrus"
     db "wants me to go  "
     db "to him?  It     "
@@ -509,14 +509,14 @@ Dialog1DC:: ; Marin, probably
     db "I will go with  "
     db "you to him...@"
 
-Dialog1DD:: ; idk
+Dialog1DD:: ; Tarin
     db "Unnnngh! Owwwww!"
     db "... ... ... ... "
     db "I've sure lost  "
     db "my taste for    "
     db "honey!@"
 
-Dialog1DE:: ; Marin, probably
+Dialog1DE:: ; Marin
     db "Humph! Your head"
     db "is always in the"
     db "clouds! Will you"
@@ -529,11 +529,11 @@ Dialog1DF:: ; idk
     db "Get ready for   "
     db "THIS!@"
 
-Dialog1E0:: ; idk
+Dialog1E0:: ; Walrus
     db "ZZZ ZZZ ZZZ ZZZ "
     db " ... <marin> ... <marin> ...@"
 
-Dialog1E1:: ; Marin, probably, and Link
+Dialog1E1:: ; Marin, Link
     db "Yes, it's that  "
     db "lazy walrus!    "
     db "Shall we give   "
@@ -541,19 +541,19 @@ Dialog1E1:: ; Marin, probably, and Link
     db "surprise?       "
     db "    Yes  No...<ask>"
 
-Dialog1E2:: ; Marin, probably
+Dialog1E2:: ; Marin
     db "Aha ha ha!  Wow!"
     db "He certainly    "
     db "woke with a     "
     db "start!@"
 
-Dialog1E3:: ; idk
+Dialog1E3:: ; Marin
     db "Hunh?  Oh, he's "
     db "calling me...   "
     db "It's the same as"
     db "always... Ha ha!@"
 
-Dialog1E4:: ; idk
+Dialog1E4:: ; Marin
     db "You're right, it"
     db "would be mean to"
     db "wake him up now!"
@@ -596,18 +596,18 @@ Dialog1E8:: ; Fisherman
     db "me have it...   "
     db "    Okay No<ask>"
 
-Dialog1E9:: ; Fisherman, probably
+Dialog1E9:: ; Fisherman
     db "Keep your eyes  "
     db "open and watch  "
     db "a pro at work.@"
 
-Dialog1EA:: ; Fisherman, probably
+Dialog1EA:: ; Fisherman
     db "You should be   "
     db "more kind to me!"
     db "I thought we    "
     db "were buddies!@"
 
-Dialog1EB:: ; Fisherman, probably
+Dialog1EB:: ; Fisherman
     db "My, that's a    "
     db "BIIIIG one!@"
 
@@ -616,18 +616,18 @@ Dialog1EC:: ; Narrator
     db "necklace <bra>!     "
     db "L-l-lucky!@"
 
-Dialog1ED:: ; Fisherman, probably
+Dialog1ED:: ; Fisherman
     db "I can't wait to "
     db "see what I'll   "
     db "catch next!@"
 
-Dialog1EE:: ; Mamasha, probably
+Dialog1EE:: ; Mamasha
     db "My husband is   "
     db "lost in the     "
     db "woods! Please   "
     db "go find him!@"
 
-Dialog1EF:: ; Secret Zora or Secret Goriya, not sure
+Dialog1EF:: ; Secret Zora
     db "Hey, you can see"
     db "me?! You must   "
     db "have a magnify- "
@@ -667,7 +667,7 @@ Dialog1F3:: ; Mermaid
     db "Promise!  You'll"
     db "only take one!@"
 
-Dialog1F4:: ; Mermaid, probably
+Dialog1F4:: ; Mermaid
     db "You are heart-  "
     db "less and cruel!@"
 
@@ -994,23 +994,23 @@ Dialog21A:: ; Book, Narrator
     db "this book reeks "
     db "of secrets...@"
 
-Dialog21B:: ; Marin, probably
+Dialog21B:: ; Marin
     db "...You're late! "
     db "I thought you'd "
     db "never come back!@"
 
-Dialog21C:: ; Marin, probably
+Dialog21C:: ; Marin
     db "...EEEK!  You're"
     db "hurt!  Arrrgh!  "
     db "Don't be so     "
     db "reckless!@"
 
-Dialog21D:: ; Marin, probably
+Dialog21D:: ; Marin
     db "#####! You're   "
     db "back!  Are you  "
     db "hurt?@"
 
-Dialog21E:: ; Marin, probably
+Dialog21E:: ; Marin
     db "...You idiot!   "
     db "I told you this "
     db "would happen... "

--- a/src/text/dialog_4.asm
+++ b/src/text/dialog_4.asm
@@ -1,11 +1,11 @@
-Dialog190::
+Dialog190:: ; Moblin
     db "Ennh?  Who's    "
     db "this suspicious-"
     db "looking runt?!  "
     db "Okay boys, let's"
     db "get ridda him!@"
 
-Dialog191::
+Dialog191:: ; Moblin Chief
     db "You must be an  "
     db "assassin sent by"
     db "Madam MeowMeow  "
@@ -15,7 +15,7 @@ Dialog191::
     db "but it is I who "
     db "will get you!!@"
 
-Dialog192::
+Dialog192:: ; Marin
     db "Oh, #####.  I   "
     db "often come to   "
     db "this village to "
@@ -28,12 +28,12 @@ Dialog192::
     db "what is your    "
     db "favorite song?@"
 
-Dialog193::
+Dialog193:: ; Marin, probably
     db "Please, don't   "
     db "ever forget this"
     db "song...or me...@"
 
-Dialog194::
+Dialog194:: ; Marin, probably
     db "Thank you for   "
     db "everything!     "
     db "#####, you are  "
@@ -45,7 +45,7 @@ Dialog194::
     db "wish?  It was..."
     db "No, it's secret!@"
 
-Dialog195::
+Dialog195:: ; Marin
     db "#####, some day "
     db "you will leave  "
     db "this island...  "
@@ -57,13 +57,13 @@ Dialog195::
     db "never forgive   "
     db "you!@"
 
-Dialog196::
+Dialog196:: ; Fox
     db "... ... ... ... "
     db "It seems to be  "
     db "totally absorbed"
     db "in Marin's song!@"
 
-Dialog197::
+Dialog197:: ; Marin, probably
     db "They say the    "
     db "'Ballad of the  "
     db "Wind Fish' is a "
@@ -74,7 +74,7 @@ Dialog197::
     db "he make my wish "
     db "come true?@"
 
-Dialog198::
+Dialog198:: ; Marin, probably
     db "Eh?  You want me"
     db "to go in there? "
     db "No, I think I'll"
@@ -82,18 +82,18 @@ Dialog198::
     db "Take care of    "
     db "yourself, #####!@"
 
-Dialog199::
+Dialog199:: ; Marin, probably
     db "Ahhh!  Ahhh, you"
     db "are a bad boy,  "
     db "#####!@"
 
-Dialog19A::
+Dialog19A:: ; idk, maybe Crazy Tracy?
     db "Here's some     "
     db "bonus treatment!"
     db "Behold!  Your   "
     db "Hearts are full!@"
 
-Dialog19B::
+Dialog19B:: ; Schule Donavitch
     db "Ya, I am Schule "
     db "Donavitch!  Zee "
     db "mermaid statue  "
@@ -107,28 +107,28 @@ Dialog19B::
     db "you to grasp, iz"
     db "it not?@"
 
-Dialog19C::
+Dialog19C:: ; Mermaid Statue, Narrator
     db "  THE MOURNING  "
     db "     MERMAID    "
     db "    By SCHULE   "
     db "? ...A scale is "
     db "missing...@"
 
-Dialog19D::
+Dialog19D:: ; Signpost and maybe ; Map
     db "Seashell Mansion@"
 
-Dialog19E::
+Dialog19E:: ; Signpost, probably
     db "Entrance to     "
     db "  Yarna Desert <right>@"
 
-Dialog19F::
-Dialog1A0::
+Dialog19F:: ; Signpost
+Dialog1A0:: ; Signpost
     db "   Mysterious   "
     db "     Forest     "
     db " (It's a little "
     db " bit mysterious)@"
 
-Dialog1A1::
+Dialog1A1:: ; Signpost, probably
     db "Do you want to  "
     db "challenge the   "
     db "river rapids on "
@@ -136,139 +136,139 @@ Dialog1A1::
     db "to the office at"
     db "once, please!@"
 
-Dialog1A2::
+Dialog1A2:: ; Signpost
     db "East <right> Ukuku    "
     db "       Prairie  "
     db "Farther East    "
     db "  Animal Village@"
 
-Dialog1A3::
+Dialog1A3:: ; Signpost and maybe ; Map
     db "Mt. Tamaranch   @"
 
-Dialog1A4::
+Dialog1A4:: ; Signpost
     db "<right> Tail Cave     "
     db "<down> Toronbo Shores@"
 
-Dialog1A5::
+Dialog1A5:: ; Signpost
     db "<right> Gopongo Swamp "
     db "<down> Mysterious    "
     db "  Forest@"
 
-Dialog1A6::
+Dialog1A6:: ; Signpost
     db "Beware of floors"
     db "with cracks!  A "
     db "heavy person    "
     db "should not stand"
     db "on them!@"
 
-Dialog1A7::
+Dialog1A7:: ; Signpost and maybe ; Map
     db "Telephone Booth @"
 
-Dialog1A8::
+Dialog1A8:: ; Signpost
     db "     DANGER!    "
     db "    Keep out!   "
     db "(Except BowWow)@"
 
-Dialog1A9::
+Dialog1A9:: ; Signpost
     db "<down> GO THIS WAY@"
 
-Dialog1AA::
+Dialog1AA:: ; Signpost
     db "<up> GO THIS WAY@"
 
-Dialog1AB::
+Dialog1AB:: ; Signpost
     db "<right> GO THIS WAY@"
 
-Dialog1AC::
+Dialog1AC:: ; Signpost
     db "<left> GO THIS WAY@"
 
-Dialog1AD::
+Dialog1AD:: ; Signpost
     db " TRY AGAIN FROM "
     db "   THE START@"
 
-Dialog1AE::
+Dialog1AE:: ; Signpost
     db "GREAT!  YOU DID "
     db "IT!  YOUR REWARD"
     db "IS <right> THIS WAY!@"
 
-Dialog1AF::
+Dialog1AF:: ; Signpost
     db "GONE ON TOUR    "
     db "         MAMU@"
 
-Dialog1B0::
+Dialog1B0:: ; Signpost
     db "<right> Crazy Tracy   "
     db "<down> Manbo's Pond@"
 
-Dialog1B1::
+Dialog1B1:: ; Signpost
     db "<right> Animal Village"
     db "<down> Martha's Bay@"
 
-Dialog1B2::
+Dialog1B2:: ; Signpost
     db "<right> Welcome to the"
     db " Animal Village!@"
 
-Dialog1B3::
+Dialog1B3:: ; Signpost
     db "<right> Cemetery      "
     db "<down> Ukuku Prairie @"
 
-Dialog1B4::
+Dialog1B4:: ; Signpost
     db "You're close to "
     db "Tal Tal Heights."
     db "The Camera Shop "
     db "is nearby.@"
 
-Dialog1B5::
+Dialog1B5:: ; Signpost
     db "<right> Tamaranch Mt. "
     db "<left> Goponga Swamp @"
 
-Dialog1B6::
+Dialog1B6:: ; Owl Statue
     db "MUSIC, THE FISH "
     db "STIRS IN THE EGG"
     db "YOU ARE THERE...@"
 
-Dialog1B7::
+Dialog1B7:: ; Owl Statue
     db "THE WIND FISH IN"
     db "NAME ONLY, FOR  "
     db "IT IS NEITHER.@"
 
-Dialog1B8::
+Dialog1B8:: ; Owl Statue
     db "IN SOIL SLEEPS  "
     db "SECRETS, BENEATH"
     db "YOUR SOLES...@"
 
-Dialog1B9::
+Dialog1B9:: ; Owl Statue
     db "IN SOIL SLEEPS  "
     db "SECRETS, BENEATH"
     db "YOUR SOLES...@"
 
-Dialog1BA::
+Dialog1BA:: ; Owl Statue
     db "AROUND HERE,    "
     db "SECRETS ARE NIGH@"
 
-Dialog1BB::
+Dialog1BB:: ; Owl Statue
     db "SECRETS ARE LIKE"
     db "WATER WHEN IT   "
     db "COMES TO BRIDGES@"
 
-Dialog1BC::
+Dialog1BC:: ; Owl Statue
     db "NOW YOU NEED    "
     db "LOOK FAR FOR    "
     db "A SECRET...@"
 
-Dialog1BD::
+Dialog1BD:: ; Owl Statue
     db "THE WIND FISH   "
     db "SLUMBERS LONG..."
     db "THE HERO'S LIFE "
     db "GONE...@"
 
-Dialog1BE::
+Dialog1BE:: ; Owl Statue
     db "SEA BEARS FOAM, "
     db "SLEEP BEARS     "
     db "DREAMS. BOTH END"
     db "IN THE SAME WAY "
     db "CRASSSH!@"
 
-Dialog1BF::
-Dialog1C0::
+Dialog1BF:: ; Tarin
+Dialog1C0:: ; Tarin
     db "Oh?!  #####, I  "
     db "see ya have a   "
     db "nice stick...   "
@@ -276,25 +276,25 @@ Dialog1C0::
     db "for a second?   "
     db "    Can  Can't<ask>"
 
-Dialog1C1::
+Dialog1C1:: ; Narrator
     db "<stick> became the    "
     db "honeycomb <honeycomb>!    "
     db "You're not sure "
     db "how it happened,"
     db "but take it!@"
 
-Dialog1C2::
+Dialog1C2:: ; Marin, probably
     db "Hmmm, #####, you"
     db "are mean!@"
 
-Dialog1C3::
+Dialog1C3:: ; Signpost
     db "Beware of Sea   "
     db "Urchins!  Don't "
     db "touch them with "
     db "your bare hands!@"
 
-Dialog1C4::
-Dialog1C5::
+Dialog1C4:: ; idk
+Dialog1C5:: ; idk
     db "I was hungry    "
     db "somethin' fierce"
     db "so I went and   "
@@ -305,7 +305,7 @@ Dialog1C5::
     db "should go and   "
     db "get some!@"
 
-Dialog1C6::
+Dialog1C6:: ; Sale
     db "Welcome to      "
     db "Sale's House O' "
     db "Bananas!  I'm   "
@@ -320,7 +320,7 @@ Dialog1C6::
     db "hobbies run in  "
     db "the family!@"
 
-Dialog1C7::
+Dialog1C7:: ; Sale
     db "What's that you "
     db "have?!  It's    "
     db "canned food! For"
@@ -331,11 +331,11 @@ Dialog1C7::
     db "What do you do? "
     db "    Give Don't<ask>"
 
-Dialog1C8::
+Dialog1C8:: ; Sale
     db "Oh thank you!   "
     db "I'll take that!@"
 
-Dialog1C9::
+Dialog1C9:: ; Sale
     db "I don't suppose "
     db "it would do any "
     db "good to beg?    "
@@ -343,7 +343,7 @@ Dialog1C9::
     db "change your     "
     db "mind, tell me.@"
 
-Dialog1CA::
+Dialog1CA:: ; Sale
     db "  MUNCH MUNCH!! "
     db "... ... ... ... "
     db "That was great! "
@@ -352,17 +352,17 @@ Dialog1CA::
     db "but here's some "
     db "bananas! YUM...@"
 
-Dialog1CB::
+Dialog1CB:: ; Narrator
     db "You gave him <dogfood>  "
     db "and got bananas "
     db "<bananas> in return!    "
     db "Good deal!@"
 
-Dialog1CC::
+Dialog1CC:: ; Sale
     db "Thank you again!"
     db "That was yummy!@"
 
-Dialog1CD::
+Dialog1CD:: ; Sale
     db "Hey friend! Have"
     db "you ever ridden "
     db "the rapids on a "
@@ -371,7 +371,7 @@ Dialog1CD::
     db "Heights!  You   "
     db "ought to try it!@"
 
-Dialog1CE::
+Dialog1CE:: ; Chef Bear
     db "Rik'm rak'm! I  "
     db "ran out of      "
     db "ingredients!  If"
@@ -379,7 +379,7 @@ Dialog1CE::
     db "could make this "
     db "fit for a king!@"
 
-Dialog1CF::
+Dialog1CF:: ; Chef Bear
     db "Hi ho! Hey you! "
     db "Is that possibly"
     db "a <honeycomb> you have?   "
@@ -388,20 +388,20 @@ Dialog1CF::
     db "for a pineapple?"
     db "    Yes  No<ask>"
 
-Dialog1D0::
+Dialog1D0:: ; Narrator
     db "You exchanged <honeycomb> "
     db "for <pineapple>!  It's not"
     db "as sweet, but it"
     db "is delicious!   @"
 
-Dialog1D1::
+Dialog1D1:: ; Chef Bear, probably
     db "That's a crying "
     db "shame, but I    "
     db "realize those   "
     db "are a rare      "
     db "delicacy!@"
 
-Dialog1D2::
+Dialog1D2:: ; Chef Bear
     db "Hi ho! Yeah, I  "
     db "know, that tub  "
     db "of goo is asleep"
@@ -421,13 +421,13 @@ Dialog1D2::
     db "sing, for sure! "
     db "Heh heh heh!@"
 
-Dialog1D3::
+Dialog1D3:: ; Chef Bear
     db "My ultimate plan"
     db "is to open a    "
     db "branch in Mabe  "
     db "Village!@"
 
-Dialog1D4::
+Dialog1D4:: ; Chef Bear
     db "HI HO!  Little  "
     db "Marin!  Welcome!"
     db "... ... ... ... "
@@ -435,7 +435,7 @@ Dialog1D4::
     db "are here too... "
     db "Sorry...@"
 
-Dialog1D5::
+Dialog1D5:: ; Marin, probably
     db "Oh, #####, I'm  "
     db "glad you found  "
     db "this place.     "
@@ -444,16 +444,16 @@ Dialog1D5::
     db "for a while?    "
     db "    Yes! No...<ask>"
 
-Dialog1D6::
+Dialog1D6:: ; Marin, probably
     db "Okay, I'll just "
     db "watch the waves "
     db "for a while...@"
 
-Dialog1D7::
+Dialog1D7:: ; Marin
     db "At the beach... "
     db " Marin  <marin>@"
 
-Dialog1D8::
+Dialog1D8:: ; Marin
     db "I wonder where  "
     db "these coconut   "
     db "trees come from?"
@@ -472,7 +472,7 @@ Dialog1D8::
     db "to give us a    "
     db "message...@"
 
-Dialog1D9::
+Dialog1D9:: ; Marin
     db "... ... ... ... "
     db "... ... ... ... "
     db "If I was a sea  "
@@ -488,20 +488,20 @@ Dialog1D9::
     db "dream will come "
     db "true... ... ...@"
 
-Dialog1DA::
+Dialog1DA:: ; Marin, Link
     db "Hey!  Are you   "
     db "listening?      "
     db "#####, are you  "
     db "listening to me?"
     db "    Yeah No...<ask>"
 
-Dialog1DB::
+Dialog1DB:: ; Marin
     db "I want to know  "
     db "everything about"
     db "you...Err...Uhh,"
     db "Ha ha ha ha!@"
 
-Dialog1DC::
+Dialog1DC:: ; Marin, probably
     db "Hunh? The walrus"
     db "wants me to go  "
     db "to him?  It     "
@@ -509,31 +509,31 @@ Dialog1DC::
     db "I will go with  "
     db "you to him...@"
 
-Dialog1DD::
+Dialog1DD:: ; idk
     db "Unnnngh! Owwwww!"
     db "... ... ... ... "
     db "I've sure lost  "
     db "my taste for    "
     db "honey!@"
 
-Dialog1DE::
+Dialog1DE:: ; Marin, probably
     db "Humph! Your head"
     db "is always in the"
     db "clouds! Will you"
     db "please listen to"
     db "me next time?!@"
 
-Dialog1DF::
+Dialog1DF:: ; idk
     db "Ha! That's all  "
     db "you've got?!    "
     db "Get ready for   "
     db "THIS!@"
 
-Dialog1E0::
+Dialog1E0:: ; idk
     db "ZZZ ZZZ ZZZ ZZZ "
     db " ... <marin> ... <marin> ...@"
 
-Dialog1E1::
+Dialog1E1:: ; Marin, probably, and Link
     db "Yes, it's that  "
     db "lazy walrus!    "
     db "Shall we give   "
@@ -541,37 +541,37 @@ Dialog1E1::
     db "surprise?       "
     db "    Yes  No...<ask>"
 
-Dialog1E2::
+Dialog1E2:: ; Marin, probably
     db "Aha ha ha!  Wow!"
     db "He certainly    "
     db "woke with a     "
     db "start!@"
 
-Dialog1E3::
+Dialog1E3:: ; idk
     db "Hunh?  Oh, he's "
     db "calling me...   "
     db "It's the same as"
     db "always... Ha ha!@"
 
-Dialog1E4::
+Dialog1E4:: ; idk
     db "You're right, it"
     db "would be mean to"
     db "wake him up now!"
     db "Let's let him   "
     db "sleep some more!@"
 
-Dialog1E5::
+Dialog1E5:: ; Marin, probably
     db "#####, I'm going"
     db "to the Animal   "
     db "Village!  Please"
     db "drop by, okay?@"
 
-Dialog1E6::
+Dialog1E6:: ; idk
     db "Arfh! Arfh! Arf!"
     db " <marin>  <marin>!  <marin>   <marin>!  "
     db "..... <link>?? @"
 
-Dialog1E7::
+Dialog1E7:: ; Fisherman
     db "It's no use,    "
     db "little buddy!  A"
     db "fish took my    "
@@ -583,7 +583,7 @@ Dialog1E7::
     db "thought this    "
     db "would happen...@"
 
-Dialog1E8::
+Dialog1E8:: ; Fisherman
     db "Oh! What is that"
     db "you have in your"
     db "hand?  It's not "
@@ -596,38 +596,38 @@ Dialog1E8::
     db "me have it...   "
     db "    Okay No<ask>"
 
-Dialog1E9::
+Dialog1E9:: ; Fisherman, probably
     db "Keep your eyes  "
     db "open and watch  "
     db "a pro at work.@"
 
-Dialog1EA::
+Dialog1EA:: ; Fisherman, probably
     db "You should be   "
     db "more kind to me!"
     db "I thought we    "
     db "were buddies!@"
 
-Dialog1EB::
+Dialog1EB:: ; Fisherman, probably
     db "My, that's a    "
     db "BIIIIG one!@"
 
-Dialog1EC::
+Dialog1EC:: ; Narrator
     db "The <fishhook> became a  "
     db "necklace <bra>!     "
     db "L-l-lucky!@"
 
-Dialog1ED::
+Dialog1ED:: ; Fisherman, probably
     db "I can't wait to "
     db "see what I'll   "
     db "catch next!@"
 
-Dialog1EE::
+Dialog1EE:: ; Mamasha, probably
     db "My husband is   "
     db "lost in the     "
     db "woods! Please   "
     db "go find him!@"
 
-Dialog1EF::
+Dialog1EF:: ; Secret Zora or Secret Goriya, not sure
     db "Hey, you can see"
     db "me?! You must   "
     db "have a magnify- "
@@ -637,7 +637,7 @@ Dialog1EF::
     db "want to live in "
     db "peace.@"
 
-Dialog1F0::
+Dialog1F0:: ; Mermaid
     db "When I was swim-"
     db "ming in the bay,"
     db "the waves took a"
@@ -649,12 +649,12 @@ Dialog1F0::
     db "take a scale    "
     db "from my tail!   @"
 
-Dialog1F1::
+Dialog1F1:: ; Mermaid
     db "I have already  "
     db "looked around   "
     db "here!@"
 
-Dialog1F2::
+Dialog1F2:: ; Mermaid
     db "Ahh!  That's it!"
     db "That's my neck- "
     db "lace!  Give it! "
@@ -663,15 +663,15 @@ Dialog1F2::
     db "scale as I said!"
     db "    Give Keep<ask>"
 
-Dialog1F3::
+Dialog1F3:: ; Mermaid
     db "Promise!  You'll"
     db "only take one!@"
 
-Dialog1F4::
+Dialog1F4:: ; Mermaid, probably
     db "You are heart-  "
     db "less and cruel!@"
 
-Dialog1F5::
+Dialog1F5:: ; Narrator
     db "You returned the"
     db "necklace <bra> and  "
     db "got a scale <scale> of"
@@ -679,12 +679,12 @@ Dialog1F5::
     db "tail.  How will "
     db "you use this?@"
 
-Dialog1F6::
+Dialog1F6:: ; Photographer
     db "I'll call this  "
     db "'I Was Very     "
     db "Afraid.' Smile!@"
 
-Dialog1F7::
+Dialog1F7:: ; Mermaid
     db "An artist once  "
     db "asked me to pose"
     db "for him, and he "
@@ -694,7 +694,7 @@ Dialog1F7::
     db "Magnifying Lens "
     db "be true...?@"
 
-Dialog1F8::
+Dialog1F8:: ; Photographer
     db "Hi there! It's  "
     db "me, the photo-  "
     db "grapher! You say"
@@ -705,22 +705,22 @@ Dialog1F8::
     db "call it 'I Found"
     db "Zora.'@"
 
-Dialog1F9::
+Dialog1F9:: ; Signpost maybe, and ; Map maybe
     db "Richard's Villa @"
 
-Dialog1FA::
+Dialog1FA:: ; Signpost
     db "Kanalet Castle  "
     db "10 Min. <right> <up>@"
 
-Dialog1FB::
+Dialog1FB:: ; Signpost
     db "Kanalet Castle  "
     db "5 Min. <right>@"
 
-Dialog1FC::
+Dialog1FC:: ; Signpost
     db "Kanalet Castle  "
     db "50 Paces <up>@"
 
-Dialog1FD::
+Dialog1FD:: ; Bucket Mouse
     db "'BRRING! BRRING!"
     db " BRRING! CLICK! "
     db "Yeees!  It's the"
@@ -732,7 +732,7 @@ Dialog1FD::
     db "dialed a wrong  "
     db "number...@"
 
-Dialog1FE::
+Dialog1FE:: ; Fisherman, Link
     db "Oh!  It's a big "
     db "one!  And it has"
     db "a Piece of      "
@@ -742,7 +742,7 @@ Dialog1FE::
     db "that! Try again?"
     db "    Yes  No<ask>"
 
-Dialog1FF::
+Dialog1FF:: ; Fisherman, Link
     db "Oh!  It's a big "
     db "one!  And it has"
     db "a Piece of      "
@@ -756,14 +756,14 @@ Dialog1FF::
     db "try again?      "
     db "    Yes  No<ask>"
 
-Dialog200::
+Dialog200:: ; Book, Narrator
     db " 'How To Handle "
     db "   Your Shield  "
     db "   Like A Pro!' "
     db "Read this book? "
     db "    YES  NO<ask>"
 
-Dialog201::
+Dialog201:: ; Book
     db "'If you hold the"
     db "Button down, you"
     db "can defend your-"
@@ -778,14 +778,14 @@ Dialog201::
     db "which can defend"
     db "against beams!'@"
 
-Dialog202::
+Dialog202:: ; Book, Narrator
     db " 'Selecting The "
     db "   Item That's  "
     db "  Right For You'"
     db "Read this book? "
     db "    YES  NO<ask>"
 
-Dialog203::
+Dialog203:: ; Book
     db "'You can select "
     db "your favorite   "
     db "item for the A  "
@@ -799,13 +799,13 @@ Dialog203::
     db "to find what's  "
     db "right for you!'@"
 
-Dialog204::
+Dialog204:: ; Book, Narrator
     db " 'Auto Map and  "
     db "Memo Guide Book'"
     db "Read this book? "
     db "    YES  NO<ask>"
 
-Dialog205::
+Dialog205:: ; Book, Narrator
     db "'You can see an "
     db "island map by   "
     db "pressing the    "
@@ -824,13 +824,13 @@ Dialog205::
     db "there...'  Ahhh!"
     db "How convenient!@"
 
-Dialog206::
+Dialog206:: ; Book, Narrator
     db " 'Secrets Of The"
     db " Whirling Blade'"
     db "Read this book? "
     db "    YES  NO<ask>"
 
-Dialog207::
+Dialog207:: ; Book
     db "'The Whirling   "
     db "Blade technique "
     db "has been handed "
@@ -848,13 +848,13 @@ Dialog207::
     db "Button!  Can you"
     db "master this?'@"
 
-Dialog208::
+Dialog208:: ; Book, Narrator
     db "'The Properties "
     db "  Of Warp Holes'"
     db "Read this book? "
     db "    YES  NO<ask>"
 
-Dialog209::
+Dialog209:: ; Book
     db "'There are some "
     db "Warp Holes on   "
     db "Koholint Island."
@@ -873,12 +873,12 @@ Dialog209::
     db "seen with your  "
     db "own eyes...'@"
 
-Dialog20A::
+Dialog20A:: ; Book, Narrator
     db "'Fun With Bombs'"
     db "Read this book? "
     db "    YES  NO<ask>"
 
-Dialog20B::
+Dialog20B:: ; Book
     db "'After you put a"
     db "Bomb down, you  "
     db "can pick it up  "
@@ -891,7 +891,7 @@ Dialog20B::
     db "time.  Did you  "
     db "know that?'@"
 
-Dialog20C::
+Dialog20C:: ; Book, Narrator
     db "   'Atlas Of    "
     db "Koholint Island'"
     db "You can move the"
@@ -902,7 +902,7 @@ Dialog20C::
     db "this map?       "
     db "    Look Don't<ask>"
 
-Dialog20D::
+Dialog20D:: ; Book, Narrator
     db " 'Dark Secrets  "
     db "  And Mysteries "
     db "   Of Koholint' "
@@ -910,7 +910,7 @@ Dialog20D::
     db "want to read it?"
     db "    YES  NO<ask>"
 
-Dialog20E::
+Dialog20E:: ; Book, Narrator
     db "Gasp! Wha-What's"
     db "this! ... ...   "
     db "You can't read  "
@@ -919,46 +919,46 @@ Dialog20E::
     db "of a magnifying "
     db "glass...@"
 
-Dialog20F::
-Dialog210::
+Dialog20F:: ; Ghost
+Dialog210:: ; Ghost
     db "...my grave...  "
     db "...take me...   "
     db "...my grave...@"
 
-Dialog211::
+Dialog211:: ; Ghost
     db "...the house... "
     db " ...take me...  "
     db "...the house... "
     db "...at the bay...@"
 
-Dialog212::
+Dialog212:: ; Ghost
     db "...N-N-No!...   "
     db "...N-not there!@"
 
-Dialog213::
+Dialog213:: ; Ghost
     db "   ...Here!...  "
     db "   ...enter...  "
     db " ...my house...@"
 
-Dialog214::
+Dialog214:: ; Ghost
     db " ...Nostalgia..."
     db " ...unchanged..."
     db " ...boo hoo...@"
 
-Dialog215::
+Dialog215:: ; Ghost
     db "  ...Enough...  "
     db " ...cemetery... "
     db "  ...take me... "
     db " ...my grave...@"
 
-Dialog216::
+Dialog216:: ; Ghost
     db "...Thank you... "
     db " ...a jar...    "
     db "...in my home..."
     db "...look inside.."
     db "...bye...bye...@"
 
-Dialog217::
+Dialog217:: ; Book, Narrator
     db "Round and round,"
     db "the passageways "
     db "of the Egg...   "
@@ -967,7 +967,7 @@ Dialog217::
     db "this book reeks "
     db "of secrets...@"
 
-Dialog218::
+Dialog218:: ; Book, Narrator
     db "Round and round,"
     db "the passageways "
     db "of the Egg...   "
@@ -976,7 +976,7 @@ Dialog218::
     db "this book reeks "
     db "of secrets...@"
 
-Dialog219::
+Dialog219:: ; Book, Narrator
     db "Round and round,"
     db "the passageways "
     db "of the Egg...   "
@@ -985,7 +985,7 @@ Dialog219::
     db "this book reeks "
     db "of secrets...@"
 
-Dialog21A::
+Dialog21A:: ; Book, Narrator
     db "Round and round,"
     db "the passageways "
     db "of the Egg...   "
@@ -994,23 +994,23 @@ Dialog21A::
     db "this book reeks "
     db "of secrets...@"
 
-Dialog21B::
+Dialog21B:: ; Marin, probably
     db "...You're late! "
     db "I thought you'd "
     db "never come back!@"
 
-Dialog21C::
+Dialog21C:: ; Marin, probably
     db "...EEEK!  You're"
     db "hurt!  Arrrgh!  "
     db "Don't be so     "
     db "reckless!@"
 
-Dialog21D::
+Dialog21D:: ; Marin, probably
     db "#####! You're   "
     db "back!  Are you  "
     db "hurt?@"
 
-Dialog21E::
+Dialog21E:: ; Marin, probably
     db "...You idiot!   "
     db "I told you this "
     db "would happen... "
@@ -1018,8 +1018,8 @@ Dialog21E::
     db "didn't say any- "
     db "thing, really!@"
 
-Dialog21F::
-Dialog220::
+Dialog21F:: ; Kid
+Dialog220:: ; Kid
     db "Hey buddy!  It's"
     db "serious!  Yeah, "
     db "really serious!!"
@@ -1048,7 +1048,7 @@ Dialog220::
     db "out for yourself"
     db "what happened!@"
 
-Dialog221::
+Dialog221:: ; Secret Goriya
     db "I found a good  "
     db "item washed up  "
     db "on the beach... "
@@ -1058,24 +1058,24 @@ Dialog221::
     db "Button...       "
     db "    Okay No<ask>"
 
-Dialog222::
+Dialog222:: ; Secret Goriya
     db "Okay, let's do  "
     db "it!  When you   "
     db "don't want the  "
     db "Boomerang any   "
     db "more, come back!@"
 
-Dialog223::
+Dialog223:: ; Secret Goriya
     db "Oh, yeah, uh... "
     db "okay, whatever.@"
 
-Dialog224::
+Dialog224:: ; Narrator
     db "You got the     "
     db "Boomerang in    "
     db "exchange for the"
     db "item you had.@"
 
-Dialog225::
+Dialog225:: ; Secret Goriya, Link
     db "Give me back the"
     db "Boomerang, I beg"
     db "you! I'll return"
@@ -1084,19 +1084,19 @@ Dialog225::
     db "    Okay Not Now"
     db "<ask>"
 
-Dialog226::
+Dialog226:: ; Narrator
     db "The item came   "
     db "back to you. You"
     db "returned the    "
     db "Boomerang.@"
 
-Dialog227::
+Dialog227:: ; Secret Goriya
     db "Ah... Don't give"
     db "me that item... "
     db "How about some- "
     db "thing else?@"
 
-Dialog228::
+Dialog228:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ya, it's Ulrira!"
     db "You haven't     "
@@ -1109,7 +1109,7 @@ Dialog228::
     db "take 'em! Bye!  "
     db "CLICK!'@"
 
-Dialog229::
+Dialog229:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ya, it's Ulrira!"
     db "You haven't     "
@@ -1121,7 +1121,7 @@ Dialog229::
     db "Bye!            "
     db "CLICK!'@"
 
-Dialog22A::
+Dialog22A:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ya, it's Ulrira!"
     db "You haven't     "
@@ -1134,14 +1134,14 @@ Dialog22A::
     db "Bye!            "
     db "CLICK!'@"
 
-Dialog22B::
+Dialog22B:: ; Photo Album, Narrator
     db "'The Travels of "
     db "#####' Do you   "
     db "want to look at "
     db "your album?     "
     db "    Look Don't<ask>"
 
-Dialog22C::
+Dialog22C:: ; Narrator
     db "Which picture   "
     db "would you like  "
     db "to see? Use <dpad> to"
@@ -1149,13 +1149,13 @@ Dialog22C::
     db "press the A     "
     db "Button!@"
 
-Dialog22D::
+Dialog22D:: ; Signpost, probably
     db "You are near the"
     db "Eagle's Tower.  "
     db "Beware of the   "
     db "bird!@"
 
-Dialog22E::
+Dialog22E:: ; Photographer
     db "Hi, #####. You  "
     db "know I love to  "
     db "take pictures.  "
@@ -1163,36 +1163,36 @@ Dialog22E::
     db "old castle make "
     db "a great photo?@"
 
-Dialog22F::
-Dialog230::
+Dialog22F:: ; Narrator
+Dialog230:: ; Narrator
     db "Hunh?  A keyhole"
     db "here?  It says, "
     db "'Tale Keyhole'@"
 
-Dialog231::
+Dialog231:: ; Narrator
     db "Hunh?  A keyhole"
     db "here?  It says, "
     db "'Slime Keyhole'@"
 
-Dialog232::
+Dialog232:: ; Narrator
     db "Hunh?  A keyhole"
     db "here?  It says, "
     db "'Angler Keyhole'@"
 
-Dialog233::
+Dialog233:: ; Narrator
     db "Hunh?  A keyhole"
     db "here?  It says, "
     db "'Bird Keyhole'@"
 
-Dialog234::
+Dialog234:: ; Narrator
     db "Hunh?  A keyhole"
     db "here?  It says, "
     db "'Face Keyhole'@"
 
-Dialog235::
+Dialog235:: ; Marin
     db "Somebody, HELP!@"
 
-Dialog236::
+Dialog236:: ; Marin
     db "Hey!  #####!    "
     db "Some monsters   "
     db "put me up here! "
@@ -1200,31 +1200,31 @@ Dialog236::
     db "do?!  I'm afraid"
     db "of heights!!@"
 
-Dialog237::
+Dialog237:: ; Marin
     db "Yow!  That was a"
     db "surprise! #####,"
     db "thank you!@"
 
-Dialog238::
+Dialog238:: ; Marin
     db "... ... ... ... "
     db "... ... ... ... "
     db "Say... #####... @"
 
-Dialog239::
+Dialog239:: ; Marin
     db "Uhh... I don't  "
     db "know how to say "
     db "this... but...@"
 
-Dialog23A::
+Dialog23A:: ; Marin
     db "Hunh?!  Tarin??!"
     db "... ... ... ... "
     db "Uh... Nevermind,"
     db "I... I gotta go!@"
 
-Dialog23B::
+Dialog23B:: ; Tarin
     db "MAAAAAAARINNNN!!@"
 
-Dialog23C::
+Dialog23C:: ; Richard
     db "Nothing yet?! I "
     db "grow tired of   "
     db "waiting. I want "
@@ -1236,7 +1236,7 @@ Dialog23C::
     db "photo, don't you"
     db "think?@"
 
-Dialog23D::
+Dialog23D:: ; Tarin
     db "Hey, Marin and  "
     db "#####! Are you  "
     db "taking pictures?"
@@ -1245,18 +1245,18 @@ Dialog23D::
     db "everyone,       "
     db "including me.@"
 
-Dialog23E::
+Dialog23E:: ; Photographer, probably
     db "I use this to   "
     db "take pictures.  "
     db "Are you ready?  "
     db "Say 'mushroom!'@"
 
-Dialog23F::
+Dialog23F:: ; Photographer, probably
     db "OK, I'm done.   "
     db "I'll go home    "
     db "now.@"
 
-Dialog240::
+Dialog240:: ; Ulrira
     db "'BRRING! BRRING!"
     db "This is Ulrira! "
     db "Oh, I heard from"
@@ -1269,7 +1269,7 @@ Dialog240::
     db "that help?  Bye!"
     db "CLICK!'@"
 
-Dialog241::
+Dialog241:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira here...  "
     db "Yes, when I was "
@@ -1282,7 +1282,7 @@ Dialog241::
     db "helpful for you?"
     db "Bye! CLICK!'@"
 
-Dialog242::
+Dialog242:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hello, this is  "
     db "Ulrira speaking!"
@@ -1293,7 +1293,7 @@ Dialog242::
     db "careful, #####! "
     db "Bye!  CLICK!'@"
 
-Dialog243::
+Dialog243:: ; Ulrira
     db "'BRRING! BRRING!"
     db "This is Ulrira! "
     db "You're lost in  "
@@ -1308,7 +1308,7 @@ Dialog243::
     db "know one little "
     db "answer!  CLICK!'@"
 
-Dialog244::
+Dialog244:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira at your  "
     db "service!  Oh?   "
@@ -1318,7 +1318,7 @@ Dialog244::
     db "would appreciate"
     db "it! Bye! CLICK!'@"
 
-Dialog245::
+Dialog245:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Yeah, this is   "
     db "Ulrira!  You are"
@@ -1334,7 +1334,7 @@ Dialog245::
     db "to play them!   "
     db "Bye!  CLICK!'@"
 
-Dialog246::
+Dialog246:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Hi, it's Ulrira!"
     db "You are doing   "
@@ -1350,7 +1350,7 @@ Dialog246::
     db "important in it."
     db "Bye!  CLICK!'@"
 
-Dialog247::
+Dialog247:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira speaking!"
     db "Are your enemies"
@@ -1363,7 +1363,7 @@ Dialog247::
     db "self and do your"
     db "best!  CLICK!'@"
 
-Dialog248::
+Dialog248:: ; Ulrira
     db "'BRRING! BRRING!"
     db "Ulrira here! ..."
     db "Go for it!      "
@@ -1372,13 +1372,13 @@ Dialog248::
     db "ing for you!    "
     db "Bye!  CLICK!'@"
 
-Dialog249::
+Dialog249:: ; idk
     db "Go ahead and    "
     db "take a picture  "
     db "of me. Any angle"
     db "you like!@"
 
-Dialog24A::
+Dialog24A:: ; idk
     db "Yarna Desert?   "
     db "There's a way to"
     db "get there to the"
@@ -1389,13 +1389,13 @@ Dialog24A::
     db "lazy walrus is  "
     db "in the way!@"
 
-Dialog24B::
+Dialog24B:: ; idk
     db "Ahhh... Sigh... "
     db "On such a nice  "
     db "day, we need a  "
     db "song from Marin!@"
 
-Dialog24C::
+Dialog24C:: ; idk
     db "Hey! Did ya know"
     db "Animal Village  "
     db "and Mabe Village"
@@ -1415,7 +1415,7 @@ Dialog24C::
     db "inside...  Is   "
     db "that true?@"
 
-Dialog24D::
+Dialog24D:: ; idk
     db "I can't go to   "
     db "Mabe Village    "
     db "because of all  "

--- a/src/text/dialog_dx.asm
+++ b/src/text/dialog_dx.asm
@@ -47,20 +47,20 @@ Dialog254:: ; idk
     db "I just decided  "
     db "to wait at home.@"
 
-Dialog255:: ; Marin, probably
+Dialog255:: ; Marin
     db "This is my first"
     db "walk with you,  "
     db "#####.@"
 
-Dialog256:: ; Marin, probably
+Dialog256:: ; Marin
     db ". . . . .@"
 
-Dialog257:: ; Marin, probably
+Dialog257:: ; Marin
     db "This cliff will "
     db "be our secret   "
     db "place. @"
 
-Dialog258:: ; Marin, probably
+Dialog258:: ; Marin
     db "Aren't you going"
     db "to say anything?@"
 
@@ -279,7 +279,7 @@ Dialog278:: ; Marin
     db "other people's  "
     db "drawers?@"
 
-Dialog279:: ; Marin, probably
+Dialog279:: ; Marin
     db "Great!  Dig it! "
     db "Dig it!  Dig to "
     db "the center of   "

--- a/src/text/dialog_dx.asm
+++ b/src/text/dialog_dx.asm
@@ -1,4 +1,4 @@
-Dialog24E::
+Dialog24E:: ; idk
     db "Have you heard  "
     db "of the Flying   "
     db "Rooster?  They  "
@@ -8,32 +8,32 @@ Dialog24E::
     db "I wonder if it's"
     db "true...@"
 
-Dialog24F::
+Dialog24F:: ; idk
     db "Aaaah, Little   "
     db "Marin... I want "
     db "her to come back"
     db "again...Her song"
     db "is the best...@"
 
-Dialog250::
+Dialog250:: ; idk
     db "I dreamed that  "
     db "I turned into a "
     db "carrot last     "
     db "night...  What  "
     db "an odd dream...@"
 
-Dialog251::
+Dialog251:: ; Rabbit
     db "Eh?  How can an "
     db "animal talk?    "
     db "How?  Hey, I'm  "
     db "just a rabbit,  "
     db "so I don't know!@"
 
-Dialog252::
+Dialog252:: ; idk
     db "Ahhh!  It's her!"
     db "Little Marin!!@"
 
-Dialog253::
+Dialog253:: ; idk
     db "If you have no  "
     db "courage,then    "
     db "you have no     "
@@ -42,29 +42,29 @@ Dialog253::
     db "won't move for  "
     db "cowards.@"
 
-Dialog254::
+Dialog254:: ; idk
     db "I'm not afraid. "
     db "I just decided  "
     db "to wait at home.@"
 
-Dialog255::
+Dialog255:: ; Marin, probably
     db "This is my first"
     db "walk with you,  "
     db "#####.@"
 
-Dialog256::
+Dialog256:: ; Marin, probably
     db ". . . . .@"
 
-Dialog257::
+Dialog257:: ; Marin, probably
     db "This cliff will "
     db "be our secret   "
     db "place. @"
 
-Dialog258::
+Dialog258:: ; Marin, probably
     db "Aren't you going"
     db "to say anything?@"
 
-Dialog259::
+Dialog259:: ; Photographer, maybe
     db "Oh how I love   "
     db "pictures! Why   "
     db "don't you take  "
@@ -73,42 +73,42 @@ Dialog259::
     db "around? You can "
     db "call it . . .@"
 
-Dialog25A::
+Dialog25A:: ; Narrator
     db "You've got the  "
     db "Blue Clothes!   "
     db "Your damage will"
     db "be reduced by   "
     db "half!@"
 
-Dialog25B::
+Dialog25B:: ; Narrator
     db "You've got the  "
     db "Red Clothes!    "
     db "Your body is    "
     db "full of energy! @"
 
-Dialog25C::
+Dialog25C:: ; Fairy Queen (Color Dungeon)
     db "Red for offense,"
     db "blue for        "
     db "defense. Which  "
     db "do you choose?  "
     db "    RED  BLUE<ask>"
 
-Dialog25D::
+Dialog25D:: ; Fairy Queen (Color Dungeon), Link
     db "Are you sure?   "
     db "    YES  NO<ask>"
 
-Dialog25E::
+Dialog25E:: ; Dion (Color Dungeon)
     db "The fairy queen "
     db "is waiting for  "
     db "you.@"
 
-Dialog25F::
+Dialog25F:: ; Gar (Color Dungeon)
     db "Do you have the "
     db "powder? If not, "
     db "you must go     "
     db "back.@"
 
-Dialog260::
+Dialog260:: ; Color Guard (Color Dungeon)
     db "Our colors are  "
     db "never the same! "
     db "If I am red, he "
@@ -118,13 +118,13 @@ Dialog260::
     db "is my cloth?    "
     db "    Red  Blue<ask>"
 
-Dialog261::
+Dialog261:: ; idk
     db "BOO! I am no    "
     db "weakling! Your  "
     db "pitiful sword is"
     db "no match for me!@"
 
-Dialog262::
+Dialog262:: ; Color Guard (Color Dungeon)
     db "I am sorry, but "
     db "this is the     "
     db "Color Dungeon.  "
@@ -138,27 +138,27 @@ Dialog262::
     db "enter.          "
     db "Farewell.@"
 
-Dialog263::
+Dialog263:: ; idk (Color Dungeon)
     db "Here is your    "
     db "clue. Make      "
     db "all the red     "
     db "blue.@"
 
-Dialog264::
+Dialog264:: ; idk
     db "No,  no. Take a "
     db "closer look and "
     db "try again.@"
 
-Dialog265::
+Dialog265:: ; idk
     db "Don't tell      "
     db "anyone.@"
 
-Dialog266::
+Dialog266:: ; Narrator
     db "Do you want to  "
     db "read this book? "
     db "    YES  NO<ask>"
 
-Dialog267::
+Dialog267:: ; Book, Narrator
     db "New world of    "
     db "color under the "
     db "5 gravestones.  "
@@ -175,7 +175,7 @@ Dialog267::
     db "what the world  "
     db "of color is?@"
 
-Dialog268::
+Dialog268:: ; Fairy Queen (Color Dungeon)
     db "Welcome, #####. "
     db "I admire you for"
     db "coming this far."
@@ -190,13 +190,13 @@ Dialog268::
     db "you want?       "
     db "    RED  BLUE<ask>"
 
-Dialog269::
+Dialog269:: ; idk
     db "You fool! Your  "
     db "sword won't     "
     db "work! Try       "
     db "something else!@"
 
-Dialog26A::
+Dialog26A:: ; idk
     db "What a greedy   "
     db "fool! You want  "
     db "more power?! A  "
@@ -205,33 +205,33 @@ Dialog26A::
     db "give up and     "
     db "go home!@"
 
-Dialog26B::
+Dialog26B:: ; Great Fairy
     db "Relax and close "
     db "your eyes.@"
 
-Dialog26C::
+Dialog26C:: ; idk (Color Dungeon)
     db "I will now take "
     db "you out.@"
 
-Dialog26D::
+Dialog26D:: ; idk (Color Dungeon)
     db "Blue is safe.   "
     db "Yellow is       "
     db "caution. Red is "
     db "danger.@"
 
-Dialog26E::
+Dialog26E:: ; idk (Color Dungeon)
     db "Yellow is       "
     db "caution. Red is "
     db "danger,Take     "
     db "your time.@"
 
-Dialog26F::
+Dialog26F:: ; idk (Color Dungeon)
     db "Blue. Start     "
     db "over. Yellow is "
     db "caution. Red is "
     db "danger.@"
 
-Dialog270::
+Dialog270:: ; Photographer
     db "Hey, that looks "
     db "great! I'll call"
     db "it '##### Plays "
@@ -239,26 +239,26 @@ Dialog270::
     db "Now get closer  "
     db "to BowWow!@"
 
-Dialog271::
+Dialog271:: ; BowWow
     db "Grrrr!@"
 
-Dialog272::
+Dialog272:: ; Photographer
     db "#####, get      "
     db "closer!@"
 
-Dialog273::
+Dialog273:: ; BowWow
     db "Grrrr! Grrrr!!@"
 
-Dialog274::
+Dialog274:: ; Photographer
     db "Much closer! OK,"
     db "I'm ready.      "
     db "Smile!@"
 
-Dialog275::
+Dialog275:: ; BowWow
     db "Grrrr! Grrrr!!  "
     db "GRRRR!@"
 
-Dialog276::
+Dialog276:: ; Marin
     db "Ha ha ha! Do it!"
     db "Do it!  Do it   "
     db "moooore! ... ..."
@@ -266,114 +266,114 @@ Dialog276::
     db "nothing... I    "
     db "didn't mean it.@"
 
-Dialog277::
+Dialog277:: ; Marin
     db "Not very good..."
     db "Eh?  What?  Did "
     db "I say something?"
     db "No, you're hear-"
     db "ing things...@"
 
-Dialog278::
+Dialog278:: ; Marin
     db "#####, do you   "
     db "always look in  "
     db "other people's  "
     db "drawers?@"
 
-Dialog279::
+Dialog279:: ; Marin, probably
     db "Great!  Dig it! "
     db "Dig it!  Dig to "
     db "the center of   "
     db "the earth!!@"
 
-Dialog27A::
+Dialog27A:: ; Marin, probably
     db "Whew!  What a   "
     db "surprise!@"
 
-Dialog27B::
+Dialog27B:: ; Marin, probably
     db "Ohh!  I'm sorry!"
     db "Are you okay?!  "
     db "#####?@"
 
-Dialog27C::
+Dialog27C:: ; Cukeman
     db "Hey Mon!@"
 
-Dialog27D::
+Dialog27D:: ; Cukeman
     db "You know me, I  "
     db "like short names"
     db "the best...@"
 
-Dialog27E::
+Dialog27E:: ; Cukeman
     db "It can display  "
     db "millions of     "
     db "polygons!@"
 
-Dialog27F::
+Dialog27F:: ; Cukeman
     db "I definitely    "
     db "need it, as soon"
     db "as possible!@"
 
-Dialog280::
+Dialog280:: ; Owl Statue
     db "Turn aside the  "
     db "spined ones with"
     db "a shield...@"
 
-Dialog281::
+Dialog281:: ; Owl Statue
     db "First, defeat   "
     db "the imprisoned  "
     db "Pols Voice,     "
     db "Last, Stalfos...@@"
 
-Dialog282::
+Dialog282:: ; Owl Statue
     db "Far away...     "
     db "Do not fear,    "
     db "dash and fly!@"
 
-Dialog283::
+Dialog283:: ; Owl Statue
     db "The glint of the"
     db "tile will be    "
     db "your guide...@"
 
-Dialog284::
+Dialog284:: ; Owl Statue
     db "Dive under where"
     db "torchlight beams"
     db "do cross...@"
 
-Dialog285::
+Dialog285:: ; Owl Statue
     db "Enter the space "
     db "where the eyes  "
     db "have walls...@"
 
-Dialog286::
+Dialog286:: ; Owl Statue
     db "The riddle is   "
     db "solved when the "
     db "pillars fall!@"
 
-Dialog287::
+Dialog287:: ; Owl Statue
     db "Fill all the    "
     db "holes with the  "
     db "rock that rolls,"
     db "this (<dpad>) is the "
     db "key!@"
 
-Dialog288::
+Dialog288:: ; Owl Statue
     db "If there is a   "
     db "door that you   "
     db "can't open, move"
     db "a stone block.@"
 
-Dialog289::
+Dialog289:: ; Owl Statue
     db "Make every block"
     db "design the same."
     db "A new path will "
     db "open.@"
 
-Dialog28A::
+Dialog28A:: ; Owl Statue
     db "Part of the     "
     db "floor is raised."
     db "Tap the blue    "
     db "crystal.@"
 
-Dialog28B::
+Dialog28B:: ; Owl Statue
     db "To defeat the   "
     db "black monster   "
     db "with the hard   "
@@ -381,7 +381,7 @@ Dialog28B::
     db "something ex-   "
     db "plosive.@"
 
-Dialog28C::
+Dialog28C:: ; Owl Statue
     db "Poke suspicious "
     db "parts of the    "
     db "wall with your  "
@@ -389,70 +389,70 @@ Dialog28C::
     db "to the sounds it"
     db "makes.@"
 
-Dialog28D::
+Dialog28D:: ; Owl Statue
     db "If you can't    "
     db "destroy a       "
     db "skeleton with   "
     db "your sword, try "
     db "using a bomb.@"
 
-Dialog28E::
+Dialog28E:: ; Owl Statue
     db "To open a       "
     db "treasure chest, "
     db "use the pots    "
     db "around it.@"
 
-Dialog28F::
+Dialog28F:: ; Owl Statue
     db "Hop on top of   "
     db "the crystals to "
     db "move forward.@"
 
-Dialog290::
+Dialog290:: ; Owl Statue
     db "If you can't go "
     db "over the poles, "
     db "try throwing    "
     db "things you have "
     db "in your hands.@"
 
-Dialog291::
+Dialog291:: ; Owl Statue
     db "Jump off the    "
     db "floor above to  "
     db "reach the chest "
     db "on the table.@"
 
-Dialog292::
+Dialog292:: ; Owl Statue
     db "To defeat the   "
     db "monsters who    "
     db "hold the key,   "
     db "attack them from"
     db "a higher place.@"
 
-Dialog293::
+Dialog293:: ; Owl Statue
     db "If the statue   "
     db "looks strange,  "
     db "shoot it with   "
     db "the bow.@"
 
-Dialog294::
+Dialog294:: ; Photographer, Link
     db "Let's take a    "
     db "picture!        "
     db "    YES  NO<ask>"
 
-Dialog295::
+Dialog295:: ; Photographer, Link
     db "No picture?! Are"
     db "you pullin' my  "
     db "leg?            "
     db "    Yes  No way<ask>"
 
-Dialog296::
+Dialog296:: ; Photographer
     db "What a bummer!@"
 
-Dialog297::
+Dialog297:: ; Photographer
     db "Beautiful! I'll "
     db "call this 'Game "
     db "Over.'@"
 
-Dialog298::
+Dialog298:: ; Photographer
     db "What's your     "
     db "name, young man?"
     db "#####? Well     "
@@ -462,85 +462,85 @@ Dialog298::
     db "before you      "
     db "leave!@"
 
-Dialog299::
+Dialog299:: ; Photographer
     db "Let's see if we "
     db "can fill that   "
     db "album!@"
 
-Dialog29A::
+Dialog29A:: ; Photographer
     db "11 shots left!  "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog29B::
+Dialog29B:: ; Photographer
     db "10 shots left!  "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog29C::
+Dialog29C:: ; Photographer
     db "9 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog29D::
+Dialog29D:: ; Photographer
     db "8 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog29E::
+Dialog29E:: ; Photographer
     db "7 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog29F::
+Dialog29F:: ; Photographer
     db "6 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog2A0::
+Dialog2A0:: ; Photographer
     db "5 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog2A1::
+Dialog2A1:: ; Photographer
     db "4 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog2A2::
+Dialog2A2:: ; Photographer
     db "3 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog2A3::
+Dialog2A3:: ; Photographer
     db "2 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog2A4::
+Dialog2A4:: ; Photographer
     db "1 shots left!   "
     db "What kind of    "
     db "picture should  "
     db "I take?@"
 
-Dialog2A5::
+Dialog2A5:: ; Photographer
     db "Oh no! You're   "
     db "out of film!    "
     db "Don't forget to "
     db "look at your    "
     db "album!@"
 
-Dialog2A6::
+Dialog2A6:: ; Photographer
     db "Hi! I'm the     "
     db "photographer!   "
     db "What a great    "
@@ -548,42 +548,42 @@ Dialog2A6::
     db "I'll call this  "
     db "'Heads Up!'@"
 
-Dialog2A7::
+Dialog2A7:: ; Photographer
     db "Hey, this       "
     db "represents your "
     db "adventures      "
     db "perfectly!@"
 
-Dialog2A8::
+Dialog2A8:: ; Photographer
     db "I'll call this  "
     db "one 'Close      "
     db "Call.' Hmm.@"
 
-Dialog2A9::
+Dialog2A9:: ; Photographer
     db "I'm too close.@"
 
-Dialog2AA::
+Dialog2AA:: ; Photographer
     db "I should back up"
     db ".@"
 
-Dialog2AB::
+Dialog2AB:: ; Photographer
     db "Aaaaaah!@"
 
-Dialog2AC::
+Dialog2AC:: ; Photographer, probably
     db "I'm going back  "
     db "to the store.   "
     db "Bye!@"
 
-Dialog2AD::
+Dialog2AD:: ; Photographer, probably
     db "See me later,   "
     db "when you're     "
     db "alone!@"
 
-Dialog2AE::
+Dialog2AE:: ; Photographer, probably
     db "Are you sure?   "
     db "    YES  NO<ask>"
 
-Dialog2AF::
+Dialog2AF:: ; Photographer, probably
     db "Ah how I love   "
     db "pictures. Hey,  "
     db "#####! What are "


### PR DESCRIPTION
I added some of these by guessing; some of them by looking at the game; and some of them by changing data and seeing what changed. I tried to indicate when I didn't know something, so I don't think there are any errors. 

- I labeled "Narrator" lines to distinguish them from unlabeled lines. 
- I labeled "idk" lines to distinguish them from unlabeled lines. 
- I labeled player responses to questions as "Link". 
- I used official names from the Switch version where I knew them. 
- I only labeled English lines. I'm not sure whether the translations should use English character names, or localized ones.

This is kind of messy, but useful to translators, I think.