### PR TITLE
Allow building with out-of-tree RGBDS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@
 # Dev tools binaries and options
 #
 
-2BPP    := rgbgfx
+RGBDS   :=
 
-ASM     := rgbasm
+2BPP    := $(RGBDS)rgbgfx
+
+ASM     := $(RGBDS)rgbasm
 
 # Get assembler version
 ASMVER    := $(shell $(ASM) --version | cut -f2 -dv)
@@ -41,10 +43,10 @@ ifeq ($(shell expr \
     --nop-after-halt
 endif
 
-LD      := rgblink
+LD      := $(RGBDS)rgblink
 LDFLAGS :=
 
-FX      := rgbfix
+FX      := $(RGBDS)rgbfix
 FXFLAGS := \
   --color-compatible \
   --sgb-compatible \


### PR DESCRIPTION
This allows you to do `make RGBDS=path/to/rgbds/` to use a non-default build of the RGBDS tools. That would let rgbds itself build LADX in its test suite, using the latest RGBDS `master` version. (An `RGBDS=dir/` variable is a convention followed by other projects, including pret's disassemblies.)