### PR TITLE
Better document the tile glint puzzle

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -2600,7 +2600,7 @@ DisplayTransientVfxForLinkRunning::
     cp   GROUND_VFX_SHALLOW_WATER                 ; $176E: $FE $05
     jr   z, .shallowWater                         ; $1770: $28 $0F
 
-    ld   a, NOISE_SFX_FOOTSTEP                        ; $1772: $3E $07
+    ld   a, NOISE_SFX_FOOTSTEP                    ; $1772: $3E $07
     ldh  [hNoiseSfx], a                           ; $1774: $E0 $F4
     ldh  a, [hLinkPositionY]                      ; $1776: $F0 $99
     add  a, $06                                   ; $1778: $C6 $06

--- a/src/code/entities/18_manbo_and_fishes.asm
+++ b/src/code/entities/18_manbo_and_fishes.asm
@@ -107,7 +107,7 @@ ManboAndFishesSingHandler::
     and  a                                        ; $4595: $A7
     jr   nz, ret_018_45B6                         ; $4596: $20 $1E
 
-    ld   a, MUSIC_MANBOS_MAMBO                     ; $4598: $3E $30
+    ld   a, MUSIC_MANBOS_MAMBO                    ; $4598: $3E $30
     ld   [wMusicTrackToPlay], a                   ; $459A: $EA $68 $D3
     call IncrementEntityState                     ; $459D: $CD $12 $3B
 

--- a/src/code/entities/bank3.asm
+++ b/src/code/entities/bank3.asm
@@ -7150,7 +7150,7 @@ jr_003_7304:
 .openBossDefeatedDialog
     ld   a, e                                     ; $7325: $7B
     call OpenDialogInTable0                       ; $7326: $CD $85 $23
-    ld   a, MUSIC_BOSS_DEFEAT                    ; $7329: $3E $5E
+    ld   a, MUSIC_BOSS_DEFEAT                     ; $7329: $3E $5E
     ld   [wMusicTrackToPlay], a                   ; $732B: $EA $68 $D3
     jr   jr_003_733E                              ; $732E: $18 $0E
 

--- a/src/code/entities/bank36.asm
+++ b/src/code/entities/bank36.asm
@@ -7857,7 +7857,7 @@ jr_036_6E3F:
 
     ld   hl, wEntitiesInertiaTable                ; $6E57: $21 $D0 $C3
     add  hl, bc                                   ; $6E5A: $09
-    ldh  a, [hTileGlintAnimation]                 ; $6E5B: $F0 $B9
+    ldh  a, [hTileGlintSequence]                  ; $6E5B: $F0 $B9
     ld   e, a                                     ; $6E5D: $5F
     sla  a                                        ; $6E5E: $CB $27
     sla  a                                        ; $6E60: $CB $27

--- a/src/code/world_handler.asm
+++ b/src/code/world_handler.asm
@@ -152,7 +152,7 @@ ENDC
     ld   hl, hFrameCounter                        ; $441C: $21 $E7 $FF
     or   [hl]                                     ; $441F: $B6
     and  $03                                      ; $4420: $E6 $03
-    ldh  [hTileGlintAnimation], a                 ; $4422: $E0 $B9
+    ldh  [hTileGlintSequence], a                  ; $4422: $E0 $B9
 
     ret                                           ; $4424: $C9
 

--- a/src/code/world_handler.asm
+++ b/src/code/world_handler.asm
@@ -148,6 +148,8 @@ ENDC
     ld   a, TILEMAP_INVENTORY                     ; $4414: $3E $02
     ld   [wBGMapToLoad], a                        ; $4416: $EA $FF $D6
 
+    ; Every time the inventory is opened in the overworld, the D4 glint puzzle solution changes.
+    ; (This ensures the puzzle is random, but doesn't change while inside the dungeon.)
     call GetRandomByte                            ; $4419: $CD $0D $28
     ld   hl, hFrameCounter                        ; $441C: $21 $E7 $FF
     or   [hl]                                     ; $441F: $B6

--- a/src/constants/memory/hram.asm
+++ b/src/constants/memory/hram.asm
@@ -249,8 +249,9 @@ hLinkCountdown::
 hObjectUnderLink::
   ds 1 ; FFB8
 
-; Animation frame of the glinting tiles in D4?
-hTileGlintAnimation::
+; There are 4 different sequences in D4 that the tile glint puzzle can take,
+; this variable indicates which one is active.
+hTileGlintSequence::
   ds 1 ; FFB9
 
 ; State of a pull switch used to move blocks


### PR DESCRIPTION
Following a remark of @daid about the misnaming of `hTileGlintAnimation`, this PR:

- Renames `hTileGlintAnimation` to `hTileGlintSequence`
- Better document the code of the associated entities