### PR TITLE
Document function at 0B2F, which is used to backup overworld objects to WRAM bank 2.

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -552,11 +552,13 @@ CopyObjectsAttributesToWRAM2::
     ld   [rSelectROMBank], a                      ; $0B2B: $EA $00 $21
     ret                                           ; $0B2E: $C9
 
-; On GBC, copy some overworld objects to ram bank 2
+; On GBC, copy the overworld object at [hl] to ram bank 2.
+;   This is used when the inventory menu is exited to restore the background data
 ; Inputs:
-;   a  data bank?
-;   hl destination in RAM bank 2
-func_2BF::
+;   a  bit7: If not set, check if the object at address hl is in a specific ignore list.
+;      bit0-6: Bank number to return to after this function is finished.
+;   hl source in RAM bank 0 and destination in RAM bank 2
+backupObjectInRAM2::
     ldh  [hMultiPurpose2], a                      ; $0B2F: $E0 $D9
     ldh  a, [hIsGBC]                              ; $0B31: $F0 $FE
     and  a                                        ; $0B33: $A7
@@ -570,7 +572,7 @@ func_2BF::
     ldh  a, [hMultiPurpose2]                      ; $0B3B: $F0 $D9
     and  $80                                      ; $0B3D: $E6 $80
     jr   nz, .else                                ; $0B3F: $20 $0A
-    callsb func_020_6E50                          ; $0B41: $3E $20 $EA $00 $21 $CD $50 $6E
+    callsb checkOverworldObjectIgnoreList         ; $0B41: $3E $20 $EA $00 $21 $CD $50 $6E
     jr   c, .endIf                                ; $0B49: $38 $09
 .else
     ld   b, [hl]                                  ; $0B4B: $46
@@ -6701,7 +6703,7 @@ label_3527::
     ld   a, $1A                                   ; $3527: $3E $1A
 
 label_3529::
-    call func_2BF                                 ; $3529: $CD $2F $0B
+    call backupObjectInRAM2                       ; $3529: $CD $2F $0B
     ret                                           ; $352C: $C9
 
 ; Copy an object from the room data to the active room
@@ -6865,7 +6867,7 @@ label_35CB::
 
 label_35E8::
     ld   a, $24                                   ; $35E8: $3E $24
-    call func_2BF                                 ; $35EA: $CD $2F $0B
+    call backupObjectInRAM2                       ; $35EA: $CD $2F $0B
     ret                                           ; $35ED: $C9
 
 label_35EE::

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -558,7 +558,7 @@ CopyObjectsAttributesToWRAM2::
 ;   a  bit7: If not set, check if the object at address hl is in a specific ignore list.
 ;      bit0-6: Bank number to return to after this function is finished.
 ;   hl source in RAM bank 0 and destination in RAM bank 2
-backupObjectInRAM2::
+BackupObjectInRAM2::
     ldh  [hMultiPurpose2], a                      ; $0B2F: $E0 $D9
     ldh  a, [hIsGBC]                              ; $0B31: $F0 $FE
     and  a                                        ; $0B33: $A7
@@ -572,7 +572,7 @@ backupObjectInRAM2::
     ldh  a, [hMultiPurpose2]                      ; $0B3B: $F0 $D9
     and  $80                                      ; $0B3D: $E6 $80
     jr   nz, .else                                ; $0B3F: $20 $0A
-    callsb checkOverworldObjectIgnoreList         ; $0B41: $3E $20 $EA $00 $21 $CD $50 $6E
+    callsb CheckOverworldObjectIgnoreList         ; $0B41: $3E $20 $EA $00 $21 $CD $50 $6E
     jr   c, .endIf                                ; $0B49: $38 $09
 .else
     ld   b, [hl]                                  ; $0B4B: $46
@@ -6703,7 +6703,7 @@ label_3527::
     ld   a, $1A                                   ; $3527: $3E $1A
 
 label_3529::
-    call backupObjectInRAM2                       ; $3529: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $3529: $CD $2F $0B
     ret                                           ; $352C: $C9
 
 ; Copy an object from the room data to the active room
@@ -6867,7 +6867,7 @@ label_35CB::
 
 label_35E8::
     ld   a, $24                                   ; $35E8: $3E $24
-    call backupObjectInRAM2                       ; $35EA: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $35EA: $CD $2F $0B
     ret                                           ; $35ED: $C9
 
 label_35EE::

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -553,7 +553,11 @@ CopyObjectsAttributesToWRAM2::
     ret                                           ; $0B2E: $C9
 
 ; On GBC, copy the overworld object at [hl] to ram bank 2.
-;   This is used when the inventory menu is exited to restore the background data
+;
+; This is used when the inventory menu is exited to restore the background objects
+; as they were modified (i.e. cut grass, holes dug with the shovel, etc.)
+;
+;
 ; Inputs:
 ;   a  bit7: If not set, check if the object at address hl is in a specific ignore list.
 ;      bit0-6: Bank number to return to after this function is finished.
@@ -4017,18 +4021,18 @@ DoUpdateBGRegion::
     ld   b, $00                                   ; $224C: $06 $00
     ld   c, [hl]                                  ; $224E: $4E
 
-    ; If running on GBC…
+    ; When on the GBC Overworld, read the object value from WRAM2 instead
+    ; (See BackupObjectInRAM2)
     ldh  a, [hIsGBC]                              ; $224F: $F0 $FE
     and  a                                        ; $2251: $A7
     jr   z, .ramSwitchEnd                         ; $2252: $28 $0E
-    ; … and is indoor…
     ld   a, [wIsIndoor]                           ; $2254: $FA $A5 $DB
     and  a                                        ; $2257: $A7
     jr   nz, .ramSwitchEnd                        ; $2258: $20 $08
-    ; … switch to RAM Bank 2,
+    ; Switch to RAM Bank 2,
     ld   a, $02                                   ; $225A: $3E $02
     ld   [rSVBK], a                               ; $225C: $E0 $70
-    ; read hl,
+    ; read the object value,
     ld   c, [hl]                                  ; $225E: $4E
     ; switch back to RAM Bank 0.
     xor  a                                        ; $225F: $AF

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -1683,7 +1683,7 @@ jr_014_5677:
 
 jr_014_5679:
     ld   a, $94                                   ; $5679: $3E $94
-    call backupObjectInRAM2                       ; $567B: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $567B: $CD $2F $0B
     call label_2887                               ; $567E: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $5681: $F0 $FE
     and  a                                        ; $5683: $A7
@@ -1848,7 +1848,7 @@ label_014_5743:
 label_014_5767:
     ld   [hl], $C6                                ; $5767: $36 $C6
     ld   a, $94                                   ; $5769: $3E $94
-    call backupObjectInRAM2                       ; $576B: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $576B: $CD $2F $0B
     call label_2887                               ; $576E: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $5771: $F0 $FE
     and  a                                        ; $5773: $A7
@@ -1923,7 +1923,7 @@ label_014_57E1:
     add  hl, de                                   ; $57E4: $19
     ld   [hl], $E8                                ; $57E5: $36 $E8
     ld   a, $94                                   ; $57E7: $3E $94
-    call backupObjectInRAM2                       ; $57E9: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $57E9: $CD $2F $0B
     call label_2887                               ; $57EC: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $57EF: $F0 $FE
     and  a                                        ; $57F1: $A7

--- a/src/code/bank14.asm
+++ b/src/code/bank14.asm
@@ -1683,7 +1683,7 @@ jr_014_5677:
 
 jr_014_5679:
     ld   a, $94                                   ; $5679: $3E $94
-    call func_2BF                                 ; $567B: $CD $2F $0B
+    call backupObjectInRAM2                       ; $567B: $CD $2F $0B
     call label_2887                               ; $567E: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $5681: $F0 $FE
     and  a                                        ; $5683: $A7
@@ -1848,7 +1848,7 @@ label_014_5743:
 label_014_5767:
     ld   [hl], $C6                                ; $5767: $36 $C6
     ld   a, $94                                   ; $5769: $3E $94
-    call func_2BF                                 ; $576B: $CD $2F $0B
+    call backupObjectInRAM2                       ; $576B: $CD $2F $0B
     call label_2887                               ; $576E: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $5771: $F0 $FE
     and  a                                        ; $5773: $A7
@@ -1923,7 +1923,7 @@ label_014_57E1:
     add  hl, de                                   ; $57E4: $19
     ld   [hl], $E8                                ; $57E5: $36 $E8
     ld   a, $94                                   ; $57E7: $3E $94
-    call func_2BF                                 ; $57E9: $CD $2F $0B
+    call backupObjectInRAM2                       ; $57E9: $CD $2F $0B
     call label_2887                               ; $57EC: $CD $87 $28
     ldh  a, [hIsGBC]                              ; $57EF: $F0 $FE
     and  a                                        ; $57F1: $A7

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -1812,7 +1812,7 @@ label_002_4C92:
     add  hl, de                                   ; $4C9A: $19
     ld   [hl], $CC                                ; $4C9B: $36 $CC
     ld   a, $82                                   ; $4C9D: $3E $82
-    call func_2BF                                 ; $4C9F: $CD $2F $0B
+    call backupObjectInRAM2                       ; $4C9F: $CD $2F $0B
     call label_2887                               ; $4CA2: $CD $87 $28
     ld   hl, wDrawCommand                         ; $4CA5: $21 $01 $D6
     ld   a, [wDrawCommandsSize]                   ; $4CA8: $FA $00 $D6
@@ -3650,7 +3650,7 @@ jr_002_568C:
 .jr_56FC
     ld   [hl], $E3                                ; $56FC: $36 $E3
     ld   a, $82                                   ; $56FE: $3E $82
-    call func_2BF                                 ; $5700: $CD $2F $0B
+    call backupObjectInRAM2                       ; $5700: $CD $2F $0B
     ld   a, JINGLE_DUNGEON_OPENED                 ; $5703: $3E $23
     ldh  [hJingle], a                             ; $5705: $E0 $F2
 

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -1812,7 +1812,7 @@ label_002_4C92:
     add  hl, de                                   ; $4C9A: $19
     ld   [hl], $CC                                ; $4C9B: $36 $CC
     ld   a, $82                                   ; $4C9D: $3E $82
-    call backupObjectInRAM2                       ; $4C9F: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $4C9F: $CD $2F $0B
     call label_2887                               ; $4CA2: $CD $87 $28
     ld   hl, wDrawCommand                         ; $4CA5: $21 $01 $D6
     ld   a, [wDrawCommandsSize]                   ; $4CA8: $FA $00 $D6
@@ -3650,7 +3650,7 @@ jr_002_568C:
 .jr_56FC
     ld   [hl], $E3                                ; $56FC: $36 $E3
     ld   a, $82                                   ; $56FE: $3E $82
-    call backupObjectInRAM2                       ; $5700: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $5700: $CD $2F $0B
     ld   a, JINGLE_DUNGEON_OPENED                 ; $5703: $3E $23
     ldh  [hJingle], a                             ; $5705: $E0 $F2
 

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5489,11 +5489,12 @@ ASSERT LOW(wRoomObjectsArea) & $0F == 0, "wRoomObjectsArea must be aligned on $1
 
     ret                                           ; $6E4F: $C9
 
-func_020_6E50::
+; Check if the object at HL is in the overworld object ignore list.
+checkOverworldObjectIgnoreList::
     push hl                                       ; $6E50: $E5
     ld   c, [hl]                                  ; $6E51: $4E
     ld   b, $0E                                   ; $6E52: $06 $0E
-    ld   hl, Data_020_6E65                        ; $6E54: $21 $65 $6E
+    ld   hl, overworldObjectIgnoreList            ; $6E54: $21 $65 $6E
 
 .loop
     ld   a, [hl+]                                 ; $6E57: $2A
@@ -5514,8 +5515,9 @@ func_020_6E50::
     pop  hl                                       ; $6E63: $E1
     ret                                           ; $6E64: $C9
 
-; Sprite table for overworld?
-Data_020_6E65::
+; List of overworld objects that should not be backed up in WRAM bank 2.
+; This is used to prevent exiting the inventory menu from messing up the overlay grass tiles.
+overworldObjectIgnoreList::
     db   $03, $04, $09, $5E, $91, $A1, $AA, $C4, $C6, $CC, $DB, $E1, $E3, $E8
 
 TilesetTables::

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5490,6 +5490,8 @@ ASSERT LOW(wRoomObjectsArea) & $0F == 0, "wRoomObjectsArea must be aligned on $1
     ret                                           ; $6E4F: $C9
 
 ; Check if the object at HL is in the overworld object ignore list.
+;
+; See BackupObjectInRAM2
 CheckOverworldObjectIgnoreList::
     push hl                                       ; $6E50: $E5
     ld   c, [hl]                                  ; $6E51: $4E

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -5490,11 +5490,11 @@ ASSERT LOW(wRoomObjectsArea) & $0F == 0, "wRoomObjectsArea must be aligned on $1
     ret                                           ; $6E4F: $C9
 
 ; Check if the object at HL is in the overworld object ignore list.
-checkOverworldObjectIgnoreList::
+CheckOverworldObjectIgnoreList::
     push hl                                       ; $6E50: $E5
     ld   c, [hl]                                  ; $6E51: $4E
     ld   b, $0E                                   ; $6E52: $06 $0E
-    ld   hl, overworldObjectIgnoreList            ; $6E54: $21 $65 $6E
+    ld   hl, OverworldObjectIgnoreList            ; $6E54: $21 $65 $6E
 
 .loop
     ld   a, [hl+]                                 ; $6E57: $2A
@@ -5517,7 +5517,7 @@ checkOverworldObjectIgnoreList::
 
 ; List of overworld objects that should not be backed up in WRAM bank 2.
 ; This is used to prevent exiting the inventory menu from messing up the overlay grass tiles.
-overworldObjectIgnoreList::
+OverworldObjectIgnoreList::
     db   $03, $04, $09, $5E, $91, $A1, $AA, $C4, $C6, $CC, $DB, $E1, $E3, $E8
 
 TilesetTables::

--- a/src/code/entities/07_kiki.asm
+++ b/src/code/entities/07_kiki.asm
@@ -421,15 +421,15 @@ jr_007_5A2A:
     ld   hl, wRoomObjectsArea + $25               ; $5A8E: $21 $25 $D7
     ld   [hl], $DB                                ; $5A91: $36 $DB
     ld   a, $87                                   ; $5A93: $3E $87
-    call func_2BF                                 ; $5A95: $CD $2F $0B
+    call backupObjectInRAM2                       ; $5A95: $CD $2F $0B
     ld   hl, wRoomObjectsArea + $35               ; $5A98: $21 $35 $D7
     ld   [hl], $DB                                ; $5A9B: $36 $DB
     ld   a, $87                                   ; $5A9D: $3E $87
-    call func_2BF                                 ; $5A9F: $CD $2F $0B
+    call backupObjectInRAM2                       ; $5A9F: $CD $2F $0B
     ld   hl, wRoomObjectsArea + $45               ; $5AA2: $21 $45 $D7
     ld   [hl], $DB                                ; $5AA5: $36 $DB
     ld   a, $87                                   ; $5AA7: $3E $87
-    jp   func_2BF                                 ; $5AA9: $C3 $2F $0B
+    jp   backupObjectInRAM2                       ; $5AA9: $C3 $2F $0B
 
 func_007_5AAC::
     call GetEntityTransitionCountdown             ; $5AAC: $CD $05 $0C

--- a/src/code/entities/07_kiki.asm
+++ b/src/code/entities/07_kiki.asm
@@ -421,15 +421,15 @@ jr_007_5A2A:
     ld   hl, wRoomObjectsArea + $25               ; $5A8E: $21 $25 $D7
     ld   [hl], $DB                                ; $5A91: $36 $DB
     ld   a, $87                                   ; $5A93: $3E $87
-    call backupObjectInRAM2                       ; $5A95: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $5A95: $CD $2F $0B
     ld   hl, wRoomObjectsArea + $35               ; $5A98: $21 $35 $D7
     ld   [hl], $DB                                ; $5A9B: $36 $DB
     ld   a, $87                                   ; $5A9D: $3E $87
-    call backupObjectInRAM2                       ; $5A9F: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $5A9F: $CD $2F $0B
     ld   hl, wRoomObjectsArea + $45               ; $5AA2: $21 $45 $D7
     ld   [hl], $DB                                ; $5AA5: $36 $DB
     ld   a, $87                                   ; $5AA7: $3E $87
-    jp   backupObjectInRAM2                       ; $5AA9: $C3 $2F $0B
+    jp   BackupObjectInRAM2                       ; $5AA9: $C3 $2F $0B
 
 func_007_5AAC::
     call GetEntityTransitionCountdown             ; $5AAC: $CD $05 $0C

--- a/src/code/entities/07_master_stalfos.asm
+++ b/src/code/entities/07_master_stalfos.asm
@@ -140,7 +140,7 @@ label_007_69D0:
     ld   h, b                                     ; $6A26: $60
     ld   l, c                                     ; $6A27: $69
     ld   a, $87                                   ; $6A28: $3E $87
-    call backupObjectInRAM2                       ; $6A2A: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6A2A: $CD $2F $0B
     pop  hl                                       ; $6A2D: $E1
     inc  bc                                       ; $6A2E: $03
     dec  e                                        ; $6A2F: $1D

--- a/src/code/entities/07_master_stalfos.asm
+++ b/src/code/entities/07_master_stalfos.asm
@@ -140,7 +140,7 @@ label_007_69D0:
     ld   h, b                                     ; $6A26: $60
     ld   l, c                                     ; $6A27: $69
     ld   a, $87                                   ; $6A28: $3E $87
-    call func_2BF                                 ; $6A2A: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6A2A: $CD $2F $0B
     pop  hl                                       ; $6A2D: $E1
     inc  bc                                       ; $6A2E: $03
     dec  e                                        ; $6A2F: $1D

--- a/src/code/entities/18_maze_signpost.asm
+++ b/src/code/entities/18_maze_signpost.asm
@@ -95,7 +95,7 @@ RevealMamuCave::
     ld   hl, wRoomObjects + $28                   ; $62F5: $21 $39 $D7
     ld   [hl], $C6                                ; $62F8: $36 $C6
     ld   a, $98                                   ; $62FA: $3E $98
-    call func_2BF                                 ; $62FC: $CD $2F $0B
+    call backupObjectInRAM2                       ; $62FC: $CD $2F $0B
     ld   a, $28                                   ; $62FF: $3E $28
     ld   [wWarp0PositionTileIndex], a             ; $6301: $EA $16 $D4
     ld   a, $20                                   ; $6304: $3E $20

--- a/src/code/entities/18_maze_signpost.asm
+++ b/src/code/entities/18_maze_signpost.asm
@@ -95,7 +95,7 @@ RevealMamuCave::
     ld   hl, wRoomObjects + $28                   ; $62F5: $21 $39 $D7
     ld   [hl], $C6                                ; $62F8: $36 $C6
     ld   a, $98                                   ; $62FA: $3E $98
-    call backupObjectInRAM2                       ; $62FC: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $62FC: $CD $2F $0B
     ld   a, $28                                   ; $62FF: $3E $28
     ld   [wWarp0PositionTileIndex], a             ; $6301: $EA $16 $D4
     ld   a, $20                                   ; $6304: $3E $20

--- a/src/code/entities/19_animate_dungeon_door_opening.asm
+++ b/src/code/entities/19_animate_dungeon_door_opening.asm
@@ -221,17 +221,17 @@ EaglesTowerOpeningState6Handler::
     ld   a, $E1                                   ; $62CD: $3E $E1
     ld   [hl], a                                  ; $62CF: $77
     ld   a, $99                                   ; $62D0: $3E $99
-    call func_2BF                                 ; $62D2: $CD $2F $0B
+    call backupObjectInRAM2                       ; $62D2: $CD $2F $0B
     ld   hl, wRoomObjects + $35                   ; $62D5: $21 $46 $D7
     ld   a, $77                                   ; $62D8: $3E $77
     ld   [hl], a                                  ; $62DA: $77
     ld   a, $99                                   ; $62DB: $3E $99
-    call func_2BF                                 ; $62DD: $CD $2F $0B
+    call backupObjectInRAM2                       ; $62DD: $CD $2F $0B
     ld   hl, wRoomObjects + $45                   ; $62E0: $21 $56 $D7
     ld   a, $77                                   ; $62E3: $3E $77
     ld   [hl], a                                  ; $62E5: $77
     ld   a, $99                                   ; $62E6: $3E $99
-    call func_2BF                                 ; $62E8: $CD $2F $0B
+    call backupObjectInRAM2                       ; $62E8: $CD $2F $0B
     call func_019_6374                            ; $62EB: $CD $74 $63
     call func_019_63B5                            ; $62EE: $CD $B5 $63
     jp   ClearEntityStatus_19                     ; $62F1: $C3 $61 $7E
@@ -811,19 +811,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $6972: $22
     ld   hl, wRoomObjects + $01                   ; $6973: $21 $12 $D7
     ld   a, $99                                   ; $6976: $3E $99
-    call func_2BF                                 ; $6978: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6978: $CD $2F $0B
     inc  hl                                       ; $697B: $23
     ld   a, $99                                   ; $697C: $3E $99
-    call func_2BF                                 ; $697E: $CD $2F $0B
+    call backupObjectInRAM2                       ; $697E: $CD $2F $0B
     inc  hl                                       ; $6981: $23
     ld   a, $99                                   ; $6982: $3E $99
-    call func_2BF                                 ; $6984: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6984: $CD $2F $0B
     inc  hl                                       ; $6987: $23
     ld   a, $99                                   ; $6988: $3E $99
-    call func_2BF                                 ; $698A: $CD $2F $0B
+    call backupObjectInRAM2                       ; $698A: $CD $2F $0B
     inc  hl                                       ; $698D: $23
     ld   a, $99                                   ; $698E: $3E $99
-    call func_2BF                                 ; $6990: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6990: $CD $2F $0B
     ld   hl, wRoomObjects + $11                   ; $6993: $21 $22 $D7
     ld   a, $B3                                   ; $6996: $3E $B3
     ld   [hl+], a                                 ; $6998: $22
@@ -837,19 +837,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $69A4: $22
     ld   hl, wRoomObjects + $11                   ; $69A5: $21 $22 $D7
     ld   a, $99                                   ; $69A8: $3E $99
-    call func_2BF                                 ; $69AA: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69AA: $CD $2F $0B
     inc  hl                                       ; $69AD: $23
     ld   a, $99                                   ; $69AE: $3E $99
-    call func_2BF                                 ; $69B0: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69B0: $CD $2F $0B
     inc  hl                                       ; $69B3: $23
     ld   a, $99                                   ; $69B4: $3E $99
-    call func_2BF                                 ; $69B6: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69B6: $CD $2F $0B
     inc  hl                                       ; $69B9: $23
     ld   a, $99                                   ; $69BA: $3E $99
-    call func_2BF                                 ; $69BC: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69BC: $CD $2F $0B
     inc  hl                                       ; $69BF: $23
     ld   a, $99                                   ; $69C0: $3E $99
-    call func_2BF                                 ; $69C2: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69C2: $CD $2F $0B
     ld   hl, wRoomObjects + $21                   ; $69C5: $21 $32 $D7
     ld   a, $AD                                   ; $69C8: $3E $AD
     ld   [hl+], a                                 ; $69CA: $22
@@ -863,19 +863,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $69D6: $22
     ld   hl, wRoomObjects + $21                   ; $69D7: $21 $32 $D7
     ld   a, $99                                   ; $69DA: $3E $99
-    call func_2BF                                 ; $69DC: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69DC: $CD $2F $0B
     inc  hl                                       ; $69DF: $23
     ld   a, $99                                   ; $69E0: $3E $99
-    call func_2BF                                 ; $69E2: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69E2: $CD $2F $0B
     inc  hl                                       ; $69E5: $23
     ld   a, $99                                   ; $69E6: $3E $99
-    call func_2BF                                 ; $69E8: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69E8: $CD $2F $0B
     inc  hl                                       ; $69EB: $23
     ld   a, $99                                   ; $69EC: $3E $99
-    call func_2BF                                 ; $69EE: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69EE: $CD $2F $0B
     inc  hl                                       ; $69F1: $23
     ld   a, $99                                   ; $69F2: $3E $99
-    call func_2BF                                 ; $69F4: $CD $2F $0B
+    call backupObjectInRAM2                       ; $69F4: $CD $2F $0B
     ld   hl, wRoomObjects + $31                   ; $69F7: $21 $42 $D7
     ld   a, $AE                                   ; $69FA: $3E $AE
     ld   [hl+], a                                 ; $69FC: $22
@@ -889,19 +889,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $6A08: $22
     ld   hl, wRoomObjects + $31                   ; $6A09: $21 $42 $D7
     ld   a, $99                                   ; $6A0C: $3E $99
-    call func_2BF                                 ; $6A0E: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6A0E: $CD $2F $0B
     inc  hl                                       ; $6A11: $23
     ld   a, $99                                   ; $6A12: $3E $99
-    call func_2BF                                 ; $6A14: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6A14: $CD $2F $0B
     inc  hl                                       ; $6A17: $23
     ld   a, $99                                   ; $6A18: $3E $99
-    call func_2BF                                 ; $6A1A: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6A1A: $CD $2F $0B
     inc  hl                                       ; $6A1D: $23
     ld   a, $99                                   ; $6A1E: $3E $99
-    call func_2BF                                 ; $6A20: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6A20: $CD $2F $0B
     inc  hl                                       ; $6A23: $23
     ld   a, $99                                   ; $6A24: $3E $99
-    call func_2BF                                 ; $6A26: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6A26: $CD $2F $0B
     call func_019_7F0E                            ; $6A29: $CD $0E $7F
     set  4, [hl]                                  ; $6A2C: $CB $E6
     xor  a                                        ; $6A2E: $AF

--- a/src/code/entities/19_animate_dungeon_door_opening.asm
+++ b/src/code/entities/19_animate_dungeon_door_opening.asm
@@ -221,17 +221,17 @@ EaglesTowerOpeningState6Handler::
     ld   a, $E1                                   ; $62CD: $3E $E1
     ld   [hl], a                                  ; $62CF: $77
     ld   a, $99                                   ; $62D0: $3E $99
-    call backupObjectInRAM2                       ; $62D2: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $62D2: $CD $2F $0B
     ld   hl, wRoomObjects + $35                   ; $62D5: $21 $46 $D7
     ld   a, $77                                   ; $62D8: $3E $77
     ld   [hl], a                                  ; $62DA: $77
     ld   a, $99                                   ; $62DB: $3E $99
-    call backupObjectInRAM2                       ; $62DD: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $62DD: $CD $2F $0B
     ld   hl, wRoomObjects + $45                   ; $62E0: $21 $56 $D7
     ld   a, $77                                   ; $62E3: $3E $77
     ld   [hl], a                                  ; $62E5: $77
     ld   a, $99                                   ; $62E6: $3E $99
-    call backupObjectInRAM2                       ; $62E8: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $62E8: $CD $2F $0B
     call func_019_6374                            ; $62EB: $CD $74 $63
     call func_019_63B5                            ; $62EE: $CD $B5 $63
     jp   ClearEntityStatus_19                     ; $62F1: $C3 $61 $7E
@@ -811,19 +811,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $6972: $22
     ld   hl, wRoomObjects + $01                   ; $6973: $21 $12 $D7
     ld   a, $99                                   ; $6976: $3E $99
-    call backupObjectInRAM2                       ; $6978: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6978: $CD $2F $0B
     inc  hl                                       ; $697B: $23
     ld   a, $99                                   ; $697C: $3E $99
-    call backupObjectInRAM2                       ; $697E: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $697E: $CD $2F $0B
     inc  hl                                       ; $6981: $23
     ld   a, $99                                   ; $6982: $3E $99
-    call backupObjectInRAM2                       ; $6984: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6984: $CD $2F $0B
     inc  hl                                       ; $6987: $23
     ld   a, $99                                   ; $6988: $3E $99
-    call backupObjectInRAM2                       ; $698A: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $698A: $CD $2F $0B
     inc  hl                                       ; $698D: $23
     ld   a, $99                                   ; $698E: $3E $99
-    call backupObjectInRAM2                       ; $6990: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6990: $CD $2F $0B
     ld   hl, wRoomObjects + $11                   ; $6993: $21 $22 $D7
     ld   a, $B3                                   ; $6996: $3E $B3
     ld   [hl+], a                                 ; $6998: $22
@@ -837,19 +837,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $69A4: $22
     ld   hl, wRoomObjects + $11                   ; $69A5: $21 $22 $D7
     ld   a, $99                                   ; $69A8: $3E $99
-    call backupObjectInRAM2                       ; $69AA: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69AA: $CD $2F $0B
     inc  hl                                       ; $69AD: $23
     ld   a, $99                                   ; $69AE: $3E $99
-    call backupObjectInRAM2                       ; $69B0: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69B0: $CD $2F $0B
     inc  hl                                       ; $69B3: $23
     ld   a, $99                                   ; $69B4: $3E $99
-    call backupObjectInRAM2                       ; $69B6: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69B6: $CD $2F $0B
     inc  hl                                       ; $69B9: $23
     ld   a, $99                                   ; $69BA: $3E $99
-    call backupObjectInRAM2                       ; $69BC: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69BC: $CD $2F $0B
     inc  hl                                       ; $69BF: $23
     ld   a, $99                                   ; $69C0: $3E $99
-    call backupObjectInRAM2                       ; $69C2: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69C2: $CD $2F $0B
     ld   hl, wRoomObjects + $21                   ; $69C5: $21 $32 $D7
     ld   a, $AD                                   ; $69C8: $3E $AD
     ld   [hl+], a                                 ; $69CA: $22
@@ -863,19 +863,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $69D6: $22
     ld   hl, wRoomObjects + $21                   ; $69D7: $21 $32 $D7
     ld   a, $99                                   ; $69DA: $3E $99
-    call backupObjectInRAM2                       ; $69DC: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69DC: $CD $2F $0B
     inc  hl                                       ; $69DF: $23
     ld   a, $99                                   ; $69E0: $3E $99
-    call backupObjectInRAM2                       ; $69E2: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69E2: $CD $2F $0B
     inc  hl                                       ; $69E5: $23
     ld   a, $99                                   ; $69E6: $3E $99
-    call backupObjectInRAM2                       ; $69E8: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69E8: $CD $2F $0B
     inc  hl                                       ; $69EB: $23
     ld   a, $99                                   ; $69EC: $3E $99
-    call backupObjectInRAM2                       ; $69EE: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69EE: $CD $2F $0B
     inc  hl                                       ; $69F1: $23
     ld   a, $99                                   ; $69F2: $3E $99
-    call backupObjectInRAM2                       ; $69F4: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $69F4: $CD $2F $0B
     ld   hl, wRoomObjects + $31                   ; $69F7: $21 $42 $D7
     ld   a, $AE                                   ; $69FA: $3E $AE
     ld   [hl+], a                                 ; $69FC: $22
@@ -889,19 +889,19 @@ jr_019_693D:
     ld   [hl+], a                                 ; $6A08: $22
     ld   hl, wRoomObjects + $31                   ; $6A09: $21 $42 $D7
     ld   a, $99                                   ; $6A0C: $3E $99
-    call backupObjectInRAM2                       ; $6A0E: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6A0E: $CD $2F $0B
     inc  hl                                       ; $6A11: $23
     ld   a, $99                                   ; $6A12: $3E $99
-    call backupObjectInRAM2                       ; $6A14: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6A14: $CD $2F $0B
     inc  hl                                       ; $6A17: $23
     ld   a, $99                                   ; $6A18: $3E $99
-    call backupObjectInRAM2                       ; $6A1A: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6A1A: $CD $2F $0B
     inc  hl                                       ; $6A1D: $23
     ld   a, $99                                   ; $6A1E: $3E $99
-    call backupObjectInRAM2                       ; $6A20: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6A20: $CD $2F $0B
     inc  hl                                       ; $6A23: $23
     ld   a, $99                                   ; $6A24: $3E $99
-    call backupObjectInRAM2                       ; $6A26: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6A26: $CD $2F $0B
     call func_019_7F0E                            ; $6A29: $CD $0E $7F
     set  4, [hl]                                  ; $6A2C: $CB $E6
     xor  a                                        ; $6A2E: $AF

--- a/src/code/entities/19_egg_song_event.asm
+++ b/src/code/entities/19_egg_song_event.asm
@@ -292,12 +292,12 @@ jr_019_4C21:
     ld   a, $C1                                   ; $4C37: $3E $C1
     ld   [hl], a                                  ; $4C39: $77
     ld   a, $99                                   ; $4C3A: $3E $99
-    call func_2BF                                 ; $4C3C: $CD $2F $0B
+    call backupObjectInRAM2                       ; $4C3C: $CD $2F $0B
     ld   hl, wRoomObjects + $35                   ; $4C3F: $21 $46 $D7
     ld   a, $CB                                   ; $4C42: $3E $CB
     ld   [hl], a                                  ; $4C44: $77
     ld   a, $99                                   ; $4C45: $3E $99
-    call func_2BF                                 ; $4C47: $CD $2F $0B
+    call backupObjectInRAM2                       ; $4C47: $CD $2F $0B
     ld   a, $50                                   ; $4C4A: $3E $50
     ldh  [hIntersectedObjectLeft], a              ; $4C4C: $E0 $CE
     ld   a, $20                                   ; $4C4E: $3E $20

--- a/src/code/entities/19_egg_song_event.asm
+++ b/src/code/entities/19_egg_song_event.asm
@@ -292,12 +292,12 @@ jr_019_4C21:
     ld   a, $C1                                   ; $4C37: $3E $C1
     ld   [hl], a                                  ; $4C39: $77
     ld   a, $99                                   ; $4C3A: $3E $99
-    call backupObjectInRAM2                       ; $4C3C: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $4C3C: $CD $2F $0B
     ld   hl, wRoomObjects + $35                   ; $4C3F: $21 $46 $D7
     ld   a, $CB                                   ; $4C42: $3E $CB
     ld   [hl], a                                  ; $4C44: $77
     ld   a, $99                                   ; $4C45: $3E $99
-    call backupObjectInRAM2                       ; $4C47: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $4C47: $CD $2F $0B
     ld   a, $50                                   ; $4C4A: $3E $50
     ldh  [hIntersectedObjectLeft], a              ; $4C4C: $E0 $CE
     ld   a, $20                                   ; $4C4E: $3E $20

--- a/src/code/entities/19_flying_rooster_events.asm
+++ b/src/code/entities/19_flying_rooster_events.asm
@@ -669,7 +669,7 @@ FlyingRoosterState0Handler::
     ld   hl, wRoomObjects + $45                   ; $521F: $21 $56 $D7
     ld   [hl], $C6                                ; $5222: $36 $C6
     ld   a, $99                                   ; $5224: $3E $99
-    call func_2BF                                 ; $5226: $CD $2F $0B
+    call backupObjectInRAM2                       ; $5226: $CD $2F $0B
     ld   a, $50                                   ; $5229: $3E $50
     ldh  [hIntersectedObjectLeft], a              ; $522B: $E0 $CE
     ld   a, $30                                   ; $522D: $3E $30
@@ -770,11 +770,11 @@ FlyingRoosterState1Handler::
     ld   hl, wRoomObjects + $25                   ; $52CC: $21 $36 $D7
     ld   [hl], $91                                ; $52CF: $36 $91
     ld   a, $99                                   ; $52D1: $3E $99
-    call func_2BF                                 ; $52D3: $CD $2F $0B
+    call backupObjectInRAM2                       ; $52D3: $CD $2F $0B
     ld   hl, wRoomObjects + $35                   ; $52D6: $21 $46 $D7
     ld   [hl], $5E                                ; $52D9: $36 $5E
     ld   a, $99                                   ; $52DB: $3E $99
-    call func_2BF                                 ; $52DD: $CD $2F $0B
+    call backupObjectInRAM2                       ; $52DD: $CD $2F $0B
     ld   a, $50                                   ; $52E0: $3E $50
     ldh  [hIntersectedObjectLeft], a              ; $52E2: $E0 $CE
     ld   a, $20                                   ; $52E4: $3E $20

--- a/src/code/entities/19_flying_rooster_events.asm
+++ b/src/code/entities/19_flying_rooster_events.asm
@@ -669,7 +669,7 @@ FlyingRoosterState0Handler::
     ld   hl, wRoomObjects + $45                   ; $521F: $21 $56 $D7
     ld   [hl], $C6                                ; $5222: $36 $C6
     ld   a, $99                                   ; $5224: $3E $99
-    call backupObjectInRAM2                       ; $5226: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $5226: $CD $2F $0B
     ld   a, $50                                   ; $5229: $3E $50
     ldh  [hIntersectedObjectLeft], a              ; $522B: $E0 $CE
     ld   a, $30                                   ; $522D: $3E $30
@@ -770,11 +770,11 @@ FlyingRoosterState1Handler::
     ld   hl, wRoomObjects + $25                   ; $52CC: $21 $36 $D7
     ld   [hl], $91                                ; $52CF: $36 $91
     ld   a, $99                                   ; $52D1: $3E $99
-    call backupObjectInRAM2                       ; $52D3: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $52D3: $CD $2F $0B
     ld   hl, wRoomObjects + $35                   ; $52D6: $21 $46 $D7
     ld   [hl], $5E                                ; $52D9: $36 $5E
     ld   a, $99                                   ; $52DB: $3E $99
-    call backupObjectInRAM2                       ; $52DD: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $52DD: $CD $2F $0B
     ld   a, $50                                   ; $52E0: $3E $50
     ldh  [hIntersectedObjectLeft], a              ; $52E2: $E0 $CE
     ld   a, $20                                   ; $52E4: $3E $20

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1918,7 +1918,7 @@ func_003_51C9::
     ld   [hl], a                                  ; $51EC: $77
     ld   [wDDD8], a                               ; $51ED: $EA $D8 $DD
     ld   a, $03                                   ; $51F0: $3E $03
-    call func_2BF                                 ; $51F2: $CD $2F $0B
+    call backupObjectInRAM2                       ; $51F2: $CD $2F $0B
 
 label_003_51F5:
     call label_2887                               ; $51F5: $CD $87 $28
@@ -5091,10 +5091,10 @@ func_003_6771::
     ld   [hl+], a                                 ; $67D9: $22
     ld   [hl-], a                                 ; $67DA: $32
     ld   a, $83                                   ; $67DB: $3E $83
-    call func_2BF                                 ; $67DD: $CD $2F $0B
+    call backupObjectInRAM2                       ; $67DD: $CD $2F $0B
     inc  hl                                       ; $67E0: $23
     ld   a, $83                                   ; $67E1: $3E $83
-    call func_2BF                                 ; $67E3: $CD $2F $0B
+    call backupObjectInRAM2                       ; $67E3: $CD $2F $0B
     dec  hl                                       ; $67E6: $2B
     ld   a, l                                     ; $67E7: $7D
     add  $10                                      ; $67E8: $C6 $10
@@ -5104,10 +5104,10 @@ func_003_6771::
     ld   [hl], a                                  ; $67EE: $77
     ld   [wDDD8], a                               ; $67EF: $EA $D8 $DD
     ld   a, $83                                   ; $67F2: $3E $83
-    call func_2BF                                 ; $67F4: $CD $2F $0B
+    call backupObjectInRAM2                       ; $67F4: $CD $2F $0B
     dec  hl                                       ; $67F7: $2B
     ld   a, $83                                   ; $67F8: $3E $83
-    call func_2BF                                 ; $67FA: $CD $2F $0B
+    call backupObjectInRAM2                       ; $67FA: $CD $2F $0B
     inc  hl                                       ; $67FD: $23
     ld   c, $03                                   ; $67FE: $0E $03
     ld   b, $00                                   ; $6800: $06 $00
@@ -5164,7 +5164,7 @@ jr_003_6828:
     ld   [hl], a                                  ; $684F: $77
     ld   [wDDD8], a                               ; $6850: $EA $D8 $DD
     ld   a, $83                                   ; $6853: $3E $83
-    call func_2BF                                 ; $6855: $CD $2F $0B
+    call backupObjectInRAM2                       ; $6855: $CD $2F $0B
 IF __OPTIMIZATIONS_3__
     ld   de, Data_003_674D
     ldh  a, [hIsGBC]

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -1918,7 +1918,7 @@ func_003_51C9::
     ld   [hl], a                                  ; $51EC: $77
     ld   [wDDD8], a                               ; $51ED: $EA $D8 $DD
     ld   a, $03                                   ; $51F0: $3E $03
-    call backupObjectInRAM2                       ; $51F2: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $51F2: $CD $2F $0B
 
 label_003_51F5:
     call label_2887                               ; $51F5: $CD $87 $28
@@ -5091,10 +5091,10 @@ func_003_6771::
     ld   [hl+], a                                 ; $67D9: $22
     ld   [hl-], a                                 ; $67DA: $32
     ld   a, $83                                   ; $67DB: $3E $83
-    call backupObjectInRAM2                       ; $67DD: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $67DD: $CD $2F $0B
     inc  hl                                       ; $67E0: $23
     ld   a, $83                                   ; $67E1: $3E $83
-    call backupObjectInRAM2                       ; $67E3: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $67E3: $CD $2F $0B
     dec  hl                                       ; $67E6: $2B
     ld   a, l                                     ; $67E7: $7D
     add  $10                                      ; $67E8: $C6 $10
@@ -5104,10 +5104,10 @@ func_003_6771::
     ld   [hl], a                                  ; $67EE: $77
     ld   [wDDD8], a                               ; $67EF: $EA $D8 $DD
     ld   a, $83                                   ; $67F2: $3E $83
-    call backupObjectInRAM2                       ; $67F4: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $67F4: $CD $2F $0B
     dec  hl                                       ; $67F7: $2B
     ld   a, $83                                   ; $67F8: $3E $83
-    call backupObjectInRAM2                       ; $67FA: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $67FA: $CD $2F $0B
     inc  hl                                       ; $67FD: $23
     ld   c, $03                                   ; $67FE: $0E $03
     ld   b, $00                                   ; $6800: $06 $00
@@ -5164,7 +5164,7 @@ jr_003_6828:
     ld   [hl], a                                  ; $684F: $77
     ld   [wDDD8], a                               ; $6850: $EA $D8 $DD
     ld   a, $83                                   ; $6853: $3E $83
-    call backupObjectInRAM2                       ; $6855: $CD $2F $0B
+    call BackupObjectInRAM2                       ; $6855: $CD $2F $0B
 IF __OPTIMIZATIONS_3__
     ld   de, Data_003_674D
     ldh  a, [hIsGBC]


### PR DESCRIPTION
If you modify an overworld object, like digging a hole, and don't call this, the hole is visually gone after opening and closing the inventory.

I haven't looked into the specifics why that is. I think it might be that it is storing "overrides" at bank 2. And after exiting the inventory menu it just restores the room overlay and then applies the overrides. But that is just guessing.