### PR TITLE
Allow setting which python executable to use.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ rwildcard = $(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(
 # Dev tools binaries and options
 #
 
-RGBDS   :=
+RGBDS   ?=
+PYTHON  ?= $(shell which python3)
 
 2BPP    := $(RGBDS)rgbgfx
 2BFLAGS := \
@@ -59,7 +60,7 @@ bin_files +=  $(wildcard src/data/backgrounds/*.attrmap.encoded)
 # Compile an PNG file for OAM memory to a 2BPP file
 # (inverting the palette and de-interleaving the tiles).
 oam_%.2bpp: oam_%.png
-	tools/gfx/gfx.py --invert --interleave --out $@ 2bpp $<
+	$(PYTHON) tools/gfx/gfx.py --invert --interleave --out $@ 2bpp $<
 
 # Compile a PNG file to a 2BPP file, without any special conversion.
 # (This uses `rgbgfx`, which is much faster than `tools/gfx/gfx.py`.)


### PR DESCRIPTION
On windows, it's very depended on which python you have installed if you need to use `python3` `python` or `py` to run it. So allow specifying which executable of python to use.

This allows to build the disasm on windows without msys2 or wsl. With the exception that clean and the compare script do not work, as those still depend on `bash`/`rm`.