### PR TITLE
RGBDS 0.7.0 is required to build

### DIFF
--- a/src/rgbdscheck.asm
+++ b/src/rgbdscheck.asm
@@ -1,7 +1,7 @@
 ; Abort if RGBDS version is too low
 IF(!DEF(__RGBDS_MAJOR__) || !DEF(__RGBDS_MINOR__) || !DEF(__RGBDS_PATCH__))
-FAIL "Requires RGBDS version >= 0.6.0"
+FAIL "Requires RGBDS version >= 0.7.0"
 ENDC
-IF(__RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ < 6)
-FAIL "Requires RGBDS version >= 0.6.0, not {d:__RGBDS_MAJOR__}.{d:__RGBDS_MINOR__}.{d:__RGBDS_PATCH__}"
+IF(__RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ < 7)
+FAIL "Requires RGBDS version >= 0.7.0, not {d:__RGBDS_MAJOR__}.{d:__RGBDS_MINOR__}.{d:__RGBDS_PATCH__}"
 ENDC


### PR DESCRIPTION
PR #572 started using RGBDS 0.8.0 in CI, which is great, but to do so it removed some RGBASM flags from the Makefile. That would make 0.6.0 no longer work, so 0.7.0 is the minimum required version. (Which should be fine, 0.7.0 is from last year and 0.6.0 from the year before that, this isn't bleeding-edge any more.)

LADX does use a `halt` opcode, so the change in behavior from 0.6.0 to 0.7.0+ is relevant:

```console
$ ../rgbds/rgbasm -V
rgbasm v0.6.0
$ make RGBDS=../rgbds/
../rgbds/rgbasm --export-all -DLANG=EN -DVERSION=0 -I src/ -o src/main.azle.o src/main.asm
warning: src/main.asm(19) -> src/code/bank0.asm(6) -> src/code/home/render_loop.asm(364): [-Wobsolete]
    `nop` after `halt` will stop being the default; pass `-H` to opt into it
../rgbds/rgblink   -n azle.sym -o azle.gbc src/main.azle.o
../rgbds/rgbfix --color-compatible  --sgb-compatible  --ram-size 0x03  --old-licensee 0x33  --new-licensee "01"  --mbc-type 0x1B  --pad-value 0xFF  --validate --rom-version 0 --non-japanese --title "ZELDA" azle.gbc
azle.gbc checksum: FAILED
make: *** [Makefile:176: test] Error 1
```