### PR TITLE
Abandoned noise track in Color Dungeon theme

### DIFF
--- a/src/data/music/music_tracks_data_1b_3.asm
+++ b/src/data/music/music_tracks_data_1b_3.asm
@@ -39,8 +39,10 @@ MusicColorDungeon_Channel3::
     dw   ChannelDefinition_1b_722d
     dw   ChannelDefinition_1b_726a
     dw   $ffff, MusicColorDungeon_Channel3
-; UNREFERENCED DATA
-    db   $22, $73, $ff, $ff, $29, $71
+
+MusicColorDungeon_Channel4Unused::
+    dw   ChannelDefinitionUnused_1b_7322
+    dw   $ffff, MusicColorDungeon_Channel4Unused
 
 ChannelDefinition_1b_712f::
     set_envelope_duty $37, $00, 2, 0
@@ -497,10 +499,34 @@ ChannelDefinition_1b_726a::
     rest
     disable_software_envelope
     end_def
-; UNREFERENCED DATA
-    db   $9b, $07, $a3, $15, $15, $1f, $a2, $06, $a3, $15, $15, $a2, $15, $a3, $10, $9c
-    db   $a2, $15, $15, $15, $15, $a3, $01, $a2, $15, $15, $15, $15, $a3, $01, $a2, $15
-    db   $15, $15, $15, $a3, $06, $06, $00
+
+MusicColorDungeon_Channel4Unused::
+    begin_loop 7
+        notelen 3
+        note NOISE_5 NOISE_5 NOISE_7
+        notelen 2
+        note NOISE_2
+        notelen 3
+        note NOISE_5 NOISE_5
+        notelen 2
+        note NOISE_5
+        notelen 3
+        note NOISE_4
+    next_loop
+
+    notelen 2
+    note NOISE_5 NOISE_5 NOISE_5 NOISE_5
+    notelen 3
+    rest
+    notelen 2
+    note NOISE_5 NOISE_5 NOISE_5 NOISE_5
+    notelen 3
+    rest
+    notelen 2
+    note NOISE_5 NOISE_5 NOISE_5 NOISE_5
+    notelen 3
+    note NOISE_2 NOISE_2
+    end_def
 
 waveform_1b_7349::
     db   $66, $66, $66, $66, $00, $00, $00, $00, $00, $00, $00, $00, $00, $00, $00, $00

--- a/src/data/music/music_tracks_data_1b_3.asm
+++ b/src/data/music/music_tracks_data_1b_3.asm
@@ -500,7 +500,7 @@ ChannelDefinition_1b_726a::
     disable_software_envelope
     end_def
 
-MusicColorDungeon_Channel4Unused::
+ChannelDefinitionUnused_1b_7322::
     begin_loop 7
         notelen 3
         note NOISE_5, NOISE_5, NOISE_7

--- a/src/data/music/music_tracks_data_1b_3.asm
+++ b/src/data/music/music_tracks_data_1b_3.asm
@@ -503,11 +503,11 @@ ChannelDefinition_1b_726a::
 MusicColorDungeon_Channel4Unused::
     begin_loop 7
         notelen 3
-        note NOISE_5 NOISE_5 NOISE_7
+        note NOISE_5, NOISE_5, NOISE_7
         notelen 2
         note NOISE_2
         notelen 3
-        note NOISE_5 NOISE_5
+        note NOISE_5, NOISE_5
         notelen 2
         note NOISE_5
         notelen 3
@@ -515,17 +515,17 @@ MusicColorDungeon_Channel4Unused::
     next_loop
 
     notelen 2
-    note NOISE_5 NOISE_5 NOISE_5 NOISE_5
+    note NOISE_5, NOISE_5, NOISE_5, NOISE_5
     notelen 3
     rest
     notelen 2
-    note NOISE_5 NOISE_5 NOISE_5 NOISE_5
+    note NOISE_5, NOISE_5, NOISE_5, NOISE_5
     notelen 3
     rest
     notelen 2
-    note NOISE_5 NOISE_5 NOISE_5 NOISE_5
+    note NOISE_5, NOISE_5, NOISE_5, NOISE_5
     notelen 3
-    note NOISE_2 NOISE_2
+    note NOISE_2, NOISE_2
     end_def
 
 waveform_1b_7349::


### PR DESCRIPTION
There are two chunks of `; UNREFERENCED DATA` in [/src/data/music/music_tracks_data_1b_3.asm](https://github.com/zladx/LADX-Disassembly/blob/01b0c92ced3e2ced2072506e09521f6e988d7c16/src/data/music/music_tracks_data_1b_3.asm). From context, we can infer that the first chunk (6 bytes)

```
    db   $22, $73, $ff, $ff, $29, $71
```

is a channel header pointing to the second chunk (39 bytes)

```
    db   $9b, $07, $a3, $15, $15, $1f, $a2, $06, $a3, $15, $15, $a2, $15, $a3, $10, $9c
    db   $a2, $15, $15, $15, $15, $a3, $01, $a2, $15, $15, $15, $15, $a3, $01, $a2, $15
    db   $15, $15, $15, $a3, $06, $06, $00
```

which appears to be an unused noise channel definition. Translating it into the audio macro language, it says:

```
begin_loop 7
    notelen 3
    note NOISE_5, NOISE_5, NOISE_7
    notelen 2
    note NOISE_2
    notelen 3
    note NOISE_5, NOISE_5
    notelen 2
    note NOISE_5
    notelen 3
    note NOISE_4
next_loop

notelen 2
note NOISE_5, NOISE_5, NOISE_5, NOISE_5
notelen 3
rest
notelen 2
note NOISE_5, NOISE_5, NOISE_5, NOISE_5
notelen 3
rest
notelen 2
note NOISE_5, NOISE_5, NOISE_5, NOISE_5
notelen 3
note NOISE_2, NOISE_2
end_def
```

For the sake of discussion, say `notelen 2` is "one beat" and `notelen 3` is "two beats".  Then the looping section lasts 14 beats and the remainder (the "coda") lasts 20 beats, for a total of 14 &times; 7 + 20 = 118 beats.  This *almost* lines up with the other tracks, which have 116 beats apiece: 96 (= 16 &times; 6) for the melody/accompaniment, plus 20 for the coda.

Pure speculation: the developers intended for the codas to align; all they had to do was chop off 2 beats&mdash;the last `NOISE_4`&mdash;from the last loop (by unrolling it once).  The overall effect is a bit trippy, because the noise loop finishes 2 beats sooner than the 16-beat arpeggios in the other tracks, causing it to "drift" backwards.

You can listen to the track in [Daid's applet](https://ladxr.daid.eu/LADX-MusicEditor/editor/) by copy-pasting the following snippet (beware that the applet's notes, including the noise notes, are all indexed off by 1).

```
sequence:
  loop
  loop
  loop
  loop
  loop
  loop
  loop
  coda
pattern: loop
 0000 4 N4 24
 0024 4 N4 24
 0048 4 N6 24
 0072 4 N1 12
 0084 4 N4 24
 0108 4 N4 24
 0132 4 N4 12
 0144 4 N3 24
 0168 5 END
pattern: coda
 0000 4 N4 12
 0012 4 N4 12
 0024 4 N4 12
 0036 4 N4 12
 0072 4 N4 12
 0084 4 N4 12
 0096 4 N4 12
 0108 4 N4 12
 0144 4 N4 12
 0156 4 N4 12
 0168 4 N4 12
 0180 4 N4 12
 0192 4 N1 24
 0216 4 N1 24
 0240 5 END
```