### PR TITLE
Bump RGBDS minimum version to 0.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ oam_%.2bpp: oam_%.png
 # Locale-specific rules below (e.g. `src/main.azlj.o`) will add their own
 # pre-requisites to the ones defined by this rule.
 src/main.%.o: src/main.asm $(asm_files) $(gfx_files:.png=.2bpp) $(bin_files)
-	$(ASM) $(ASFLAGS) $($*_ASFLAGS) -i src/ -o $@ $<
+	$(ASM) $(ASFLAGS) $($*_ASFLAGS) -I src/ -o $@ $<
 
 # Link object files into a GBC executable rom
 # The arguments used are both the global options (e.g. `LDFLAGS`) and the
@@ -83,17 +83,17 @@ azlj_bin = $(shell find revisions/J0 -type f -name '*.tilemap.encoded' -o -name 
 
 games += azlj.gbc
 src/main.azlj.o: $(azlj_asm) $(azlj_gfx:.png=.2bpp) $(azlj_bin)
-azlj_ASFLAGS = -DLANG=JP -DVERSION=0 -i revisions/J0/src/
+azlj_ASFLAGS = -DLANG=JP -DVERSION=0 -I revisions/J0/src/
 azlj_FXFLAGS = --rom-version 0 --title "ZELDA"
 
 games += azlj-r1.gbc
 src/main.azlj-r1.o: $(azlj_asm) $(azlj_gfx:.png=.2bpp) $(azlj_bin)
-azlj-r1_ASFLAGS = -DLANG=JP -DVERSION=1 -i revisions/J0/src/
+azlj-r1_ASFLAGS = -DLANG=JP -DVERSION=1 -I revisions/J0/src/
 azlj-r1_FXFLAGS = --rom-version 1 --title "ZELDA"
 
 games += azlj-r2.gbc
 src/main.azlj-r2.o: $(azlj_asm) $(azlj_gfx:.png=.2bpp) $(azlj_bin)
-azlj-r2_ASFLAGS = -DLANG=JP -DVERSION=2 -i revisions/J0/src/
+azlj-r2_ASFLAGS = -DLANG=JP -DVERSION=2 -I revisions/J0/src/
 azlj-r2_FXFLAGS = --rom-version 2 --title "ZELDA" --game-id "AZLJ"
 
 #
@@ -106,12 +106,12 @@ azlg_bin = $(shell find revisions/G0 -type f -name '*.tilemap.encoded' -o -name 
 
 games += azlg.gbc
 src/main.azlg.o: $(azlg_asm) $(azlg_gfx:.png=.2bpp) $(azlg_bin)
-azlg_ASFLAGS = -DLANG=DE -DVERSION=0 -i revisions/G0/src/
+azlg_ASFLAGS = -DLANG=DE -DVERSION=0 -I revisions/G0/src/
 azlg_FXFLAGS = --rom-version 0 --non-japanese --title "ZELDA"
 
 games += azlg-r1.gbc
 src/main.azlg-r1.o: $(azlg_asm) $(azlg_gfx:.png=.2bpp) $(azlg_bin) azlj-r2.gbc
-azlg-r1_ASFLAGS = -DLANG=DE -DVERSION=1 -i revisions/G0/src/
+azlg-r1_ASFLAGS = -DLANG=DE -DVERSION=1 -I revisions/G0/src/
 azlg-r1_LDFLAGS = -O azlj-r2.gbc
 azlg-r1_FXFLAGS = --rom-version 1 --non-japanese --title "ZELDA" --game-id "AZLD"
 
@@ -125,12 +125,12 @@ azlf_bin = $(shell find revisions/F0 -type f -name '*.tilemap.encoded' -o -name 
 
 games += azlf.gbc
 src/main.azlf.o: $(azlf_asm) $(azlf_gfx:.png=.2bpp) $(azlf_bin)
-azlf_ASFLAGS = -DLANG=FR -DVERSION=0 -i revisions/F0/src/
+azlf_ASFLAGS = -DLANG=FR -DVERSION=0 -I revisions/F0/src/
 azlf_FXFLAGS = --rom-version 0 --non-japanese --title "ZELDA"
 
 games += azlf-r1.gbc
 src/main.azlf-r1.o: $(azlf_asm) $(azlf_gfx:.png=.2bpp) $(azlf_bin) azlg-r1.gbc
-azlf-r1_ASFLAGS = -DLANG=FR -DVERSION=1 -i revisions/F0/src/
+azlf-r1_ASFLAGS = -DLANG=FR -DVERSION=1 -I revisions/F0/src/
 azlf-r1_LDFLAGS = -O azlg-r1.gbc
 azlf-r1_FXFLAGS = --rom-version 1 --non-japanese --title "ZELDA" --game-id "AZLF"
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Additionally, a wiki includes a [high-level overview of the game engine](https:/
 
 ## Usage
 
-1. Install Python 3 and [rgbds](https://github.com/gbdev/rgbds#1-installing-rgbds) (version >= 0.5.1 required);
+1. Install Python 3 and [rgbds](https://github.com/gbdev/rgbds#1-installing-rgbds) (version >= 0.6.0 required);
 2. `make all`.
 
 This will build both the games and their debug symbols. Once built, use [BGB](https://github.com/zladx/LADX-Disassembly/wiki/Tooling-for-reverse-engineering#bgb) to load the debug symbols into the debugger.

--- a/src/rgbdscheck.asm
+++ b/src/rgbdscheck.asm
@@ -1,7 +1,7 @@
 ; Abort if RGBDS version is too low
 IF(!DEF(__RGBDS_MAJOR__) || !DEF(__RGBDS_MINOR__) || !DEF(__RGBDS_PATCH__))
-FAIL "Requires RGBDS version >= 0.5.1"
+FAIL "Requires RGBDS version >= 0.6.0"
 ENDC
-IF((__RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ < 5) || (__RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ == 5 && __RGBDS_PATCH__ < 1))
-FAIL "Requires RGBDS version >= 0.5.1, not {d:__RGBDS_MAJOR__}.{d:__RGBDS_MINOR__}.{d:__RGBDS_PATCH__}"
+IF(__RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ < 6)
+FAIL "Requires RGBDS version >= 0.6.0, not {d:__RGBDS_MAJOR__}.{d:__RGBDS_MINOR__}.{d:__RGBDS_PATCH__}"
 ENDC


### PR DESCRIPTION
[RGBDS v0.7.0](https://github.com/gbdev/rgbds/releases/tag/v0.7.0) has just been released, and it deprecates `rgbasm -i` in favor of `rgbasm -I`. To suppress deprecation notices, I have therefore changed the `Makefile` accordingly. However, `rgbasm -I` was only added as an alias in [v0.6.0](https://github.com/gbdev/rgbds/releases/tag/v0.6.0). Therefore, I have also bumped the minimum dependency version of RGBDS.

RGBDS v0.6.0 is over a year old (released in October 2022), so I feel like this should be OK, but I'm not sure if any contributors rely on older versions in package managers. (Note that RGBDS has started releasing statically linked binaries, so that's perhaps not of great concern anymore.)

Happy new year!