### PR TITLE
Use RGBDS 1.0.1 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ghcr.io/gbdev/rgbds:v1.0.0
+      - image: ghcr.io/gbdev/rgbds:v1.0.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Happy New Year! 🥳

[RGBDS 1.0.1](https://github.com/gbdev/rgbds/releases/tag/v1.0.1) was just released. It's simply a small bugfix update, so nobody even *needs* to upgrade from the 1.0.0 installation. But may as well use the latest in CI to ensure it works.