### PR TITLE
Use explicit `ldh` and `halt+nop` instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ RGBDS   :=
 2BPP    := $(RGBDS)rgbgfx
 
 ASM     := $(RGBDS)rgbasm
+ASFLAGS := \
+  --export-all\
+  --halt-without-nop\
+  --preserve-ld
 
 # Get assembler version
 ASMVER    := $(shell $(ASM) --version | cut -f2 -dv)
@@ -26,21 +30,6 @@ ifneq ($(MAKECMDGOALS), "clean")
   ), 1)
     $(error Requires RGBDS version >= 0.5.0)
   endif
-endif
-
-ASFLAGS := --export-all
-
-# If we're using RGBDS >= 0.6.0, add flags to force behavior that used to be default
-ifeq ($(shell expr \
-  \( $(ASMVERMAJ) \> 0 \) \|\
-  \(\
-    \( $(ASMVERMAJ) = 0 \) \&\
-    \( $(ASMVERMIN) \> 5 \)\
-  \)\
-), 1)
-  ASFLAGS += \
-    --auto-ldh\
-    --nop-after-halt
 endif
 
 LD      := $(RGBDS)rgblink

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -385,15 +385,15 @@ CopyDataToVRAM::
     ; On CGB, configure a GDMA transfer
     ; to copy $0F bytes from "${b}00" to "$8000 + ${c}00"
     ld   a, b                                     ; $0A1B: $78
-    ld   [rHDMA1], a                              ; $0A1C: $E0 $51
+    ldh  [rHDMA1], a                              ; $0A1C: $E0 $51
     ld   a, $00                                   ; $0A1E: $3E $00
-    ld   [rHDMA2], a                              ; $0A20: $E0 $52
+    ldh  [rHDMA2], a                              ; $0A20: $E0 $52
     ld   a, c                                     ; $0A22: $79
-    ld   [rHDMA3], a                              ; $0A23: $E0 $53
+    ldh  [rHDMA3], a                              ; $0A23: $E0 $53
     ld   a, $00                                   ; $0A25: $3E $00
-    ld   [rHDMA4], a                              ; $0A27: $E0 $54
+    ldh  [rHDMA4], a                              ; $0A27: $E0 $54
     ld   a, $0F                                   ; $0A29: $3E $0F
-    ld   [rHDMA5], a                              ; $0A2B: $E0 $55
+    ldh  [rHDMA5], a                              ; $0A2B: $E0 $55
 
     ; Fallthrough to switch back to the bank in h
 .restoreBankAndReturn
@@ -543,10 +543,10 @@ CopyObjectsAttributesToWRAM2::
     ldh  a, [hMultiPurpose0]                      ; $0B1A: $F0 $D7
     ld   [rSelectROMBank], a                      ; $0B1C: $EA $00 $21
     ld   a, $02                                   ; $0B1F: $3E $02
-    ld   [rSVBK], a                               ; $0B21: $E0 $70
+    ldh  [rSVBK], a                               ; $0B21: $E0 $70
     call CopyData                                 ; $0B23: $CD $14 $29
     xor  a                                        ; $0B26: $AF
-    ld   [rSVBK], a                               ; $0B27: $E0 $70
+    ldh  [rSVBK], a                               ; $0B27: $E0 $70
     ; Restore bank $20
     ld   a, $20                                   ; $0B29: $3E $20
     ld   [rSelectROMBank], a                      ; $0B2B: $EA $00 $21
@@ -581,10 +581,10 @@ BackupObjectInRAM2::
 .else
     ld   b, [hl]                                  ; $0B4B: $46
     ld   a, $02                                   ; $0B4C: $3E $02
-    ld   [rSVBK], a                               ; $0B4E: $E0 $70
+    ldh  [rSVBK], a                               ; $0B4E: $E0 $70
     ld   [hl], b                                  ; $0B50: $70
     xor  a                                        ; $0B51: $AF
-    ld   [rSVBK], a                               ; $0B52: $E0 $70
+    ldh  [rSVBK], a                               ; $0B52: $E0 $70
 .endIf
 
     ldh  a, [hMultiPurpose2]                      ; $0B54: $F0 $D9
@@ -619,11 +619,11 @@ CopyBGMapFromBank::
     add  hl, de                                   ; $0B75: $19
     ; Switch to VRAM bank 1
     ld   a, $01                                   ; $0B76: $3E $01
-    ld   [rVBK], a                                ; $0B78: $E0 $4F
+    ldh  [rVBK], a                                ; $0B78: $E0 $4F
     call CopyToBGMap0                             ; $0B7A: $CD $96 $0B
     ; Switch back to VRAM bank 0
     xor  a                                        ; $0B7D: $AF
-    ld   [rVBK], a                                ; $0B7E: $E0 $4F
+    ldh  [rVBK], a                                ; $0B7E: $E0 $4F
 .gbcEnd
 
     pop  hl                                       ; $0B80: $E1
@@ -4042,12 +4042,12 @@ DoUpdateBGRegion::
     jr   nz, .ramSwitchEnd                        ; $2258: $20 $08
     ; Switch to RAM Bank 2,
     ld   a, $02                                   ; $225A: $3E $02
-    ld   [rSVBK], a                               ; $225C: $E0 $70
+    ldh  [rSVBK], a                               ; $225C: $E0 $70
     ; read the object value,
     ld   c, [hl]                                  ; $225E: $4E
     ; switch back to RAM Bank 0.
     xor  a                                        ; $225F: $AF
-    ld   [rSVBK], a                               ; $2260: $E0 $70
+    ldh  [rSVBK], a                               ; $2260: $E0 $70
 .ramSwitchEnd
 
     ; bc = bc * 4
@@ -4307,22 +4307,22 @@ ReadJoypadState::
 
 .readState
     ld   a, J_BUTTONS                             ; $2852: $3E $20
-    ld   [rP1], a                                 ; $2854: $E0 $00
-    ld   a, [rP1]                                 ; $2856: $F0 $00
-    ld   a, [rP1]                                 ; $2858: $F0 $00
+    ldh  [rP1], a                                 ; $2854: $E0 $00
+    ldh  a, [rP1]                                 ; $2856: $F0 $00
+    ldh  a, [rP1]                                 ; $2858: $F0 $00
     cpl                                           ; $285A: $2F
     and  $0F                                      ; $285B: $E6 $0F
     ld   b, a                                     ; $285D: $47
     ld   a, J_DPAD                                ; $285E: $3E $10
-    ld   [rP1], a                                 ; $2860: $E0 $00
-    ld   a, [rP1]                                 ; $2862: $F0 $00
-    ld   a, [rP1]                                 ; $2864: $F0 $00
-    ld   a, [rP1]                                 ; $2866: $F0 $00
-    ld   a, [rP1]                                 ; $2868: $F0 $00
-    ld   a, [rP1]                                 ; $286A: $F0 $00
-    ld   a, [rP1]                                 ; $286C: $F0 $00
-    ld   a, [rP1]                                 ; $286E: $F0 $00
-    ld   a, [rP1]                                 ; $2870: $F0 $00
+    ldh  [rP1], a                                 ; $2860: $E0 $00
+    ldh  a, [rP1]                                 ; $2862: $F0 $00
+    ldh  a, [rP1]                                 ; $2864: $F0 $00
+    ldh  a, [rP1]                                 ; $2866: $F0 $00
+    ldh  a, [rP1]                                 ; $2868: $F0 $00
+    ldh  a, [rP1]                                 ; $286A: $F0 $00
+    ldh  a, [rP1]                                 ; $286C: $F0 $00
+    ldh  a, [rP1]                                 ; $286E: $F0 $00
+    ldh  a, [rP1]                                 ; $2870: $F0 $00
     swap a                                        ; $2872: $CB $37
     cpl                                           ; $2874: $2F
     and  $F0                                      ; $2875: $E6 $F0
@@ -4335,7 +4335,7 @@ ReadJoypadState::
     ld   a, c                                     ; $287F: $79
     ldh  [hPressedButtonsMask], a                 ; $2880: $E0 $CB
     ld   a, J_BUTTONS | J_DPAD                    ; $2882: $3E $30
-    ld   [rP1], a                                 ; $2884: $E0 $00
+    ldh  [rP1], a                                 ; $2884: $E0 $00
 
 .return
     ret                                           ; $2886: $C9
@@ -4415,26 +4415,26 @@ TableJump::
 ; Turn off LCD at next vertical blanking
 LCDOff::
     ; Save interrupts configuration
-    ld   a, [rIE]                                 ; $28CF: $F0 $FF
+    ldh  a, [rIE]                                 ; $28CF: $F0 $FF
     ldh  [hInterrupts], a                         ; $28D1: $E0 $D2
     ; Disable VBlank interrupt
     res  IEB_VBLANK, a                            ; $28D3: $CB $87
-    ld   [rIE], a                                 ; $28D5: $E0 $FF
+    ldh  [rIE], a                                 ; $28D5: $E0 $FF
 
     ; Wait for row 145
 .waitForEndOfLine
-    ld   a, [rLY]                                 ; $28D7: $F0 $44
+    ldh  a, [rLY]                                 ; $28D7: $F0 $44
     cp   SCRN_Y + 1                               ; $28D9: $FE $91
     jr   nz, .waitForEndOfLine                    ; $28DB: $20 $FA
 
     ; Switch off LCD screen
-    ld   a, [rLCDC]                               ; $28DD: $F0 $40
+    ldh  a, [rLCDC]                               ; $28DD: $F0 $40
     and  ~LCDCF_ON                                ; $28DF: $E6 $7F
-    ld   [rLCDC], a                               ; $28E1: $E0 $40
+    ldh  [rLCDC], a                               ; $28E1: $E0 $40
 
     ; Restore interrupts configuration
     ldh  a, [hInterrupts]                         ; $28E3: $F0 $D2
-    ld   [rIE], a                                 ; $28E5: $E0 $FF
+    ldh  [rIE], a                                 ; $28E5: $E0 $FF
 
     ret                                           ; $28E7: $C9
 
@@ -5538,12 +5538,12 @@ WriteObjectToBG_DMG::
 WriteOverworldObjectToBG::
     ; Switch to RAM bank 2 (object attributes?)
     ld   a, $02                                   ; $300E: $3E $02
-    ld   [rSVBK], a                               ; $3010: $E0 $70
+    ldh  [rSVBK], a                               ; $3010: $E0 $70
     ; ObjectAttributeValue = [hl]
     ld   c, [hl]                                  ; $3012: $4E
     ; Switch back to RAM bank 0
     xor  a                                        ; $3013: $AF
-    ld   [rSVBK], a                               ; $3014: $E0 $70
+    ldh  [rSVBK], a                               ; $3014: $E0 $70
     jr   doCopyObjectToBG                         ; $3016: $18 $01
 
 ; Given an indoor object, retrieve its tiles indices and palettes (2x2),
@@ -5614,12 +5614,12 @@ doCopyObjectToBG:
     ldh  a, [hMultiPurposeA]                      ; $305E: $F0 $E1
     ld   l, a                                     ; $3060: $6F
     ld   a, $01                                   ; $3061: $3E $01
-    ld   [rVBK], a                                ; $3063: $E0 $4F
+    ldh  [rVBK], a                                ; $3063: $E0 $4F
     call CopyWord                                 ; $3065: $CD $C7 $2F
 
     ; Restore RAM and ROM banks
     xor  a                                        ; $3068: $AF
-    ld   [rVBK], a                                ; $3069: $E0 $4F
+    ldh  [rVBK], a                                ; $3069: $E0 $4F
     call SwitchToObjectsTilemapBank               ; $306B: $CD $05 $39
 
     ; Update palette offset
@@ -5650,12 +5650,12 @@ doCopyObjectToBG:
     ldh  a, [hMultiPurposeA]                      ; $308A: $F0 $E1
     ld   l, a                                     ; $308C: $6F
     ld   a, $01                                   ; $308D: $3E $01
-    ld   [rVBK], a                                ; $308F: $E0 $4F
+    ldh  [rVBK], a                                ; $308F: $E0 $4F
     call CopyWord                                 ; $3091: $CD $C7 $2F
 
     ; Restore RAM and ROM banks
     xor  a                                        ; $3094: $AF
-    ld   [rVBK], a                                ; $3095: $E0 $4F
+    ldh  [rVBK], a                                ; $3095: $E0 $4F
     call SwitchToObjectsTilemapBank               ; $3097: $CD $05 $39
 
     ret                                           ; $309A: $C9
@@ -5747,7 +5747,7 @@ ASSERT LOW(wRoomObjectsArea) & $0F == 0, "wRoomObjectsArea must be aligned on $1
 LoadRoom::
     ; Disable all interrupts except VBlank
     ld   a, IEF_VBLANK                            ; $30F4: $3E $01
-    ld   [rIE], a                                 ; $30F6: $E0 $FF
+    ldh  [rIE], a                                 ; $30F6: $E0 $FF
 
     ; Increment wD47F
     ld   hl, wD47F                                ; $30F8: $21 $7F $D4

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -768,10 +768,10 @@ FileSaveFadeOut::
 
 .loop_583A
     ld   a, $03                                   ; $583A: $3E $03
-    ld   [rSVBK], a                               ; $583C: $E0 $70
+    ldh  [rSVBK], a                               ; $583C: $E0 $70
     ld   b, [hl]                                  ; $583E: $46
     dec  a                                        ; $583F: $3D
-    ld   [rSVBK], a                               ; $5840: $E0 $70
+    ldh  [rSVBK], a                               ; $5840: $E0 $70
     ld   [hl], b                                  ; $5842: $70
     inc  hl                                       ; $5843: $23
     dec  c                                        ; $5844: $0D
@@ -779,10 +779,10 @@ FileSaveFadeOut::
     and  a                                        ; $5846: $A7
     jr   nz, .loop_583A                           ; $5847: $20 $F1
     ld   a, $03                                   ; $5849: $3E $03
-    ld   [rSVBK], a                               ; $584B: $E0 $70
+    ldh  [rSVBK], a                               ; $584B: $E0 $70
     xor  a                                        ; $584D: $AF
     ld   [wIsFileSelectionArrowShifted], a        ; $584E: $EA $00 $D0
-    ld   [rSVBK], a                               ; $5851: $E0 $70
+    ldh  [rSVBK], a                               ; $5851: $E0 $70
     ei                                            ; $5853: $FB
 
 jr_001_5854::
@@ -829,7 +829,7 @@ InitializeInventoryBar::
     ld   a, $80                                   ; $5895: $3E $80
     ld   [wWindowY], a                            ; $5897: $EA $9A $DB
     ld   a, $07                                   ; $589A: $3E $07
-    ld   [rWX], a                                 ; $589C: $E0 $4B
+    ldh  [rWX], a                                 ; $589C: $E0 $4B
     ; Set wSubscreenScrollIncrement to be $08 (closing/closed), so it's
     ; ready to be flipped to $F8 if inventory is opened
     ld   a, $08                                   ; $589E: $3E $08
@@ -2384,9 +2384,9 @@ func_001_6162::
     ld   [wOBJ0Palette], a                        ; $616C: $EA $98 $DB
     ld   [wOBJ1Palette], a                        ; $616F: $EA $99 $DB
     ld   [wBGPalette], a                          ; $6172: $EA $97 $DB
-    ld   [rBGP], a                                ; $6175: $E0 $47
-    ld   [rOBP0], a                               ; $6177: $E0 $48
-    ld   [rOBP1], a                               ; $6179: $E0 $49
+    ldh  [rBGP], a                                ; $6175: $E0 $47
+    ldh  [rOBP0], a                               ; $6177: $E0 $48
+    ldh  [rOBP1], a                               ; $6179: $E0 $49
     ldh  [hBaseScrollY], a                        ; $617B: $E0 $97
     ldh  [hBaseScrollX], a                        ; $617D: $E0 $96
     ld   [wSwitchBlocksState], a                  ; $617F: $EA $FB $D6
@@ -2482,10 +2482,10 @@ PeachPictureState0Handler::
 
 .loop_6816
     xor  a                                        ; $6816: $AF
-    ld   [rSVBK], a                               ; $6817: $E0 $70
+    ldh  [rSVBK], a                               ; $6817: $E0 $70
     ld   b, [hl]                                  ; $6819: $46
     ld   a, $03                                   ; $681A: $3E $03
-    ld   [rSVBK], a                               ; $681C: $E0 $70
+    ldh  [rSVBK], a                               ; $681C: $E0 $70
     ld   [hl], b                                  ; $681E: $70
     inc  hl                                       ; $681F: $23
     dec  c                                        ; $6820: $0D
@@ -2493,7 +2493,7 @@ PeachPictureState0Handler::
     and  a                                        ; $6822: $A7
     jr   nz, .loop_6816                           ; $6823: $20 $F1
     xor  a                                        ; $6825: $AF
-    ld   [rSVBK], a                               ; $6826: $E0 $70
+    ldh  [rSVBK], a                               ; $6826: $E0 $70
     ei                                            ; $6828: $FB
 
 PeachPictureState1Handler::
@@ -3147,7 +3147,7 @@ func_001_6D11::
 
 .jr_6D1C::
     ld   a, $01                                   ; $6D1C: $3E $01
-    ld   [rVBK], a                                ; $6D1E: $E0 $4F
+    ldh  [rVBK], a                                ; $6D1E: $E0 $4F
     ld   hl, vBGMap0                              ; $6D20: $21 $00 $98
     ld   bc, $400                                 ; $6D23: $01 $00 $04
 
@@ -3159,7 +3159,7 @@ func_001_6D11::
     or   c                                        ; $6D2A: $B1
     jr   nz, .loop_6D26                           ; $6D2B: $20 $F9
     ld   a, $00                                   ; $6D2D: $3E $00
-    ld   [rVBK], a                                ; $6D2F: $E0 $4F
+    ldh  [rVBK], a                                ; $6D2F: $E0 $4F
     ret                                           ; $6D31: $C9
 
 include "code/oam_dma.asm"

--- a/src/code/bank2.asm
+++ b/src/code/bank2.asm
@@ -2055,10 +2055,10 @@ func_002_4DFC::
     ; Copy 8 bytes from 01:DC50 to 02:DC50
 .loop
     xor  a                                        ; $4E04: $AF
-    ld   [rSVBK], a                               ; $4E05: $E0 $70
+    ldh  [rSVBK], a                               ; $4E05: $E0 $70
     ld   b, [hl]                                  ; $4E07: $46
     ld   a, $02                                   ; $4E08: $3E $02
-    ld   [rSVBK], a                               ; $4E0A: $E0 $70
+    ldh  [rSVBK], a                               ; $4E0A: $E0 $70
     ld   a, b                                     ; $4E0C: $78
     ld   [hl], a                                  ; $4E0D: $77
     inc  hl                                       ; $4E0E: $23
@@ -2068,7 +2068,7 @@ func_002_4DFC::
     jr   c, .loop                                 ; $4E13: $38 $EF
 
     xor  a                                        ; $4E15: $AF
-    ld   [rSVBK], a                               ; $4E16: $E0 $70
+    ldh  [rSVBK], a                               ; $4E16: $E0 $70
     ei                                            ; $4E18: $FB
     pop  de                                       ; $4E19: $D1
     pop  bc                                       ; $4E1A: $C1
@@ -6251,7 +6251,7 @@ CheckPositionForMapTransition::
     ; … reset scrollX to zero.
     xor  a                                        ; $6DDE: $AF
     ld   [wScrollXOffset], a                      ; $6DDF: $EA $BF $C1
-    ld   [rSCX], a                                ; $6DE2: $E0 $43
+    ldh  [rSCX], a                                ; $6DE2: $E0 $43
 .eagleTowerBossEnd
 
     ;

--- a/src/code/bank20.asm
+++ b/src/code/bank20.asm
@@ -578,7 +578,7 @@ func_020_4856::
 
     di                                            ; $4858: $F3
     ld   a, $05                                   ; $4859: $3E $05
-    ld   [rSVBK], a                               ; $485B: $E0 $70
+    ldh  [rSVBK], a                               ; $485B: $E0 $70
     ld   hl, wIsFileSelectionArrowShifted         ; $485D: $21 $00 $D0
 
 .loop
@@ -736,12 +736,12 @@ func_020_4923::
     ld   [wAddRupeeBufferLow], a                  ; $492E: $EA $90 $DB
     di                                            ; $4931: $F3
     ld   a, $05                                   ; $4932: $3E $05
-    ld   [rSVBK], a                               ; $4934: $E0 $70
+    ldh  [rSVBK], a                               ; $4934: $E0 $70
     ld   hl, wD011                                ; $4936: $21 $11 $D0
     add  hl, de                                   ; $4939: $19
     ld   [hl], a                                  ; $493A: $77
     xor  a                                        ; $493B: $AF
-    ld   [rSVBK], a                               ; $493C: $E0 $70
+    ldh  [rSVBK], a                               ; $493C: $E0 $70
     ei                                            ; $493E: $FB
     call label_2887                               ; $493F: $CD $87 $28
     push bc                                       ; $4942: $C5
@@ -4469,7 +4469,7 @@ jr_020_6628:
     ld   a, $80                                   ; $6638: $3E $80
     ld   [wWindowY], a                            ; $663A: $EA $9A $DB
     ld   a, $07                                   ; $663D: $3E $07
-    ld   [rWX], a                                 ; $663F: $E0 $4B
+    ldh  [rWX], a                                 ; $663F: $E0 $4B
     ld   a, $08                                   ; $6641: $3E $08
     ld   [wSubscreenScrollIncrement], a           ; $6643: $EA $50 $C1
     ld   a, $07                                   ; $6646: $3E $07
@@ -4486,10 +4486,10 @@ jr_020_6628:
 
 .loop_6659
     ld   a, $03                                   ; $6659: $3E $03
-    ld   [rSVBK], a                               ; $665B: $E0 $70
+    ldh  [rSVBK], a                               ; $665B: $E0 $70
     ld   b, [hl]                                  ; $665D: $46
     dec  a                                        ; $665E: $3D
-    ld   [rSVBK], a                               ; $665F: $E0 $70
+    ldh  [rSVBK], a                               ; $665F: $E0 $70
     ld   [hl], b                                  ; $6661: $70
     inc  hl                                       ; $6662: $23
     dec  c                                        ; $6663: $0D
@@ -4498,10 +4498,10 @@ jr_020_6628:
     jr   nz, .loop_6659                           ; $6666: $20 $F1
 
     xor  a                                        ; $6668: $AF
-    ld   [rSVBK], a                               ; $6669: $E0 $70
+    ldh  [rSVBK], a                               ; $6669: $E0 $70
     ld   a, [wLCDControl]                         ; $666B: $FA $FD $D6
     and  ~LCDCF_ON                                ; $666E: $E6 $7F
-    ld   [rLCDC], a                               ; $6670: $E0 $40
+    ldh  [rLCDC], a                               ; $6670: $E0 $40
     ldh  a, [hMapId]                              ; $6672: $F0 $F7
     cp   MAP_COLOR_DUNGEON                        ; $6674: $FE $FF
     jr   nz, .jr_667C                             ; $6676: $20 $04
@@ -4511,7 +4511,7 @@ jr_020_6628:
 
 .jr_667C
     ld   a, [wLCDControl]                         ; $667C: $FA $FD $D6
-    ld   [rLCDC], a                               ; $667F: $E0 $40
+    ldh  [rLCDC], a                               ; $667F: $E0 $40
     ei                                            ; $6681: $FB
 
 label_020_6682:

--- a/src/code/dialog_letters.asm
+++ b/src/code/dialog_letters.asm
@@ -256,11 +256,11 @@ AnimateDialogClosingAttrs::
     ld   e, $12                                   ; $4B16: $1E $12
 .loop_4B18_1C
     ld   a, $02                                   ; $4B18: $3E $02
-    ld   [rSVBK], a                               ; $4B1A: $E0 $70
+    ldh  [rSVBK], a                               ; $4B1A: $E0 $70
     ld   a, [bc]                                  ; $4B1C: $0A
     ld   d, a                                     ; $4B1D: $57
     xor  a                                        ; $4B1E: $AF
-    ld   [rSVBK], a                               ; $4B1F: $E0 $70
+    ldh  [rSVBK], a                               ; $4B1F: $E0 $70
     ld   a, d                                     ; $4B21: $7A
     ldi  [hl], a                                  ; $4B22: $22
     inc  bc                                       ; $4B23: $03

--- a/src/code/face_shrine_mural.asm
+++ b/src/code/face_shrine_mural.asm
@@ -24,10 +24,10 @@ FaceShrineMuralStage0Handler::
 
 .loop_6B18
     xor  a                                        ; $6B18: $AF
-    ld   [rSVBK], a                               ; $6B19: $E0 $70
+    ldh  [rSVBK], a                               ; $6B19: $E0 $70
     ld   b, [hl]                                  ; $6B1B: $46
     ld   a, $03                                   ; $6B1C: $3E $03
-    ld   [rSVBK], a                               ; $6B1E: $E0 $70
+    ldh  [rSVBK], a                               ; $6B1E: $E0 $70
     ld   [hl], b                                  ; $6B20: $70
     inc  hl                                       ; $6B21: $23
     dec  c                                        ; $6B22: $0D
@@ -35,7 +35,7 @@ FaceShrineMuralStage0Handler::
     and  a                                        ; $6B24: $A7
     jr   nz, .loop_6B18                           ; $6B25: $20 $F1
     xor  a                                        ; $6B27: $AF
-    ld   [rSVBK], a                               ; $6B28: $E0 $70
+    ldh  [rSVBK], a                               ; $6B28: $E0 $70
     ei                                            ; $6B2A: $FB
 
 FaceShrineMuralStage1Handler::

--- a/src/code/file_save_screen.asm
+++ b/src/code/file_save_screen.asm
@@ -32,7 +32,7 @@ FileSaveInitial::
 
     ; Select WRAM Bank 3
     ld   a, $03                                   ; $4020: $3E $03
-    ld   [rSVBK], a                               ; $4022: $E0 $70
+    ldh  [rSVBK], a                               ; $4022: $E0 $70
 
     ; If wIsFileSelectionArrowShifted == 0...
     ld   a, [wIsFileSelectionArrowShifted]        ; $4024: $FA $00 $D0
@@ -43,12 +43,12 @@ FileSaveInitial::
 .loop
     ; Switch to WRAM bank 0
     xor  a                                        ; $402A: $AF
-    ld   [rSVBK], a                               ; $402B: $E0 $70
+    ldh  [rSVBK], a                               ; $402B: $E0 $70
     ; Read a byte
     ld   b, [hl]                                  ; $402D: $46
     ; Switch to WRAM bank 3
     ld   a, $03                                   ; $402E: $3E $03
-    ld   [rSVBK], a                               ; $4030: $E0 $70
+    ldh  [rSVBK], a                               ; $4030: $E0 $70
     ; Write a byte
     ld   [hl], b                                  ; $4032: $70
     ; Increment the pointer, and loop until done.
@@ -65,7 +65,7 @@ FileSaveInitial::
 .done
     ; Switch back to WRAM bank 0
     xor  a                                        ; $403E: $AF
-    ld   [rSVBK], a                               ; $403F: $E0 $70
+    ldh  [rSVBK], a                               ; $403F: $E0 $70
     ; Enable interrupts
     ei                                            ; $4041: $FB
 
@@ -153,10 +153,10 @@ label_40D6::
     xor  a                                        ; $40D6: $AF
     ld   [wOBJ0Palette], a                        ; $40D7: $EA $98 $DB
     ld   [wOBJ1Palette], a                        ; $40DA: $EA $99 $DB
-    ld   [rOBP0], a                               ; $40DD: $E0 $48
-    ld   [rOBP1], a                               ; $40DF: $E0 $49
+    ldh  [rOBP0], a                               ; $40DD: $E0 $48
+    ldh  [rOBP1], a                               ; $40DF: $E0 $49
     ld   [wBGPalette], a                          ; $40E1: $EA $97 $DB
-    ld   [rBGP], a                                ; $40E4: $E0 $47
+    ldh  [rBGP], a                                ; $40E4: $E0 $47
     ldh  a, [hLinkPositionX]                      ; $40E6: $F0 $98
     ld   [wMapEntrancePositionX], a               ; $40E8: $EA $9D $DB
     ldh  a, [hLinkPositionY]                      ; $40EB: $F0 $99
@@ -192,17 +192,17 @@ LCDOn::
     ;   Bit 1: Sprite displayed enabled
     ;   Bit 0: Background display enabled
     ld   a, LCDCF_ON | LCDCF_WIN9C00 | LCDCF_OBJ16 | LCDCF_OBJON | LCDCF_BGON ; $410D: $3E $C7
-    ld   [rLCDC], a                               ; $410F: $E0 $40
+    ldh  [rLCDC], a                               ; $410F: $E0 $40
     ld   [wLCDControl], a                         ; $4111: $EA $FD $D6
 
     ; Set Window X position
     ld   a, $07                                   ; $4114: $3E $07
-    ld   [rWX], a                                 ; $4116: $E0 $4B
+    ldh  [rWX], a                                 ; $4116: $E0 $4B
 
     ; Set Window Y position (inventory status bar)
     ld   a, $80                                   ; $4118: $3E $80
     ld   [wWindowY], a                            ; $411A: $EA $9A $DB
-    ld   [rWY], a                                 ; $411D: $E0 $4A
+    ldh  [rWY], a                                 ; $411D: $E0 $4A
 
     ; Configure volume
     ld   a, $07                                   ; $411F: $3E $07
@@ -250,7 +250,7 @@ func_001_412A::
 
 .wait1
     xor  a                                        ; $4158: $AF
-    ld   [rBGP], a                                ; $4159: $E0 $47
+    ldh  [rBGP], a                                ; $4159: $E0 $47
     nop                                           ; $415B: $00
     nop                                           ; $415C: $00
     nop                                           ; $415D: $00
@@ -287,21 +287,21 @@ func_001_412A::
 
 .loop1
     ld   a, $40                                   ; $417E: $3E $40
-    ld   [rBGP], a                                ; $4180: $E0 $47
+    ldh  [rBGP], a                                ; $4180: $E0 $47
     dec  e                                        ; $4182: $1D
     jr   nz, .loop1                               ; $4183: $20 $F9
     ld   e, $30                                   ; $4185: $1E $30
 
 .loop2
     ld   a, $80                                   ; $4187: $3E $80
-    ld   [rBGP], a                                ; $4189: $E0 $47
+    ldh  [rBGP], a                                ; $4189: $E0 $47
     dec  e                                        ; $418B: $1D
     jr   nz, .loop2                               ; $418C: $20 $F9
     ld   e, $FF                                   ; $418E: $1E $FF
 
 .wait2
     ld   a, $C0                                   ; $4190: $3E $C0
-    ld   [rBGP], a                                ; $4192: $E0 $47
+    ldh  [rBGP], a                                ; $4192: $E0 $47
     nop                                           ; $4194: $00
     nop                                           ; $4195: $00
     nop                                           ; $4196: $00
@@ -326,19 +326,19 @@ func_001_412A::
 
 .loop3
     ld   a, $80                                   ; $41AB: $3E $80
-    ld   [rBGP], a                                ; $41AD: $E0 $47
+    ldh  [rBGP], a                                ; $41AD: $E0 $47
     dec  e                                        ; $41AF: $1D
     jr   nz, .loop3                               ; $41B0: $20 $F9
     ld   e, $30                                   ; $41B2: $1E $30
 
 .loop4
     ld   a, $40                                   ; $41B4: $3E $40
-    ld   [rBGP], a                                ; $41B6: $E0 $47
+    ldh  [rBGP], a                                ; $41B6: $E0 $47
     dec  e                                        ; $41B8: $1D
     jr   nz, .loop4                               ; $41B9: $20 $F9
 
 .cleanup
     xor  a                                        ; $41BB: $AF
     ld   [wBGPalette], a                          ; $41BC: $EA $97 $DB
-    ld   [rBGP], a                                ; $41BF: $E0 $47
+    ldh  [rBGP], a                                ; $41BF: $E0 $47
     ret                                           ; $41C1: $C9

--- a/src/code/home/dialog.asm
+++ b/src/code/home/dialog.asm
@@ -231,16 +231,16 @@ label_2444::
     ld   a, [hl]                                  ; $2444: $7E
     ld   [bc], a                                  ; $2445: $02
     ld   a, $01                                   ; $2446: $3E $01
-    ld   [rVBK], a                                ; $2448: $E0 $4F
+    ldh  [rVBK], a                                ; $2448: $E0 $4F
 
 label_244A::
     ld   a, $02                                   ; $244A: $3E $02
-    ld   [rSVBK], a                               ; $244C: $E0 $70
+    ldh  [rSVBK], a                               ; $244C: $E0 $70
     ld   a, [hl]                                  ; $244E: $7E
     ld   [bc], a                                  ; $244F: $02
     xor  a                                        ; $2450: $AF
-    ld   [rVBK], a                                ; $2451: $E0 $4F
-    ld   [rSVBK], a                               ; $2453: $E0 $70
+    ldh  [rVBK], a                                ; $2451: $E0 $4F
+    ldh  [rSVBK], a                               ; $2453: $E0 $70
     inc  bc                                       ; $2455: $03
     ld   a, l                                     ; $2456: $7D
     add  a, $01                                   ; $2457: $C6 $01

--- a/src/code/home/init.asm
+++ b/src/code/home/init.asm
@@ -9,20 +9,20 @@ Start::
     ; Switch CPU to double-speed if needed
     cp   BOOTUP_A_CGB ; running on Game Boy Color? ; $0150: $FE $11
     jr   nz, .notGBC                              ; $0152: $20 $1A
-    ld   a, [rKEY1]                               ; $0154: $F0 $4D
+    ldh  a, [rKEY1]                               ; $0154: $F0 $4D
     and  KEY1F_DBLSPEED       ; do we need to     ; $0156: $E6 $80
     jr   nz, .speedSwitchDone ; switch CPU speed? ; $0158: $20 $0D
     ld   a, P1F_5 | P1F_4 ; \                     ; $015A: $3E $30
-    ld   [rP1], a         ; |                     ; $015C: $E0 $00
+    ldh  [rP1], a         ; |                     ; $015C: $E0 $00
     ld   a, KEY1F_PREPARE ; |                     ; $015E: $3E $01
-    ld   [rKEY1], a       ; | Prepare CPU speed   ; $0160: $E0 $4D
+    ldh  [rKEY1], a       ; | Prepare CPU speed   ; $0160: $E0 $4D
     xor  a                ; |                     ; $0162: $AF
-    ld   [rIE], a         ; |                     ; $0163: $E0 $FF
+    ldh  [rIE], a         ; |                     ; $0163: $E0 $FF
     stop                  ; / Switch CPU speed    ; $0165: $10 $00
 
 .speedSwitchDone
     xor  a                                        ; $0167: $AF
-    ld   [rSVBK], a                               ; $0168: $E0 $70
+    ldh  [rSVBK], a                               ; $0168: $E0 $70
     ld   a, $01 ; isGBC = true                    ; $016A: $3E $01
     jr   Init                                     ; $016C: $18 $01
 
@@ -39,9 +39,9 @@ Init::
 
     ; Clear registers
     xor  a                                        ; $017F: $AF
-    ld   [rBGP], a                                ; $0180: $E0 $47
-    ld   [rOBP0], a                               ; $0182: $E0 $48
-    ld   [rOBP1], a                               ; $0184: $E0 $49
+    ldh  [rBGP], a                                ; $0180: $E0 $47
+    ldh  [rOBP0], a                               ; $0182: $E0 $48
+    ldh  [rOBP1], a                               ; $0184: $E0 $49
 
     ; Clear Tiles
     ld   hl, vTiles0                              ; $0186: $21 $00 $80
@@ -72,12 +72,12 @@ Init::
     ;   Bit 3: Mode 0 H-Blank interrupt disabled
     ;   Bit 2-0: read-only
     ld   a, STATF_LYC | STATF_LYCF                ; $01AE: $3E $44
-    ld   [rSTAT], a                               ; $01B0: $E0 $41
+    ldh  [rSTAT], a                               ; $01B0: $E0 $41
 
     ; Initialize LY Compare register
     ; Request a STAT interrupt when LY equals $4F
     ld   a, $4F                                   ; $01B2: $3E $4F
-    ld   [rLYC], a                                ; $01B4: $E0 $45
+    ldh  [rLYC], a                                ; $01B4: $E0 $45
 
     ; Initialize wCurrentBank
     ld   a, $01                                   ; $01B6: $3E $01
@@ -90,7 +90,7 @@ Init::
     ;   Bit 1: LCD STAT interrupt disabled
     ;   Bit 0: V-Blank interrupt enabled
     ld   a, IEF_VBLANK                            ; $01BB: $3E $01
-    ld   [rIE], a                                 ; $01BD: $E0 $FF
+    ldh  [rIE], a                                 ; $01BD: $E0 $FF
 
     ; Initialize save files
     call InitSaveFiles                            ; $01BF: $CD $AA $46

--- a/src/code/home/interrupts.asm
+++ b/src/code/home/interrupts.asm
@@ -25,10 +25,10 @@ InterruptLCDStatus::
     push hl                                       ; $038A: $E5
     push de                                       ; $038B: $D5
     push bc                                       ; $038C: $C5
-    ld   a, [rSVBK]  ; Save current WRAM Bank to c ; $038D: $F0 $70
+    ldh  a, [rSVBK]  ; Save current WRAM Bank to c ; $038D: $F0 $70
     ld   c, a        ;                            ; $038F: $4F
     xor  a           ; Load WRAM Bank 1 (as "0" fallbacks to loading bank 1) ; $0390: $AF
-    ld   [rSVBK], a  ;                            ; $0391: $E0 $70
+    ldh  [rSVBK], a  ;                            ; $0391: $E0 $70
     ld   a, [wGameplayType]                       ; $0393: $FA $95 $DB
     cp   GAMEPLAY_CREDITS ; if GameplayType != GAMEPLAY_CREDITS ; $0396: $FE $01
     jr   nz, .skipScrollY                         ; $0398: $20 $13
@@ -45,7 +45,7 @@ InterruptLCDStatus::
     ldh  a, [hBaseScrollY]                        ; $03A6: $F0 $97
 
 .setScrollY
-    ld   [rSCY], a ; scrollY                      ; $03A8: $E0 $42
+    ldh  [rSCY], a ; scrollY                      ; $03A8: $E0 $42
     jp   .clearBGTilesFlag                        ; $03AA: $C3 $FF $03
 
 .skipScrollY
@@ -62,7 +62,7 @@ InterruptLCDStatus::
     ld   a, [hl]                                  ; $03BB: $7E
     ld   hl, hBaseScrollX ; a = hBaseScrollX + [hl] ; $03BC: $21 $96 $FF
     add  a, [hl]                                  ; $03BF: $86
-    ld   [rSCX], a        ; set scrollX           ; $03C0: $E0 $43
+    ldh  [rSCX], a        ; set scrollX           ; $03C0: $E0 $43
     ld   a, [wGameplaySubtype]                    ; $03C2: $FA $96 $DB
     cp   $06  ; if GameplaySubtype < 6 (intro sea) ; $03C5: $FE $06
     jr   c, .setupNextInterruptForIntroSea        ; $03C7: $38 $10
@@ -71,7 +71,7 @@ InterruptLCDStatus::
     ld   hl, IntroBeachScreenSections             ; $03C9: $21 $84 $03
     add  hl, de        ; hl = ScreenSectionsTable + SectionIndex ; $03CC: $19
     ld   a, [hl]       ;                          ; $03CD: $7E
-    ld   [rLYC], a     ; Fire LCD Y-compare interrupt when reaching the row for the next section ; $03CE: $E0 $45
+    ldh  [rLYC], a     ; Fire LCD Y-compare interrupt when reaching the row for the next section ; $03CE: $E0 $45
     ld   a, e          ; a = SectionIndex + 1     ; $03D0: $7B
     inc  a             ;                          ; $03D1: $3C
     and  $03           ; a = a % 4                ; $03D2: $E6 $03
@@ -82,7 +82,7 @@ InterruptLCDStatus::
     ld   hl, IntroSeaScreenSections               ; $03D9: $21 $7F $03
     add  hl, de        ; hl = LCDScreenSectionsTable + SectionIndex ; $03DC: $19
     ld   a, [hl]       ;                          ; $03DD: $7E
-    ld   [rLYC], a     ; Fire LCD Y-compare interrupt when reaching the row for the next section ; $03DE: $E0 $45
+    ldh  [rLYC], a     ; Fire LCD Y-compare interrupt when reaching the row for the next section ; $03DE: $E0 $45
     ld   a, e          ; a = SectionIndex + 1     ; $03E0: $7B
     inc  a             ;                          ; $03E1: $3C
     cp   $05           ; if SectionIndex != 5     ; $03E2: $FE $05
@@ -97,21 +97,21 @@ InterruptLCDStatus::
     jr   nz, .clearBGTilesFlag ; skip             ; $03ED: $20 $10
     ; If we are drawing the last section (4)
     ld   a, [wIntroBGYOffset] ; Apply the Y offset to compensate for sea vertical movement ; $03EF: $FA $06 $C1
-    ld   [rSCY], a               ; (so that the horizon position stays constant). ; $03F2: $E0 $42
+    ldh  [rSCY], a               ; (so that the horizon position stays constant). ; $03F2: $E0 $42
     cpl                ; a = $FF - a + $61        ; $03F4: $2F
     inc  a             ;                          ; $03F5: $3C
     add  a, $60        ;                          ; $03F6: $C6 $60
-    ld   [rLYC], a     ; Fire LCD Y-compare interrupt when reaching the row for the next transition step ; $03F8: $E0 $45
+    ldh  [rLYC], a     ; Fire LCD Y-compare interrupt when reaching the row for the next transition step ; $03F8: $E0 $45
     jr   .clearBGTilesFlag                        ; $03FA: $18 $03
 
 .clearScrollX
     xor  a                                        ; $03FC: $AF
-    ld   [rSCX], a ; scrollX                      ; $03FD: $E0 $43
+    ldh  [rSCX], a ; scrollX                      ; $03FD: $E0 $43
 
 .clearBGTilesFlag
     ; Restore banks and register
     ld   a, c                                     ; $03FF: $79
-    ld   [rSVBK], a                               ; $0400: $E0 $70
+    ldh  [rSVBK], a                               ; $0400: $E0 $70
     pop  bc                                       ; $0402: $C1
     pop  de                                       ; $0403: $D1
     pop  hl                                       ; $0404: $E1
@@ -200,7 +200,7 @@ LoadRequestedGfx::
     ld   [wBGMapToLoad], a                        ; $045E: $EA $FF $D6
     ld   [wTilesetToLoad], a                      ; $0461: $EA $FE $D6
     ld   a, [wLCDControl]                         ; $0464: $FA $FD $D6
-    ld   [rLCDC], a                               ; $0467: $E0 $40
+    ldh  [rLCDC], a                               ; $0467: $E0 $40
 .return
     ret                                           ; $0469: $C9
 
@@ -226,11 +226,11 @@ InterruptVBlank::
     push hl                                       ; $046F: $E5
 
     ; Save the current RAM bank, and switch to RAM0
-    ld   a, [rSVBK]                               ; $0470: $F0 $70
+    ldh  a, [rSVBK]                               ; $0470: $F0 $70
     and  $07                                      ; $0472: $E6 $07
     ld   c, a                                     ; $0474: $4F
     xor  a                                        ; $0475: $AF
-    ld   [rSVBK], a                               ; $0476: $E0 $70
+    ldh  [rSVBK], a                               ; $0476: $E0 $70
     push bc                                       ; $0478: $C5
 
     di                                            ; $0479: $F3
@@ -424,7 +424,7 @@ InterruptVBlank::
     ; Restore the RAM bank
     pop  bc                                       ; $056A: $C1
     ld   a, c                                     ; $056B: $79
-    ld   [rSVBK], a                               ; $056C: $E0 $70
+    ldh  [rSVBK], a                               ; $056C: $E0 $70
 
     ; Restore registers
     pop  hl                                       ; $056E: $E1

--- a/src/code/home/render_loop.asm
+++ b/src/code/home/render_loop.asm
@@ -45,7 +45,7 @@ ENDC
     ldh  a, [hBaseScrollY]                        ; $01F5: $F0 $97
     add  a, [hl]                                  ; $01F7: $86
 .setScrollY
-    ld   [rSCY], a                                ; $01F8: $E0 $42
+    ldh  [rSCY], a                                ; $01F8: $E0 $42
 
     ;
     ; Set scroll X
@@ -57,7 +57,7 @@ ENDC
     add  a, [hl]                                  ; $01FF: $86
     ld   hl, wScrollXOffset                       ; $0200: $21 $BF $C1
     add  a, [hl]                                  ; $0203: $86
-    ld   [rSCX], a ; scrollX                      ; $0204: $E0 $43
+    ldh  [rSCX], a ; scrollX                      ; $0204: $E0 $43
 
     ;
     ; Load requested GFX (if needed)
@@ -113,10 +113,10 @@ ENDC
     ld   a, [wLCDControl]                         ; $023D: $FA $FD $D6
     and  ~LCDCF_ON                                ; $0240: $E6 $7F
     ld   e, a                                     ; $0242: $5F
-    ld   a, [rLCDC]                               ; $0243: $F0 $40
+    ldh  a, [rLCDC]                               ; $0243: $F0 $40
     and  LCDCF_ON                                 ; $0245: $E6 $80
     or   e                                        ; $0247: $B3
-    ld   [rLCDC], a                               ; $0248: $E0 $40
+    ldh  [rLCDC], a                               ; $0248: $E0 $40
 
     ; Increment the global frame counter
     ld   hl, hFrameCounter                        ; $024A: $21 $E7 $FF
@@ -222,11 +222,11 @@ ENDC
     call PlayAudioStep                            ; $02C0: $CD $A4 $08
     ; Apply pending palettes
     ld   a, [wBGPalette]                          ; $02C3: $FA $97 $DB
-    ld   [rBGP], a                                ; $02C6: $E0 $47
+    ldh  [rBGP], a                                ; $02C6: $E0 $47
     ld   a, [wOBJ0Palette]                        ; $02C8: $FA $98 $DB
-    ld   [rOBP0], a                               ; $02CB: $E0 $48
+    ldh  [rOBP0], a                               ; $02CB: $E0 $48
     ld   a, [wOBJ1Palette]                        ; $02CD: $FA $99 $DB
-    ld   [rOBP1], a                               ; $02D0: $E0 $49
+    ldh  [rOBP1], a                               ; $02D0: $E0 $49
     ; This is a non-interactive transition: no new gameplay frame is rendered.
     ; Wait for the next V-Blank.
     jp   .waitForNextFrame                        ; $02D2: $C3 $5F $03
@@ -238,13 +238,13 @@ ENDC
 
     ; Update graphics registers from game values
     ld   a, [wWindowY]                            ; $02D5: $FA $9A $DB
-    ld   [rWY], a                                 ; $02D8: $E0 $4A
+    ldh  [rWY], a                                 ; $02D8: $E0 $4A
     ld   a, [wBGPalette]                          ; $02DA: $FA $97 $DB
-    ld   [rBGP], a                                ; $02DD: $E0 $47
+    ldh  [rBGP], a                                ; $02DD: $E0 $47
     ld   a, [wOBJ0Palette]                        ; $02DF: $FA $98 $DB
-    ld   [rOBP0], a                               ; $02E2: $E0 $48
+    ldh  [rOBP0], a                               ; $02E2: $E0 $48
     ld   a, [wOBJ1Palette]                        ; $02E4: $FA $99 $DB
-    ld   [rOBP1], a                               ; $02E7: $E0 $49
+    ldh  [rOBP1], a                               ; $02E7: $E0 $49
 
     call PlayAudioStep                            ; $02E9: $CD $A4 $08
     call ReadJoypadState                          ; $02EC: $CD $1E $28
@@ -361,7 +361,8 @@ ENDC
     ldh  [hIsRenderingFrame], a                   ; $0370: $E0 $FD
 
     ; Stop the CPU until the next interrupt
-    halt                                          ; $0372: $76 $00
+    halt                                          ; $0372: $76
+    nop                                           ; $0373: $00
 
     ; An interrupt occured; but maybe it wasn't the V-Blank interrupt.
     ; Busy-loop until the V-Blank interrupt actually ran and finished.

--- a/src/code/intro.asm
+++ b/src/code/intro.asm
@@ -70,7 +70,7 @@ IntroHandlerEntryPoint::
     ld   [wEntitiesStatusTable + $03], a          ; $6E74: $EA $83 $C2
     ld   [wEntitiesStatusTable + $04], a          ; $6E77: $EA $84 $C2
 
-    ld   [rBGP], a                                ; $6E7A: $E0 $47
+    ldh  [rBGP], a                                ; $6E7A: $E0 $47
     ld   [wBGPalette], a                          ; $6E7C: $EA $97 $DB
 
     ld   a, $10                                   ; $6E7F: $3E $10
@@ -91,16 +91,16 @@ IntroHandlerEntryPoint::
     ld   [wGameplaySubtype], a                    ; $6E98: $EA $96 $DB
     ldh  [hBaseScrollX], a                        ; $6E9B: $E0 $96
     ldh  [hBaseScrollY], a                        ; $6E9D: $E0 $97
-    ld   [rBGP], a                                ; $6E9F: $E0 $47
+    ldh  [rBGP], a                                ; $6E9F: $E0 $47
     ld   [wBGPalette], a                          ; $6EA1: $EA $97 $DB
     ld   hl, wGameplayType                        ; $6EA4: $21 $95 $DB
     inc  [hl]                                     ; $6EA7: $34
 
 .enableVBlankInterruptAndReturn
     ld   a, IEF_VBLANK                            ; $6EA8: $3E $01
-    ld   [rIE], a ; Enable VBlank interrupt only  ; $6EAA: $E0 $FF
+    ldh  [rIE], a ; Enable VBlank interrupt only  ; $6EAA: $E0 $FF
     ld   a, $4F                                   ; $6EAC: $3E $4F
-    ld   [rLYC], a                                ; $6EAE: $E0 $45
+    ldh  [rLYC], a                                ; $6EAE: $E0 $45
     ret                                           ; $6EB0: $C9
 
 RenderIntroFrame::
@@ -171,10 +171,10 @@ ENDC
     ld   a, $A2                                   ; $6F10: $3E $A2
     ld   [wRandomSeed], a                         ; $6F12: $EA $3D $C1
     ; Disable window
-    ld   a, [rLCDC]                               ; $6F15: $F0 $40
+    ldh  a, [rLCDC]                               ; $6F15: $F0 $40
     and  ~LCDCF_WINON                             ; $6F17: $E6 $DF
     ld   [wLCDControl], a                         ; $6F19: $EA $FD $D6
-    ld   [rLCDC], a                               ; $6F1C: $E0 $40
+    ldh  [rLCDC], a                               ; $6F1C: $E0 $40
     ld   a, $B4                                   ; $6F1E: $3E $B4
     ld   [wD016], a                               ; $6F20: $EA $16 $D0
     xor  a                                        ; $6F23: $AF
@@ -206,9 +206,9 @@ IntroSceneStage2Handler::
     ld   a, $E0                                   ; $6F4C: $3E $E0
     ld   [wOBJ1Palette], a                        ; $6F4E: $EA $99 $DB
     ld   a, IEF_STAT | IEF_VBLANK                 ; $6F51: $3E $03
-    ld   [rIE], a                                 ; $6F53: $E0 $FF
+    ldh  [rIE], a                                 ; $6F53: $E0 $FF
     ld   a, $00                                   ; $6F55: $3E $00
-    ld   [rLYC], a                                ; $6F57: $E0 $45
+    ldh  [rLYC], a                                ; $6F57: $E0 $45
     ld   e, $11                                   ; $6F59: $1E $11
     ld   hl, wIntroLightningVisibleCountdown      ; $6F5B: $21 $00 $D0
     xor  a                                        ; $6F5E: $AF
@@ -300,7 +300,7 @@ IntroShipOnSeaHandler::
     ld   a, $92                                   ; $700A: $3E $92
     ld   [wScrollXOffsetForSection+1], a          ; $700C: $EA $01 $C1
     ld   a, IEF_STAT | IEF_VBLANK                 ; $700F: $3E $03
-    ld   [rIE], a                                 ; $7011: $E0 $FF
+    ldh  [rIE], a                                 ; $7011: $E0 $FF
 
 .jp_001_7013
     ret                                           ; $7013: $C9
@@ -313,13 +313,13 @@ IntroShipOnSeaHandler::
 
     ; Transition to next sequence
     ld   a, $FF                                   ; $701B: $3E $FF
-    ld   [rBGP], a                                ; $701D: $E0 $47
+    ldh  [rBGP], a                                ; $701D: $E0 $47
     ld   a, GAMEPLAY_INTRO_LINK_FACE              ; $701F: $3E $04
     ld   [wGameplaySubtype], a                    ; $7021: $EA $96 $DB
     ld   a, TILEMAP_INTRO_LINK_FACE               ; $7024: $3E $0F
     ld   [wBGMapToLoad], a                        ; $7026: $EA $FF $D6
     ld   a, IEF_VBLANK                            ; $7029: $3E $01
-    ld   [rIE], a                                 ; $702B: $E0 $FF
+    ldh  [rIE], a                                 ; $702B: $E0 $FF
     xor  a                                        ; $702D: $AF
     ldh  [hBaseScrollX], a                        ; $702E: $E0 $96
     ret                                           ; $7030: $C9
@@ -458,7 +458,7 @@ IntroLinkFaceHandler::
     call LoadTileMapZero_trampoline               ; $70E3: $CD $08 $71
     ; Enable interrupts on VBlank and LCDStat
     ld   a, IEF_STAT | IEF_VBLANK                 ; $70E6: $3E $03
-    ld   [rIE], a                                 ; $70E8: $E0 $FF
+    ldh  [rIE], a                                 ; $70E8: $E0 $FF
     xor  a                                        ; $70EA: $AF
     ld   [wEntitiesStatusTable], a                ; $70EB: $EA $80 $C2
     ld   [wEntitiesStatusTable+1], a              ; $70EE: $EA $81 $C2
@@ -521,7 +521,7 @@ IntroStage6Handler::
     jr   nz, .jr_001_7168                         ; $7160: $20 $06
     push af                                       ; $7162: $F5
     ld   a, $02                                   ; $7163: $3E $02
-    ld   [rLYC], a                                ; $7165: $E0 $45
+    ldh  [rLYC], a                                ; $7165: $E0 $45
     pop  af                                       ; $7167: $F1
 
 .jr_001_7168
@@ -1353,9 +1353,9 @@ IntroMarinState3::
     jr   nz, .jr_775C                             ; $7749: $20 $11
     ld   a, $A0                                   ; $774B: $3E $A0
     ld   [hl], a                                  ; $774D: $77
-    ld   [rSCX], a                                ; $774E: $E0 $43
+    ldh  [rSCX], a                                ; $774E: $E0 $43
     ld   a, IEF_VBLANK                            ; $7750: $3E $01
-    ld   [rIE], a                                 ; $7752: $E0 $FF
+    ldh  [rIE], a                                 ; $7752: $E0 $FF
     call GetEntityTransitionCountdown             ; $7754: $CD $05 $0C
     ld   [hl], $E0                                ; $7757: $36 $E0
     jp   IncrementEntityState                     ; $7759: $C3 $12 $3B

--- a/src/code/marin_beach.asm
+++ b/src/code/marin_beach.asm
@@ -50,10 +50,10 @@ MarinBeachPrepare0::
 
 .loop_624D
     xor  a                                        ; $624D: $AF
-    ld   [rSVBK], a                               ; $624E: $E0 $70
+    ldh  [rSVBK], a                               ; $624E: $E0 $70
     ld   b, [hl]                                  ; $6250: $46
     ld   a, $03                                   ; $6251: $3E $03
-    ld   [rSVBK], a                               ; $6253: $E0 $70
+    ldh  [rSVBK], a                               ; $6253: $E0 $70
     ld   [hl], b                                  ; $6255: $70
     inc  hl                                       ; $6256: $23
     dec  c                                        ; $6257: $0D
@@ -61,7 +61,7 @@ MarinBeachPrepare0::
     and  a                                        ; $6259: $A7
     jr   nz, .loop_624D                           ; $625A: $20 $F1
     xor  a                                        ; $625C: $AF
-    ld   [rSVBK], a                               ; $625D: $E0 $70
+    ldh  [rSVBK], a                               ; $625D: $E0 $70
     ei                                            ; $625F: $FB
 
 MarinBeachPrepare1::

--- a/src/code/minimap.asm
+++ b/src/code/minimap.asm
@@ -156,7 +156,7 @@ ENDC
 .loop
     ld   d, $01                                   ; $67C7: $16 $01
     xor  a                                        ; $67C9: $AF
-    ld   [rSVBK], a                               ; $67CA: $E0 $70
+    ldh  [rSVBK], a                               ; $67CA: $E0 $70
     ld   a, [hl]                                  ; $67CC: $7E
     cp   $ED                                      ; $67CD: $FE $ED
     jr   nz, .jr_002_67D3                         ; $67CF: $20 $02
@@ -165,7 +165,7 @@ ENDC
 
 .jr_002_67D3
     ld   a, $02                                   ; $67D3: $3E $02
-    ld   [rSVBK], a                               ; $67D5: $E0 $70
+    ldh  [rSVBK], a                               ; $67D5: $E0 $70
     ld   a, d                                     ; $67D7: $7A
     ld   [hl], a                                  ; $67D8: $77
     inc  hl                                       ; $67D9: $23
@@ -177,7 +177,7 @@ ENDC
     jr   nz, .loop                                ; $67DE: $20 $E7
 
     xor  a                                        ; $67E0: $AF
-    ld   [rSVBK], a                               ; $67E1: $E0 $70
+    ldh  [rSVBK], a                               ; $67E1: $E0 $70
     ei                                            ; $67E3: $FB
 
 .return
@@ -270,9 +270,9 @@ jr_002_6848:
     push hl                                       ; $684E: $E5
     di                                            ; $684F: $F3
     ld   a, $02                                   ; $6850: $3E $02
-    ld   [rSVBK], a                               ; $6852: $E0 $70
+    ldh  [rSVBK], a                               ; $6852: $E0 $70
     ld   a, $01                                   ; $6854: $3E $01
-    ld   [rVBK], a                                ; $6856: $E0 $4F
+    ldh  [rVBK], a                                ; $6856: $E0 $4F
     ld   c, $00                                   ; $6858: $0E $00
     ld   d, c                                     ; $685A: $51
 
@@ -306,8 +306,8 @@ jr_002_6848:
 
 .jr_687D
     xor  a                                        ; $687D: $AF
-    ld   [rSVBK], a                               ; $687E: $E0 $70
-    ld   [rVBK], a                                ; $6880: $E0 $4F
+    ldh  [rSVBK], a                               ; $687E: $E0 $70
+    ldh  [rVBK], a                                ; $6880: $E0 $4F
     ei                                            ; $6882: $FB
 
 .jr_6883

--- a/src/code/oam_dma.asm
+++ b/src/code/oam_dma.asm
@@ -5,7 +5,7 @@ WriteDMACodeToHRAM::
     ld   hl, DMARoutine ; start                   ; $6D36: $21 $40 $6D
 .copy
     ld   a, [hli]                                 ; $6D39: $2A
-    ld   [$FF00+C], a                             ; $6D3A: $E2
+    ldh  [$FF00+c], a                             ; $6D3A: $E2
     inc  c                                        ; $6D3B: $0C
     dec  b                                        ; $6D3C: $05
     jr   nz, .copy                                ; $6D3D: $20 $FA
@@ -15,7 +15,7 @@ WriteDMACodeToHRAM::
 DMARoutine:
     ; Initiate DMA
     ld   a, wOAMBuffer / $100 ;                   ; $6D40: $3E $C0
-    ld   [rDMA], a                                ; $6D42: $E0 $46
+    ldh  [rDMA], a                                ; $6D42: $E0 $46
 
     ; Wait for DMA to finish
     ld   a, $28                                   ; $6D44: $3E $28

--- a/src/code/photo_album.asm
+++ b/src/code/photo_album.asm
@@ -141,7 +141,7 @@ PhotoAlbumInit1Handler:
     ldh  [hVolumeLeft], a                         ; $40CD: PhotoAlbumInit1Handler $E0 $AA
     call func_028_47CB                            ; $40CF: PhotoAlbumInit1Handler $CD $CB $47
     ld   a, IEF_SERIAL | IEF_VBLANK               ; $40D2: PhotoAlbumInit1Handler $3E $09
-    ld   [rIE], a                                 ; $40D4: PhotoAlbumInit1Handler $E0 $FF
+    ldh  [rIE], a                                 ; $40D4: PhotoAlbumInit1Handler $E0 $FF
     jp   PhotoAlbumIncrementState                 ; $40D6: PhotoAlbumInit1Handler $C3 $DB $44
 
 PhotoAlbumInit2Handler:
@@ -213,7 +213,7 @@ ENDC
     call func_028_4176                            ; $4165: PhotoAlbumInit3Handler $CD $76 $41
     ld   a, LCDCF_ON | LCDCF_WIN9C00 | LCDCF_OBJ16 | LCDCF_OBJON | LCDCF_BGON ; $4168: PhotoAlbumInit3Handler $3E $C7
     ld   [wLCDControl], a                         ; $416A: PhotoAlbumInit3Handler $EA $FD $D6
-    ld   [rLCDC], a                               ; $416D: PhotoAlbumInit3Handler $E0 $40
+    ldh  [rLCDC], a                               ; $416D: PhotoAlbumInit3Handler $E0 $40
     xor  a                                        ; $416F: PhotoAlbumInit3Handler $AF
     ld   [wTransitionSequenceCounter], a          ; $4170: PhotoAlbumInit3Handler $EA $6B $C1
     jp   PhotoAlbumIncrementState                 ; $4173: PhotoAlbumInit3Handler $C3 $DB $44
@@ -224,10 +224,10 @@ func_028_4176::
     ret  z                                        ; $4179: $C8
 
     ld   a, $02                                   ; $417A: $3E $02
-    ld   [rSVBK], a                               ; $417C: $E0 $70
+    ldh  [rSVBK], a                               ; $417C: $E0 $70
     call CopyData                                 ; $417E: $CD $14 $29
     xor  a                                        ; $4181: $AF
-    ld   [rSVBK], a                               ; $4182: $E0 $70
+    ldh  [rSVBK], a                               ; $4182: $E0 $70
     ret                                           ; $4184: $C9
 
 
@@ -292,7 +292,7 @@ func_028_4185::
     jr   z, .else_41F5_28                         ; $41DA: $28 $19
 
     ld   a, $01                                   ; $41DC: $3E $01
-    ld   [rVBK], a                                ; $41DE: $E0 $4F
+    ldh  [rVBK], a                                ; $41DE: $E0 $4F
     ld   a, $02                                   ; $41E0: $3E $02
     ldi  [hl], a                                  ; $41E2: $22
     ldi  [hl], a                                  ; $41E3: $22
@@ -308,7 +308,7 @@ func_028_4185::
     ldi  [hl], a                                  ; $41F0: $22
     ld   [hl], a                                  ; $41F1: $77
     xor  a                                        ; $41F2: $AF
-    ld   [rVBK], a                                ; $41F3: $E0 $4F
+    ldh  [rVBK], a                                ; $41F3: $E0 $4F
 .else_41F5_28:
     inc  c                                        ; $41F5: $0C
     ld   a, c                                     ; $41F6: $79
@@ -611,7 +611,7 @@ PhotoAlbumPreparePictureHandler:
     call func_028_442C                            ; $43BB: PhotoAlbumPreparePictureHandler $CD $2C $44
     ld   a, LCDCF_ON | LCDCF_WIN9C00 | LCDCF_OBJ16 | LCDCF_OBJON | LCDCF_BGON ; $43BE: PhotoAlbumPreparePictureHandler $3E $C7
     ld   [wLCDControl], a                         ; $43C0: PhotoAlbumPreparePictureHandler $EA $FD $D6
-    ld   [rLCDC], a                               ; $43C3: PhotoAlbumPreparePictureHandler $E0 $40
+    ldh  [rLCDC], a                               ; $43C3: PhotoAlbumPreparePictureHandler $E0 $40
     xor  a                                        ; $43C5: PhotoAlbumPreparePictureHandler $AF
     ld   [wTransitionSequenceCounter], a          ; $43C6: PhotoAlbumPreparePictureHandler $EA $6B $C1
     jp   PhotoAlbumIncrementState                 ; $43C9: PhotoAlbumPreparePictureHandler $C3 $DB $44
@@ -787,7 +787,7 @@ JumpTable_028_44AA:
     ldh  [hVolumeLeft], a                         ; $44D0: JumpTable_028_44AA $E0 $AA
     ld   a, [wLCDControl]                         ; $44D2: JumpTable_028_44AA $FA $FD $D6
     ld   [wLCDControl], a                         ; $44D5: JumpTable_028_44AA $EA $FD $D6
-    ld   [rLCDC], a                               ; $44D8: JumpTable_028_44AA $E0 $40
+    ldh  [rLCDC], a                               ; $44D8: JumpTable_028_44AA $E0 $40
     ret                                           ; $44DA: JumpTable_028_44AA $C9
 
 PhotoAlbumIncrementState::
@@ -971,7 +971,7 @@ func_028_45E9::
 ; ----------------------------------------------
 
 PrinterInterruptSerial::
-    ld   a, [rSC]                                 ; $4601: $F0 $02
+    ldh  a, [rSC]                                 ; $4601: $F0 $02
     bit  7, a                                     ; $4603: $CB $7F
     jr   nz, .return_4615_28                      ; $4605: $20 $0E
 
@@ -1066,11 +1066,11 @@ func_028_4670::
     ld   hl, Data_028_4A7C                        ; $4677: $21 $7C $4A
     add  hl, bc                                   ; $467A: $09
     ld   a, [hl]                                  ; $467B: $7E
-    ld   [rSB], a                                 ; $467C: $E0 $01
+    ldh  [rSB], a                                 ; $467C: $E0 $01
     ld   a, $01                                   ; $467E: $3E $01
-    ld   [rSC], a                                 ; $4680: $E0 $02
+    ldh  [rSC], a                                 ; $4680: $E0 $02
     ld   a, $81                                   ; $4682: $3E $81
-    ld   [rSC], a                                 ; $4684: $E0 $02
+    ldh  [rSC], a                                 ; $4684: $E0 $02
     ld   a, [wD17A]                               ; $4686: $FA $7A $D1
     cp   $02                                      ; $4689: $FE $02
     ret  nz                                       ; $468B: $C0
@@ -1092,10 +1092,10 @@ func_028_4695::
     ld   a, [wD184]                               ; $46A1: $FA $84 $D1
     ld   h, a                                     ; $46A4: $67
     add  hl, bc                                   ; $46A5: $09
-    ld   a, [rSB]                                 ; $46A6: $F0 $01
+    ldh  a, [rSB]                                 ; $46A6: $F0 $01
     ld   [wD18F], a                               ; $46A8: $EA $8F $D1
     ld   a, [hl]                                  ; $46AB: $7E
-    ld   [rSB], a                                 ; $46AC: $E0 $01
+    ldh  [rSB], a                                 ; $46AC: $E0 $01
     ld   l, a                                     ; $46AE: $6F
     ld   a, [wD178]                               ; $46AF: $FA $78 $D1
     add  l                                        ; $46B2: $85
@@ -1104,9 +1104,9 @@ func_028_4695::
     adc  $00                                      ; $46B9: $CE $00
     ld   [wD179], a                               ; $46BB: $EA $79 $D1
     ld   a, $01                                   ; $46BE: $3E $01
-    ld   [rSC], a                                 ; $46C0: $E0 $02
+    ldh  [rSC], a                                 ; $46C0: $E0 $02
     ld   a, $81                                   ; $46C2: $3E $81
-    ld   [rSC], a                                 ; $46C4: $E0 $02
+    ldh  [rSC], a                                 ; $46C4: $E0 $02
     ld   hl, wD17A                                ; $46C6: $21 $7A $D1
     inc  [hl]                                     ; $46C9: $34
     jr   nz, .else_46CE_28                        ; $46CA: $20 $02
@@ -1196,25 +1196,25 @@ func_028_474E::
     ld   hl, wD178                                ; $4751: $21 $78 $D1
     add  hl, bc                                   ; $4754: $09
     ld   a, [hl]                                  ; $4755: $7E
-    ld   [rSB], a                                 ; $4756: $E0 $01
+    ldh  [rSB], a                                 ; $4756: $E0 $01
     ld   a, $01                                   ; $4758: $3E $01
-    ld   [rSC], a                                 ; $475A: $E0 $02
+    ldh  [rSC], a                                 ; $475A: $E0 $02
     ld   a, $81                                   ; $475C: $3E $81
-    ld   [rSC], a                                 ; $475E: $E0 $02
+    ldh  [rSC], a                                 ; $475E: $E0 $02
     ld   hl, wD176                                ; $4760: $21 $76 $D1
     inc  [hl]                                     ; $4763: $34
     ret                                           ; $4764: $C9
 
 
 func_028_4765::
-    ld   a, [rSB]                                 ; $4765: $F0 $01
+    ldh  a, [rSB]                                 ; $4765: $F0 $01
     ld   [wD16E], a                               ; $4767: $EA $6E $D1
     xor  a                                        ; $476A: $AF
-    ld   [rSB], a                                 ; $476B: $E0 $01
+    ldh  [rSB], a                                 ; $476B: $E0 $01
     ld   a, $01                                   ; $476D: $3E $01
-    ld   [rSC], a                                 ; $476F: $E0 $02
+    ldh  [rSC], a                                 ; $476F: $E0 $02
     ld   a, $81                                   ; $4771: $3E $81
-    ld   [rSC], a                                 ; $4773: $E0 $02
+    ldh  [rSC], a                                 ; $4773: $E0 $02
     ld   hl, wD177                                ; $4775: $21 $77 $D1
     inc  [hl]                                     ; $4778: $34
     ld   a, [hl]                                  ; $4779: $7E
@@ -1229,7 +1229,7 @@ func_028_477F::
     ld   [wD192], a                               ; $4782: $EA $92 $D1
     ld   a, [wD16D]                               ; $4785: $FA $6D $D1
     ld   [wD193], a                               ; $4788: $EA $93 $D1
-    ld   a, [rSB]                                 ; $478B: $F0 $01
+    ldh  a, [rSB]                                 ; $478B: $F0 $01
     ld   [wD16D], a                               ; $478D: $EA $6D $D1
     cp   $FF                                      ; $4790: $FE $FF
     jr   nz, func_028_47A0                        ; $4792: $20 $0C
@@ -1272,8 +1272,8 @@ func_028_47C5::
 
 func_028_47CB::
     xor  a                                        ; $47CB: $AF
-    ld   [rSB], a                                 ; $47CC: $E0 $01
-    ld   [rSC], a                                 ; $47CE: $E0 $02
+    ldh  [rSB], a                                 ; $47CC: $E0 $01
+    ldh  [rSC], a                                 ; $47CE: $E0 $02
     ld   [wD16B], a                               ; $47D0: $EA $6B $D1
     ld   [wD16C], a                               ; $47D3: $EA $6C $D1
     dec  a                                        ; $47D6: $3D
@@ -1876,11 +1876,11 @@ func_028_4B88::
     ld   [wD17A], a                               ; $4B91: $EA $7A $D1
     ld   [wD172], a                               ; $4B94: $EA $72 $D1
     ld   a, [Data_028_4A7C]                       ; $4B97: $FA $7C $4A
-    ld   [rSB], a                                 ; $4B9A: $E0 $01
+    ldh  [rSB], a                                 ; $4B9A: $E0 $01
     ld   a, $01                                   ; $4B9C: $3E $01
-    ld   [rSC], a                                 ; $4B9E: $E0 $02
+    ldh  [rSC], a                                 ; $4B9E: $E0 $02
     ld   a, $81                                   ; $4BA0: $3E $81
-    ld   [rSC], a                                 ; $4BA2: $E0 $02
+    ldh  [rSC], a                                 ; $4BA2: $E0 $02
     ld   a, $F0                                   ; $4BA4: $3E $F0
     ret                                           ; $4BA6: $C9
 

--- a/src/code/photos.asm
+++ b/src/code/photos.asm
@@ -204,7 +204,7 @@ JumpTable_037_40EC::
     push hl                                       ; $414A: $E5
     ld   de, wObjPal1 + 2*2                       ; $414B: $11 $54 $DC
     ld   a, $02                                   ; $414E: $3E $02
-    ld   [rSVBK], a                               ; $4150: $E0 $70
+    ldh  [rSVBK], a                               ; $4150: $E0 $70
 .loop_4152_37
     ld   a, [hl+]                                 ; $4152: $2A
     ld   [de], a                                  ; $4153: $12
@@ -229,7 +229,7 @@ JumpTable_037_40EC::
     ld   a, [hl]                                  ; $416F: $7E
     ld   [de], a                                  ; $4170: $12
     xor  a                                        ; $4171: $AF
-    ld   [rSVBK], a                               ; $4172: $E0 $70
+    ldh  [rSVBK], a                               ; $4172: $E0 $70
 .else_4174_37:
     xor  a                                        ; $4174: $AF
     ldh  [hBaseScrollX], a                        ; $4175: $E0 $96

--- a/src/code/photos_bg.asm
+++ b/src/code/photos_bg.asm
@@ -38,7 +38,7 @@ LoadPhotoBgMap::
     call LCDOff                                   ; $4029: $CD $CF $28
     ld   a, [wLCDControl]                         ; $402C: $FA $FD $D6
     and ~LCDCF_ON                                 ; $402F: $E6 $7F
-    ld   [rLCDC], a                               ; $4031: $E0 $40
+    ldh  [rLCDC], a                               ; $4031: $E0 $40
 
     ; Get the BG map pointer for the photo
     ld   hl, PhotosBgMapPointers                  ; $4033: $21 $34 $65
@@ -62,10 +62,10 @@ LoadPhotoBgMap::
     jr   z, .copyBgAttributesEnd                  ; $404B: $28 $0A
     ; copy the photo BG attributes to VRAM
     ld   a, $01                                   ; $404D: $3E $01
-    ld   [rVBK], a                                ; $404F: $E0 $4F
+    ldh  [rVBK], a                                ; $404F: $E0 $4F
     call CopyToBGMap0                             ; $4051: $CD $96 $0B
     xor  a                                        ; $4054: $AF
-    ld   [rVBK], a                                ; $4055: $E0 $4F
+    ldh  [rVBK], a                                ; $4055: $E0 $4F
 .copyBgAttributesEnd
 
     pop  hl                                       ; $4057: $E1
@@ -88,15 +88,15 @@ LoadPhotoBgMap::
     jr   z, .else_4081_3D                         ; $4072: $28 $0D
 
     ld   a, $01                                   ; $4074: $3E $01
-    ld   [rVBK], a                                ; $4076: $E0 $4F
+    ldh  [rVBK], a                                ; $4076: $E0 $4F
     ld   de, vBGMap1                              ; $4078: $11 $00 $9C
     call func_03D_4000                            ; $407B: $CD $00 $40
     xor  a                                        ; $407E: $AF
-    ld   [rVBK], a                                ; $407F: $E0 $4F
+    ldh  [rVBK], a                                ; $407F: $E0 $4F
 .else_4081_3D:
     ld   a, LCDCF_ON | LCDCF_WIN9C00 | LCDCF_OBJ16 | LCDCF_OBJON | LCDCF_BGON ; $4081: $3E $C7
     ld   [wLCDControl], a                         ; $4083: $EA $FD $D6
-    ld   [rLCDC], a                               ; $4086: $E0 $40
+    ldh  [rLCDC], a                               ; $4086: $E0 $40
     ld   a, [wGameplayType]                       ; $4088: $FA $95 $DB
     sub  $0E                                      ; $408B: $D6 $0E
     ld   e, a                                     ; $408D: $5F

--- a/src/code/super_gameboy.asm
+++ b/src/code/super_gameboy.asm
@@ -19,30 +19,30 @@ SuperGameBoyInit::
     call WaitFor3Frames                           ; $6A32: $CD $86 $6B
 
     ; Try to detect the Super GameBoy by reading from the joypad
-    ld   a, [rP1]                                 ; $6A35: $F0 $00
+    ldh  a, [rP1]                                 ; $6A35: $F0 $00
     and  J_RIGHT | J_LEFT                         ; $6A37: $E6 $03
     cp   J_RIGHT | J_LEFT                         ; $6A39: $FE $03
     jr   nz, .superGameBoyDetected                ; $6A3B: $20 $39
     ld   a, J_B                                   ; $6A3D: $3E $20
-    ld   [rP1], a                                 ; $6A3F: $E0 $00
-    ld   a, [rP1]                                 ; $6A41: $F0 $00
-    ld   a, [rP1]                                 ; $6A43: $F0 $00
+    ldh  [rP1], a                                 ; $6A3F: $E0 $00
+    ldh  a, [rP1]                                 ; $6A41: $F0 $00
+    ldh  a, [rP1]                                 ; $6A43: $F0 $00
     ld   a, J_A | J_B                             ; $6A45: $3E $30
-    ld   [rP1], a                                 ; $6A47: $E0 $00
+    ldh  [rP1], a                                 ; $6A47: $E0 $00
     ld   a, J_A                                   ; $6A49: $3E $10
-    ld   [rP1], a                                 ; $6A4B: $E0 $00
-    ld   a, [rP1]                                 ; $6A4D: $F0 $00
-    ld   a, [rP1]                                 ; $6A4F: $F0 $00
-    ld   a, [rP1]                                 ; $6A51: $F0 $00
-    ld   a, [rP1]                                 ; $6A53: $F0 $00
-    ld   a, [rP1]                                 ; $6A55: $F0 $00
-    ld   a, [rP1]                                 ; $6A57: $F0 $00
+    ldh  [rP1], a                                 ; $6A4B: $E0 $00
+    ldh  a, [rP1]                                 ; $6A4D: $F0 $00
+    ldh  a, [rP1]                                 ; $6A4F: $F0 $00
+    ldh  a, [rP1]                                 ; $6A51: $F0 $00
+    ldh  a, [rP1]                                 ; $6A53: $F0 $00
+    ldh  a, [rP1]                                 ; $6A55: $F0 $00
+    ldh  a, [rP1]                                 ; $6A57: $F0 $00
     ld   a, J_A | J_B                             ; $6A59: $3E $30
-    ld   [rP1], a                                 ; $6A5B: $E0 $00
-    ld   a, [rP1]                                 ; $6A5D: $F0 $00
-    ld   a, [rP1]                                 ; $6A5F: $F0 $00
-    ld   a, [rP1]                                 ; $6A61: $F0 $00
-    ld   a, [rP1]                                 ; $6A63: $F0 $00
+    ldh  [rP1], a                                 ; $6A5B: $E0 $00
+    ldh  a, [rP1]                                 ; $6A5D: $F0 $00
+    ldh  a, [rP1]                                 ; $6A5F: $F0 $00
+    ldh  a, [rP1]                                 ; $6A61: $F0 $00
+    ldh  a, [rP1]                                 ; $6A63: $F0 $00
     and  J_RIGHT | J_LEFT                         ; $6A65: $E6 $03
     cp   J_RIGHT | J_LEFT                         ; $6A67: $FE $03
     jr   nz, .superGameBoyDetected                ; $6A69: $20 $0B
@@ -162,7 +162,7 @@ SuperGameBoyInit::
     jr   nz, .loop_6B30_3C                        ; $6B35: $20 $F9
 
     ld   a, LCDCF_ON | LCDCF_BGON                 ; $6B37: $3E $81
-    ld   [rLCDC], a                               ; $6B39: $E0 $40
+    ldh  [rLCDC], a                               ; $6B39: $E0 $40
     ld   bc, $06                                  ; $6B3B: $01 $06 $00
     call WaitForBCFrames                          ; $6B3E: $CD $92 $6B
 
@@ -174,7 +174,7 @@ SuperGameBoyInit::
 
     ; Disable all LCD Control flags
     xor  a                                        ; $6B4D: $AF
-    ld   [rLCDC], a                               ; $6B4E: $E0 $40
+    ldh  [rLCDC], a                               ; $6B4E: $E0 $40
     ret                                           ; $6B50: $C9
 
 SendUploadCommand::
@@ -186,9 +186,9 @@ SendUploadCommand::
 .func_03C_6B58::
     push bc                                       ; $6B58: $C5
     xor  a                                        ; $6B59: $AF
-    ld   [$ff00+c], a                             ; $6B5A: $E2
+    ldh  [$ff00+c], a                             ; $6B5A: $E2
     ld   a, $30                                   ; $6B5B: $3E $30
-    ld   [$ff00+c], a                             ; $6B5D: $E2
+    ldh  [$ff00+c], a                             ; $6B5D: $E2
     ld   b, $10                                   ; $6B5E: $06 $10
 .loop_6B60_3C
     ld   e, $08                                   ; $6B60: $1E $08
@@ -200,18 +200,18 @@ SendUploadCommand::
     jr   nz, .else_6B6C_3C                        ; $6B68: $20 $02
     ld   a, $20                                   ; $6B6A: $3E $20
 .else_6B6C_3C:
-    ld   [$ff00+c], a                             ; $6B6C: $E2
+    ldh  [$ff00+c], a                             ; $6B6C: $E2
     ld   a, $30                                   ; $6B6D: $3E $30
-    ld   [$ff00+c], a                             ; $6B6F: $E2
+    ldh  [$ff00+c], a                             ; $6B6F: $E2
     rr   d                                        ; $6B70: $CB $1A
     dec  e                                        ; $6B72: $1D
     jr   nz, .loop_6B64_3C                        ; $6B73: $20 $EF
     dec  b                                        ; $6B75: $05
     jr   nz, .loop_6B60_3C                        ; $6B76: $20 $E8
     ld   a, $20                                   ; $6B78: $3E $20
-    ld   [$ff00+c], a                             ; $6B7A: $E2
+    ldh  [$ff00+c], a                             ; $6B7A: $E2
     ld   a, $30                                   ; $6B7B: $3E $30
-    ld   [$ff00+c], a                             ; $6B7D: $E2
+    ldh  [$ff00+c], a                             ; $6B7D: $E2
     pop  bc                                       ; $6B7E: $C1
     dec  b                                        ; $6B7F: $05
     ret  z                                        ; $6B80: $C8
@@ -269,7 +269,7 @@ WaitForBCFrames::
 SendVRAMCommand::
     push de                                       ; $6BA3: $D5
     ld   a, $E4                                   ; $6BA4: $3E $E4
-    ld   [rBGP], a                                ; $6BA6: $E0 $47
+    ldh  [rBGP], a                                ; $6BA6: $E0 $47
     ld   de, $8800                                ; $6BA8: $11 $00 $88
     ld   bc, $1000                                ; $6BAB: $01 $00 $10
     call CopyData                                 ; $6BAE: $CD $14 $29
@@ -288,7 +288,7 @@ SendVRAMCommand::
     dec  c                                        ; $6BC3: $0D
     jr   nz, .loop_6BBB_3C                        ; $6BC4: $20 $F5
     ld   a, LCDCF_ON | LCDCF_BGON                 ; $6BC6: $3E $81
-    ld   [rLCDC], a                               ; $6BC8: $E0 $40
+    ldh  [rLCDC], a                               ; $6BC8: $E0 $40
     ld   bc, $05                                  ; $6BCA: $01 $05 $00
     call WaitForBCFrames                          ; $6BCD: $CD $92 $6B
     pop  hl                                       ; $6BD0: $E1
@@ -296,5 +296,5 @@ SendVRAMCommand::
     ld   bc, $06                                  ; $6BD4: $01 $06 $00
     call WaitForBCFrames                          ; $6BD7: $CD $92 $6B
     xor  a                                        ; $6BDA: $AF
-    ld   [rLCDC], a                               ; $6BDB: $E0 $40
+    ldh  [rLCDC], a                               ; $6BDB: $E0 $40
     ret                                           ; $6BDD: $C9

--- a/src/code/world_handler.asm
+++ b/src/code/world_handler.asm
@@ -257,10 +257,10 @@ GameplayWorldSelectTilesetHandler::
     jr   z, .jr_44C9                              ; $44BB: $28 $0C
     di                                            ; $44BD: $F3
     ld   a, $03                                   ; $44BE: $3E $03
-    ld   [rSVBK], a                               ; $44C0: $E0 $70
+    ldh  [rSVBK], a                               ; $44C0: $E0 $70
     xor  a                                        ; $44C2: $AF
     ld   [wIsFileSelectionArrowShifted], a        ; $44C3: $EA $00 $D0
-    ld   [rSVBK], a                               ; $44C6: $E0 $70
+    ldh  [rSVBK], a                               ; $44C6: $E0 $70
     ei                                            ; $44C8: $FB
 
 .jr_44C9::
@@ -341,10 +341,10 @@ GameplayWorldLoad6Handler::
     ; Finish preparations
     ;
 
-    ld   a, [rLCDC]                               ; $450A: $F0 $40
+    ldh  a, [rLCDC]                               ; $450A: $F0 $40
     or   LCDCF_WINON                              ; $450C: $F6 $20
     ld   [wLCDControl], a                         ; $450E: $EA $FD $D6
-    ld   [rLCDC], a                               ; $4511: $E0 $40
+    ldh  [rLCDC], a                               ; $4511: $E0 $40
 
     call IncrementGameplaySubtype                 ; $4513: $CD $D6 $44
 

--- a/src/code/world_map.asm
+++ b/src/code/world_map.asm
@@ -34,17 +34,17 @@ WorldMapState0Handler::
     ld   c, $80                                   ; $5653: $0E $80
     di                                            ; $5655: $F3
     ld   a, $03                                   ; $5656: $3E $03
-    ld   [rSVBK], a                               ; $5658: $E0 $70
+    ldh  [rSVBK], a                               ; $5658: $E0 $70
     ld   a, [wIsFileSelectionArrowShifted]        ; $565A: $FA $00 $D0
     and  a                                        ; $565D: $A7
     jr   nz, jr_001_5674                          ; $565E: $20 $14
 
 .loop_5660
     xor  a                                        ; $5660: $AF
-    ld   [rSVBK], a                               ; $5661: $E0 $70
+    ldh  [rSVBK], a                               ; $5661: $E0 $70
     ld   b, [hl]                                  ; $5663: $46
     ld   a, $03                                   ; $5664: $3E $03
-    ld   [rSVBK], a                               ; $5666: $E0 $70
+    ldh  [rSVBK], a                               ; $5666: $E0 $70
     ld   [hl], b                                  ; $5668: $70
     inc  hl                                       ; $5669: $23
     dec  c                                        ; $566A: $0D
@@ -56,7 +56,7 @@ WorldMapState0Handler::
 
 jr_001_5674::
     xor  a                                        ; $5674: $AF
-    ld   [rSVBK], a                               ; $5675: $E0 $70
+    ldh  [rSVBK], a                               ; $5675: $E0 $70
     ei                                            ; $5677: $FB
 
 WorldMapState1Handler::
@@ -110,10 +110,10 @@ WorldMapState1Handler::
     ld   [wC1B1], a                               ; $56D9: $EA $B1 $C1
     ld   a, [wDBB4]                               ; $56DC: $FA $B4 $DB
     ld   [wC1B4], a                               ; $56DF: $EA $B4 $C1
-    ld   a, [rLCDC]                               ; $56E2: $F0 $40
+    ldh  a, [rLCDC]                               ; $56E2: $F0 $40
     and  ~LCDCF_WINON                             ; $56E4: $E6 $DF
     ld   [wLCDControl], a                         ; $56E6: $EA $FD $D6
-    ld   [rLCDC], a                               ; $56E9: $E0 $40
+    ldh  [rLCDC], a                               ; $56E9: $E0 $40
     call func_001_5888                            ; $56EB: $CD $88 $58
     ld   a, TILEMAP_WORLD_MAP                     ; $56EE: $3E $08
     ld   [wBGMapToLoad], a                        ; $56F0: $EA $FF $D6


### PR DESCRIPTION
This removes the need for `--auto-ldh` and `--nop-after-halt` flags for RGBASM, which are deprecated and will be removed in a future release.

Note that `ldh` was already used the majority of the time (237 `ldh`s, 229 `ld`s that were automatically `ldh`s). And there was only one `halt`.

(Yes, the `--preserve-ld` and `--halt-without-nop` flags have existed since before RGBDS 0.5.0, so no compatibility issues there.)