### PR TITLE
CI: use rgbds 0.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: kemenaran/rgbds:0.6.0
+      - image: kemenaran/rgbds:0.8.0
     steps:
       - checkout
       - run:

--- a/.circleci/images/rgbds/Dockerfile
+++ b/.circleci/images/rgbds/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y build-essential bison pkg-config libpng-dev
 # Retrieve rgbds
 RUN git clone https://github.com/gbdev/rgbds.git && \
   cd rgbds && \
-  git fetch --tags && git checkout v0.6.0
+  git fetch --tags && git checkout v0.8.0
 
 # Build rgbds
 RUN cd rgbds && make install

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,7 @@ RGBDS   :=
 
 ASM     := $(RGBDS)rgbasm
 ASFLAGS := \
-  --export-all\
-  --halt-without-nop\
-  --preserve-ld
+  --export-all
 
 LD      := $(RGBDS)rgblink
 LDFLAGS :=


### PR DESCRIPTION
rgbds 0.8.0 removes some deprecated command-line switches.

A new Docker image for rgbds 0.8.0 has been built and pushed.

The build should remain compatible with rgbds >= 0.6.0 : only unused command line switches are removed.