### PR TITLE
Add an apostrophe in "Link's Awakening"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Links Awakening DX Disassembly
+# Link's Awakening DX Disassembly
 
 Disassembly of one of my favorite games. Taking it easy for now.
 


### PR DESCRIPTION
This is the only place in the repo lacking an apostrophe, but being the top-level README heading, it stands out. :P

There's also the GitHub repo's "About" description: "Disassembly of Legend of Zelda: *Links Awakening* DX". That should be corrected along with this PR.